### PR TITLE
feat: Add basic threading support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
         run: make -j8
 
       - name: Test aluminac
-        run: make test-aluminac        
+        run: make test-aluminac
   docker:
     name: Build docker image
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,9 +2,8 @@ name: Publish Docker image
 
 on:
   schedule:
-    - cron: '30 6 * * 1'
+    - cron: "30 6 * * 1"
   workflow_dispatch: {}
-
 
 jobs:
   docker:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,14 +24,14 @@ jobs:
       - name: Build documentation
         env:
           ALUMINADOC_BASE_PATH: https://docs.alumina-lang.net
-        run: make -j8 docs    
+        run: make -j8 docs
 
       - name: Generate the sitemap
         id: sitemap
         uses: cicirello/generate-sitemap@v1
         with:
           base-url-path: https://docs.alumina-lang.net
-          path-to-root: ./build/docs          
+          path-to-root: ./build/docs
 
       - name: Publish to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/MISSING.md
+++ b/MISSING.md
@@ -40,8 +40,6 @@
     - no buffered I/O (fwrite/...). Native Alumina IO primitives should be much more ergonomic.
     - no random small functions where it can be done efficiently in Alumina (memfrob, htonl, ...)
       - memcpy/memove/strlen are an exception. these are heavily optimized an may actually be compiler builtins
-    - what to do about math (libm?) yay or nay?
-      - yay.
     - I really wanted to say *absolutely nothing with varargs*, but unfortunately `ioctl` and `fcntl` are varargs :(
 - tests
 - how portable should it be? currently it seems to be working quite well on ARM and x86_64 on Linux, Android and Mac. Windows is not supported yet.

--- a/Makefile
+++ b/Makefile
@@ -121,12 +121,13 @@ $(ALUMINA_DOC).c: $(ALU_DEPS) $(ALUMINAC_LIB_SOURCES) $(ALUMINA_DOC_SOURCES) src
 $(ALUMINA_DOC): $(ALUMINA_DOC).c $(BUILD_DIR)/parser.o
 	$(CC) $(CFLAGS) -o $@ $^ -ltree-sitter $(LDFLAGS)
 
-.PHONY: docs
-
-docs: $(ALUMINA_DOC)
+$(BUILD_ROOT)/docs/index.html: $(ALUMINA_DOC) $(SYSROOT_FILES)
 	$(ALUMINA_DOC) \
 		$(foreach src,$(SYSROOT_FILES),$(subst __root__,, $(subst /,::,$(basename $(subst ./sysroot,,$(src)))))=$(src)) 
 	cp -rf tools/alumina-doc/static $(BUILD_ROOT)/docs/
+
+.PHONY: docs
+docs: $(BUILD_ROOT)/docs/index.html
 
 ## ------------------------------ Various ------------------------------
 
@@ -152,7 +153,7 @@ test-examples: alumina-boot
 test-aluminac: $(ALUMINAC_TESTS)
 	$(ALUMINAC_TESTS) $(TEST_FLAGS)
 
-test: test-std test-examples
+test: test-std test-aluminac test-examples 
 
 test-fix: $(ALUMINA_BOOT)
 	cd tools/snapshot-tests/ && pytest snapshot.py --snapshot-update

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ test-examples: alumina-boot
 test-aluminac: $(ALUMINAC_TESTS)
 	$(ALUMINAC_TESTS) $(TEST_FLAGS)
 
-test: test-std test-aluminac test-examples 
+test: test-std test-examples 
 
 test-fix: $(ALUMINA_BOOT)
 	cd tools/snapshot-tests/ && pytest snapshot.py --snapshot-update

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ Finished:
     - string functions and formatting
     - spawning processes
     - standard, file and pipe I/O
+    - multithreading
+    - atomics
+    - basic synchronization primitives
     - basic filesystem operations
     - TCP/IP sockets
     - random number generation
@@ -192,13 +195,21 @@ cc hello_world_test.c -o hello_world_test
 ./hello_world_test
 ```
 
+If you wish to compile with multithreading enabled, add `--cfg threading` and link with `libpthread`.
+
+```
+./alumina-boot --cfg threading --sysroot ./sysroot hello_world=./examples/threading.alu -o threading.c
+cc threading.c -o threading -lpthread
+./threading
+```
+
 
 To compile the self-hosted compiler, run:
 ```
 make aluminac
 ```
 
-See [examples](./examples), [standard library](./sysroot) and the [self-hosted compiler](./src/aluminac) for a tour of the language, documentation is TBD.
+See [examples](./examples), [standard library](./sysroot) and the [self-hosted compiler](./src/aluminac) for a tour of the language.
 
 # Contributing
 

--- a/examples/defer_and_move.alu
+++ b/examples/defer_and_move.alu
@@ -11,13 +11,13 @@ fn main() {
     defer vec.free(); // vec will now be automatically freed when `main` exits
 
     vec.extend_from_slice("Hello, world!");
-    
+
     // This would be wrong and lead to double free, as the same vector would be
     // freed both in `accept_vector` and `main`.
     // accept_vector(vec);
-    
-    // If we need to transfer ownership, we can use the move() function. This 
-    // creates an efficient shallow copy of the vector and leaves the original 
+
+    // If we need to transfer ownership, we can use the move() function. This
+    // creates an efficient shallow copy of the vector and leaves the original
     // `vec` nulled, so free is a no-op.
     accept_vector(vec.move());
 

--- a/examples/file_io.alu
+++ b/examples/file_io.alu
@@ -2,7 +2,7 @@ use std::fs::{File, Path};
 use std::io::{Error, Readable, Writable};
 
 fn copy<S: Readable<S>, D: Writable<D>>(
-    src: &mut S, 
+    src: &mut S,
     dst: &mut D
 ) -> Result<(), Error> {
     let buf: [u8; 1024];

--- a/examples/first_class_functions.alu
+++ b/examples/first_class_functions.alu
@@ -1,14 +1,14 @@
 use std::builtins::Callable;
 
-// This function will accept a function pointer as a parameter. 
+// This function will accept a function pointer as a parameter.
 fn say_twice_pointer<T>(sayer: fn(T), what: T) {
     sayer(what);
     sayer(what);
 }
 
-// say_twice_mono will be monomorphized using a specific function say<T> for a given T it is invoked 
+// say_twice_mono will be monomorphized using a specific function say<T> for a given T it is invoked
 // with. This allows for e.g. inlining and other optimizations. Unlike function pointers,
-// function types are zero-sized (each function type is a unit type containing only one 
+// function types are zero-sized (each function type is a unit type containing only one
 // function), so the "sayer" parameter will be elided away and `say` will be called directly
 // from the body of the function.
 fn say_twice_mono<T>(sayer: say<T>, what: T) {
@@ -30,8 +30,8 @@ fn say<T>(what: T) {
 fn main() {
     say_twice_pointer(say, "hello");
     say_twice_mono(say, "world");
-    
-    // Unfortunately type inference is not yet smart enough to figure out the T parameter 
+
+    // Unfortunately type inference is not yet smart enough to figure out the T parameter
     // of say if it is only constrained by the protocol bound, so we need to add a type
     // hint.
     say_twice_protocol(say::<&[u8]>, "!");

--- a/examples/for_loop.alu
+++ b/examples/for_loop.alu
@@ -4,7 +4,7 @@ use std::collections::{HashMap, Vector, free_all};
 use std::string::StringBuf;
 use std::fmt::format;
 use std::iter::for_each;
-use std::random::DEFAULT_RNG;
+use std::random::thread_rng;
 
 fn main() {
     let vec: Vector<StringBuf> = Vector::new();
@@ -18,7 +18,7 @@ fn main() {
     defer hm.free();
 
     for i in vec {
-        hm.insert(i.as_slice(), DEFAULT_RNG.next_u32());
+        hm.insert(i.as_slice(), thread_rng().next_u32());
     }
 
     for elem in hm {

--- a/examples/formatting.alu
+++ b/examples/formatting.alu
@@ -1,5 +1,5 @@
 struct Foo {
-    a: i32, 
+    a: i32,
     b: i32
 }
 

--- a/examples/hello_world.alu
+++ b/examples/hello_world.alu
@@ -1,4 +1,4 @@
 fn main() {
     // look ma, no 0-terminated strings!
-    println!("Hello, world!"); 
+    println!("Hello, world!");
 }

--- a/examples/iterators.alu
+++ b/examples/iterators.alu
@@ -4,14 +4,14 @@ use std::iter::{map, filter, filter_map, take_while, reduce, inspect};
 fn main() {
     let without_wovels = "Quick brown fox jumps over the lazy dog"
         .iter()
-        .filter(|a: u8| -> bool { 
+        .filter(|a: u8| -> bool {
             switch a.to_upper() {
                 'A', 'E', 'I', 'O', 'U' => false,
                 _ => true
             }
         })
         .to_vector();
-    
+
     defer without_wovels.free();
     println!("{}", without_wovels.as_slice());
 

--- a/examples/lambdas_closures.alu
+++ b/examples/lambdas_closures.alu
@@ -40,22 +40,22 @@ fn main() {
     // Anonymous functions can be coerced to function pointers.
     let hw_ptr: fn() = hw;
     hw_ptr();
-    
+
     // Closures are anonymous functions that capture variables from ambient scope.
-    // Captures can be either by value (`=capture`) or by reference (`&capture`) and 
+    // Captures can be either by value (`=capture`) or by reference (`&capture`) and
     // they need to be explicitly specified in the function signature.
 
-    // `a` is passed by value (is copied) into the closure. Captured values are part of the 
+    // `a` is passed by value (is copied) into the closure. Captured values are part of the
     // closure's state and can be mutated, but the original variable remains unchanged.
     let a = 1i64;
-    let f = |=a, increment: i64| { 
-        a += increment; 
-        println!("[inside] a = {}", a) 
+    let f = |=a, increment: i64| {
+        a += increment;
+        println!("[inside] a = {}", a)
     };
 
     f(10);
-    f(1); 
-    
+    f(1);
+
     println!("[outside] a = {}", a);
 
 
@@ -64,7 +64,7 @@ fn main() {
     let composites: Vector<i64> = Vector::new();
     defer composites.free();
 
-    print_filtered(1..100, |&composites, p: i64| -> bool { 
+    print_filtered(1..100, |&composites, p: i64| -> bool {
         if is_prime(p) {
             true
         } else {

--- a/examples/line_numbering.alu
+++ b/examples/line_numbering.alu
@@ -9,7 +9,7 @@ fn main() {
 
     let lines_iter = br.lines();
     defer lines_iter.free();
-    
+
     let padded: StringBuf = StringBuf::new();
     defer padded.free();
 

--- a/examples/macros.alu
+++ b/examples/macros.alu
@@ -2,11 +2,11 @@ fn printf_impl(fmt: &[u8], args: &[&void]) {
     let i = 0usize;
     let buf: [u8; 32];
     let buf: &mut [u8] = &buf;
-    
+
     let buf_pos = 0usize;
     let in_escape = false;
 
-    // Macros are hygienic, but if defined in linear scopes, 
+    // Macros are hygienic, but if defined in linear scopes,
     // they can bind ambient variables (like buf, buf_pos here)
     macro buf_append($val) {
         buf[buf_pos] = $val;
@@ -16,7 +16,7 @@ fn printf_impl(fmt: &[u8], args: &[&void]) {
             buf_pos = 0;
         }
     }
-    
+
     macro pop_arg() {
         if args.len == 0 {
             panic!("too few arguments");
@@ -34,7 +34,7 @@ fn printf_impl(fmt: &[u8], args: &[&void]) {
                     print!("{}", buf[0..buf_pos]);
                     print!("{}", *(pop_arg!() as &&[u8]));
                     buf_pos = 0;
-                } 
+                }
                 'd' => {
                     print!("{}", buf[0..buf_pos]);
                     print!("{}", *(pop_arg!() as &i32));
@@ -57,7 +57,7 @@ fn printf_impl(fmt: &[u8], args: &[&void]) {
         }
         i += 1;
     }
-    
+
     print!("{}", buf[0..buf_pos]);
 
     if args.len > 0 {
@@ -72,8 +72,8 @@ macro printf($fmt, $expr...) {
 
 fn main() {
     printf!(
-        "hello %s, you are %d years old, you have %d dogs and %d cats\n", 
-        "user", 
+        "hello %s, you are %d years old, you have %d dogs and %d cats\n",
+        "user",
         42,
         3,
         6

--- a/examples/process.alu
+++ b/examples/process.alu
@@ -2,16 +2,16 @@ use std::string::{trim};
 use std::process::{Command, Stdio};
 use std::fs::Path;
 
-fn main() {  
+fn main() {
     let command = Command::new(Path::new("/usr/bin/uname"))
         .stdout(Stdio::Piped)
         .args(&["-s"]);
-        
+
     let output = command.spawn()
         .unwrap()
         .wait_with_output()
         .unwrap();
     defer output.free();
-    
+
     println!("Running on {}", output.stdout.as_slice().trim());
 }

--- a/examples/quicksort.alu
+++ b/examples/quicksort.alu
@@ -17,7 +17,7 @@ fn quicksort<T>(arr: &mut [T]) {
     if arr.len <= 1 {
         return;
     }
-    
+
     let p = partition(arr);
     quicksort(arr[..p]);
     quicksort(arr[p+1..]);
@@ -38,15 +38,15 @@ fn partition<T>(arr: &mut [T]) -> usize {
         j += 1;
     }
     swap(&arr[i], &arr[arr.len - 1]);
-    
+
     i
 }
 
 
 fn main() {
     let values = [
-        1i64, 13, 1597, 233, 2, 8, 3, 
-        610, 4181, 377, 5, 6765, 987, 
+        1i64, 13, 1597, 233, 2, 8, 3,
+        610, 4181, 377, 5, 6765, 987,
         144, 2584, 21, 55, 0, 1, 34, 89
     ];
 

--- a/examples/range_slicing.alu
+++ b/examples/range_slicing.alu
@@ -2,5 +2,5 @@ fn main() {
     let hw = "Hello world!";
 
     print!("{}", hw[5..]);
-    print!("{}", hw[..5]);   
+    print!("{}", hw[..5]);
 }

--- a/examples/result.alu
+++ b/examples/result.alu
@@ -1,8 +1,8 @@
-use std::random::{DEFAULT_RNG as rng, range};
+use std::random::{thread_rng, range};
 use std::result::{Result, try};
 
 fn try_get_number() -> Result<i32, ()> {
-    let val = rng.range(0, 3) as i32;
+    let val = thread_rng().range(0, 3) as i32;
     
     if val > 0 {
         Result::ok(val)

--- a/examples/result.alu
+++ b/examples/result.alu
@@ -3,7 +3,7 @@ use std::result::{Result, try};
 
 fn try_get_number() -> Result<i32, ()> {
     let val = thread_rng().range(0, 3) as i32;
-    
+
     if val > 0 {
         Result::ok(val)
     } else {

--- a/examples/sorting_fun.alu
+++ b/examples/sorting_fun.alu
@@ -42,11 +42,11 @@ fn main() {
     ];
 
     println!("Original: {}", words.printable());
-    
+
     use std::random::{thread_rng, shuffle};
     thread_rng().shuffle(words);
     println!("Shuffled: {}", words.printable());
-    
+
     std::collections::sort(words);
     println!("Sorted:   {}", words.printable());
 }

--- a/examples/sorting_fun.alu
+++ b/examples/sorting_fun.alu
@@ -43,8 +43,8 @@ fn main() {
 
     println!("Original: {}", words.printable());
     
-    use std::random::{DEFAULT_RNG, shuffle};
-    DEFAULT_RNG.shuffle(words);
+    use std::random::{thread_rng, shuffle};
+    thread_rng().shuffle(words);
     println!("Shuffled: {}", words.printable());
     
     std::collections::sort(words);

--- a/examples/tcp_client_server.alu
+++ b/examples/tcp_client_server.alu
@@ -5,7 +5,7 @@ use std::net::{
 use std::collections::Vector;
 use std::result::{Result, try};
 use std::io::{
-    BufferedReader, lines, File, Error, 
+    BufferedReader, lines, File, Error,
     StdioStream, copy
 };
 use std::process::{Forked, exit};
@@ -35,8 +35,8 @@ fn client() {
         copy(&StdioStream::stdin(), &socket).unwrap();
         socket.shutdown(Shutdown::Write).unwrap();
         exit(0);
-    } 
-    
+    }
+
     copy(&socket, &StdioStream::stdout()).unwrap();
 
     let status = maybe_child.unwrap().wait().unwrap();
@@ -47,7 +47,7 @@ fn client() {
 
 fn handle_connection(socket: TcpStream) -> Result<(), Error> {
     defer socket.close();
-   
+
     // "Split" the socket into a buffered reader and writer pair
     let (reader, writer) = socket.buffered(1024, 1024);
     defer reader.free();
@@ -66,13 +66,13 @@ fn handle_connection(socket: TcpStream) -> Result<(), Error> {
 
     writer.flush()?;
     socket.shutdown(Shutdown::Write)?;
-    
+
     Result::ok(())
 }
 
 fn server() -> ! {
     let addr = SocketAddr::parse("[::]:24601").unwrap();
-    let listener = TcpListener::bind(&addr).unwrap();  
+    let listener = TcpListener::bind(&addr).unwrap();
     defer listener.close();
 
     println!("Listening on {}", listener.socket_addr().unwrap());
@@ -89,7 +89,7 @@ fn server() -> ! {
     }
 }
 
-fn main(args: &[&[u8]]) -> i32 {  
+fn main(args: &[&[u8]]) -> i32 {
     // Mask sigpipe
     std::libc::signal(std::libc::SIGPIPE, std::libc::SIG_IGN);
 
@@ -102,7 +102,7 @@ fn main(args: &[&[u8]]) -> i32 {
         usage!()
     }
 
-    switch args[1] { 
+    switch args[1] {
         "--server" => server(),
         "--client" => client(),
         _ => usage!()

--- a/examples/tests.alu
+++ b/examples/tests.alu
@@ -1,5 +1,5 @@
 // Compile with `--cfg test` and run the compiled output.
-// Test runner source is currently part of stdlib (std::test), but will eventually be 
+// Test runner source is currently part of stdlib (std::test), but will eventually be
 // extracted.
 
 use std::builtins::Numeric;

--- a/examples/threading.alu
+++ b/examples/threading.alu
@@ -12,7 +12,7 @@ fn main() {
             c1.send(i);
             println!("Sent {}", i);
         }
-        
+
         // Signal that no more values are coming
         c1.close();
     });
@@ -20,7 +20,7 @@ fn main() {
 
     // Give the producer a head start
     std::thread::sleep(Duration::from_millis(100));
-    
+
     // Receive all the values slowly
     for i in c1 {
         println!("Received {}", i);

--- a/examples/threading.alu
+++ b/examples/threading.alu
@@ -1,0 +1,29 @@
+use std::thread::{sleep, spawn};
+use std::time::Duration;
+use std::sync::Channel;
+
+fn main() {
+    // Create a new channel with capacity of 5
+    let c1: Channel<i32> = Channel::new(5);
+    defer c1.free();
+
+    let t1 = spawn(|&c1| {
+        for i in 0..10 {
+            c1.send(i);
+            println!("Sent {}", i);
+        }
+        
+        // Signal that no more values are coming
+        c1.close();
+    });
+    defer t1.join().unwrap();
+
+    // Give the producer a head start
+    std::thread::sleep(Duration::from_millis(100));
+    
+    // Receive all the values slowly
+    for i in c1 {
+        println!("Received {}", i);
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}

--- a/examples/when_expression.alu
+++ b/examples/when_expression.alu
@@ -5,7 +5,7 @@ fn type_name<T>() -> &[u8] {
     when T: !Primitive {
         compile_fail!("only primitive types are supported");
     }
-    
+
     when T: u8 {
         "u8"
     } else when T: u16 {
@@ -13,13 +13,13 @@ fn type_name<T>() -> &[u8] {
     } else {
         "something else, lol"
     }
-}   
+}
 
 
 fn main() {
     println!("{}", type_name::<u8>());
     println!("{}", type_name::<u16>());
-    
+
     // This would be a compile-time error
     // println!("{}", type_name::<&u8>());
 }

--- a/libraries/tree_sitter.alu
+++ b/libraries/tree_sitter.alu
@@ -19,24 +19,24 @@ struct TSQueryCursor {}
 struct TSPoint {
     row: u32,
     column: u32,
-}  
+}
 
 enum TSInputEncoding {
     UTF8 = 0i32,
     UTF16 = 1i32,
-}  
+}
 
 enum TSSymbolType {
     Regular = 0i32,
     Anonymous = 1i32,
     Auxiliary = 2i32,
-}  
+}
 
 struct TSInput{
     payload: &void,
     read: fn(&void, u32, TSPoint, &mut u32) -> &c_char,
     encoding: TSInputEncoding
-}   
+}
 
 struct TSNode {
     context: [u32; 4],
@@ -217,7 +217,7 @@ impl TSTreeCursor {
     }
 
     fn goto_first_child(self: &mut TSTreeCursor) -> bool {
-       ts_tree_cursor_goto_first_child(self) 
+       ts_tree_cursor_goto_first_child(self)
     }
 
     fn goto_parent(self: &mut TSTreeCursor) -> bool {

--- a/src/alumina-boot/src/ast/maker.rs
+++ b/src/alumina-boot/src/ast/maker.rs
@@ -378,7 +378,7 @@ impl<'ast> AstItemMaker<'ast> {
             .is_some();
 
         if has_varargs && !is_extern {
-            panic!("no");
+            return Err(CodeErrorKind::VarArgsCanOnlyBeExtern).with_span_from(&scope, node);
         }
 
         let is_protocol_fn = matches!(scope.parent().map(|s| s.typ()), Some(ScopeType::Protocol));

--- a/src/alumina-boot/src/ast/mod.rs
+++ b/src/alumina-boot/src/ast/mod.rs
@@ -639,6 +639,7 @@ pub enum Attribute {
     Inline,
     Align(u32),
     NoInline,
+    ThreadLocal,
     Builtin,
     ForceInline,
     Intrinsic,

--- a/src/alumina-boot/src/codegen/functions.rs
+++ b/src/alumina-boot/src/codegen/functions.rs
@@ -511,6 +511,12 @@ impl<'ir, 'gen> FunctionWriter<'ir, 'gen> {
     ) -> Result<(), AluminaError> {
         self.type_writer.add_type(item.typ)?;
 
+        let attributes = if item.attributes.contains(&Attribute::ThreadLocal) {
+            " __thread"
+        } else {
+            ""
+        };
+
         if item.r#extern {
             self.ctx
                 .register_name(id, CName::Native(item.name.unwrap()));
@@ -522,14 +528,16 @@ impl<'ir, 'gen> FunctionWriter<'ir, 'gen> {
             if item.r#extern {
                 w!(
                     self.fn_decls,
-                    "\nextern {} {};",
+                    "\nextern{} {} {};",
+                    attributes,
                     self.ctx.get_type(item.typ),
                     self.ctx.get_name(id)
                 );
             } else {
                 w!(
                     self.fn_decls,
-                    "\nstatic {} {};",
+                    "\nstatic{} {} {};",
+                    attributes,
                     self.ctx.get_type(item.typ),
                     self.ctx.get_name(id)
                 );

--- a/src/alumina-boot/src/common.rs
+++ b/src/alumina-boot/src/common.rs
@@ -218,6 +218,8 @@ pub enum CodeErrorKind {
     CanOnlyCloseOverLocals,
     #[error("anonymous functions that bind environment variables cannot be coerced to a function pointer")]
     ClosuresAreNotFns,
+    #[error("thread local storage is not supported")]
+    ThreadLocalNotSupported,    
 
     // Warnings
     #[error("defer inside a loop: this defered statement will only be executed once")]

--- a/src/alumina-boot/src/common.rs
+++ b/src/alumina-boot/src/common.rs
@@ -9,13 +9,14 @@ use thiserror::Error;
 use tree_sitter::Node;
 
 macro_rules! ice {
-    ($why:literal) => {
+    ($why:literal) => {{
+        use crate::common::CodeErrorBuilder; 
         return Err(CodeErrorKind::InternalError(
             $why.to_string(),
             backtrace::Backtrace::new(),
         ))
         .with_no_span()
-    };
+    }};
 }
 
 pub(crate) use ice;
@@ -179,6 +180,8 @@ pub enum CodeErrorKind {
     FunctionMustHaveBody,
     #[error("protocol functions cannot be extern")]
     ProtocolFnsCannotBeExtern,
+    #[error("varargs functions can only be extern")]
+    VarArgsCanOnlyBeExtern,
     #[error("type `{}` matches `{}`, which it should not", .0, .1)]
     ProtocolMatch(String, String),
     #[error("type `{}` does not match `{}`", .0, .1)]

--- a/src/alumina-boot/src/common.rs
+++ b/src/alumina-boot/src/common.rs
@@ -219,7 +219,7 @@ pub enum CodeErrorKind {
     #[error("anonymous functions that bind environment variables cannot be coerced to a function pointer")]
     ClosuresAreNotFns,
     #[error("thread local storage is not supported")]
-    ThreadLocalNotSupported,    
+    ThreadLocalNotSupported,
 
     // Warnings
     #[error("defer inside a loop: this defered statement will only be executed once")]

--- a/src/alumina-boot/src/common.rs
+++ b/src/alumina-boot/src/common.rs
@@ -10,12 +10,12 @@ use tree_sitter::Node;
 
 macro_rules! ice {
     ($why:literal) => {{
-        use crate::common::CodeErrorBuilder; 
+        use crate::common::CodeErrorBuilder;
         return Err(CodeErrorKind::InternalError(
             $why.to_string(),
             backtrace::Backtrace::new(),
         ))
-        .with_no_span()
+        .with_no_span();
     }};
 }
 

--- a/src/alumina-boot/src/ir/mod.rs
+++ b/src/alumina-boot/src/ir/mod.rs
@@ -351,6 +351,7 @@ pub struct Static<'ir> {
     pub name: Option<&'ir str>,
     pub typ: TyP<'ir>,
     pub init: Option<ExprP<'ir>>,
+    pub attributes: &'ir [Attribute],
     pub r#extern: bool,
 }
 

--- a/src/alumina-boot/src/ir/mono.rs
+++ b/src/alumina-boot/src/ir/mono.rs
@@ -721,6 +721,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             },
             Some(LangItemKind::ProtoPrimitive) => match ty {
                 ir::Ty::Builtin(_) => return Ok(BoundCheckResult::Matches),
+                ir::Ty::Pointer(_, _) => return Ok(BoundCheckResult::Matches),
                 _ => return Ok(BoundCheckResult::DoesNotMatch),
             },
             Some(LangItemKind::ProtoPointer) => match ty {
@@ -933,6 +934,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                 name: s.name.map(|n| n.alloc_on(child.mono_ctx.ir)),
                 typ,
                 init,
+                attributes: s.attributes.alloc_on(child.mono_ctx.ir),
                 r#extern: s.r#extern,
             });
             item.assign(res);
@@ -3143,6 +3145,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             name: None,
             typ: res.ty,
             init: Some(res),
+            attributes: &[],
             r#extern: false,
         }));
 
@@ -3218,6 +3221,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             name: None,
             typ: res.ty,
             init: Some(res),
+            attributes: &[],
             r#extern: false,
         }));
 

--- a/src/alumina-boot/src/name_resolution/pass1.rs
+++ b/src/alumina-boot/src/name_resolution/pass1.rs
@@ -111,7 +111,7 @@ impl<'ast, 'src> AluminaVisitor<'src> for FirstPassVisitor<'ast, 'src> {
     type ReturnType = Result<(), AluminaError>;
 
     fn visit_source_file(&mut self, node: Node<'src>) -> Self::ReturnType {
-        let attributes = parse_attributes!(self, node);
+        parse_attributes!(self, node);
         self.visit_children_by_field(node, "body")
     }
 

--- a/src/alumina-boot/src/name_resolution/pass1.rs
+++ b/src/alumina-boot/src/name_resolution/pass1.rs
@@ -111,7 +111,8 @@ impl<'ast, 'src> AluminaVisitor<'src> for FirstPassVisitor<'ast, 'src> {
     type ReturnType = Result<(), AluminaError>;
 
     fn visit_source_file(&mut self, node: Node<'src>) -> Self::ReturnType {
-        self.visit_children(node)
+        let attributes = parse_attributes!(self, node);
+        self.visit_children_by_field(node, "body")
     }
 
     fn visit_mod_definition(&mut self, node: Node<'src>) -> Self::ReturnType {

--- a/src/alumina-boot/src/visitors.rs
+++ b/src/alumina-boot/src/visitors.rs
@@ -358,7 +358,7 @@ impl<'ast, 'src> AluminaVisitor<'src> for AttributeVisitor<'ast, 'src> {
                 if self.global_ctx.has_flag("threading") {
                     self.attributes.push(Attribute::ThreadLocal)
                 }
-            },
+            }
             "test_main" => self.attributes.push(Attribute::TestMain),
             "link_name" => {
                 let link_name = inner

--- a/src/alumina-boot/src/visitors.rs
+++ b/src/alumina-boot/src/visitors.rs
@@ -331,7 +331,10 @@ impl<'ast, 'src> AluminaVisitor<'src> for AttributeVisitor<'ast, 'src> {
         self.visit_attributes(node)
     }
 
-    fn visit_top_level_attribute_item(&mut self, node: tree_sitter::Node<'src>) -> Self::ReturnType {
+    fn visit_top_level_attribute_item(
+        &mut self,
+        node: tree_sitter::Node<'src>,
+    ) -> Self::ReturnType {
         self.visit_attribute_item(node)
     }
     fn visit_attribute_item(&mut self, node: Node<'src>) -> Self::ReturnType {

--- a/src/alumina-boot/src/visitors.rs
+++ b/src/alumina-boot/src/visitors.rs
@@ -327,6 +327,13 @@ impl<'ast, 'src> AluminaVisitor<'src> for AttributeVisitor<'ast, 'src> {
         Ok(())
     }
 
+    fn visit_top_level_attributes(&mut self, node: tree_sitter::Node<'src>) -> Self::ReturnType {
+        self.visit_attributes(node)
+    }
+
+    fn visit_top_level_attribute_item(&mut self, node: tree_sitter::Node<'src>) -> Self::ReturnType {
+        self.visit_attribute_item(node)
+    }
     fn visit_attribute_item(&mut self, node: Node<'src>) -> Self::ReturnType {
         let inner = node.child_by_field_name("inner").unwrap();
 

--- a/src/alumina-boot/src/visitors.rs
+++ b/src/alumina-boot/src/visitors.rs
@@ -352,6 +352,13 @@ impl<'ast, 'src> AluminaVisitor<'src> for AttributeVisitor<'ast, 'src> {
             "builtin" => self.attributes.push(Attribute::Builtin),
             "export" => self.attributes.push(Attribute::Export),
             "force_inline" => self.attributes.push(Attribute::ForceInline),
+            "thread_local" => {
+                // We can skip thread-local on programs that are compiled with threads
+                // disabled.
+                if self.global_ctx.has_flag("threading") {
+                    self.attributes.push(Attribute::ThreadLocal)
+                }
+            },
             "test_main" => self.attributes.push(Attribute::TestMain),
             "link_name" => {
                 let link_name = inner

--- a/src/aluminac/lib/arena.alu
+++ b/src/aluminac/lib/arena.alu
@@ -84,7 +84,7 @@ impl Arena {
     }
 
     #[inline]
-    fn alloc_slice<T>(self: &mut Arena, len: usize) -> &mut [T] {       
+    fn alloc_slice<T>(self: &mut Arena, len: usize) -> &mut [T] {
         let ptr = self.aligned_alloc(size_of::<T>() * len, align_of::<T>()) as &mut T;
         std::mem::slice::from_raw(ptr, len)
     }
@@ -116,10 +116,10 @@ mod tests {
         for i in 0..1000001 {
             let ptr: &mut i32 = arena.alloc(1023);
             let slice: &mut [i32] = arena.alloc_slice(133);
-            
+
             *ptr = i;
             slice[4] = i;
         }
     }
 }
- 
+

--- a/src/aluminac/lib/common.alu
+++ b/src/aluminac/lib/common.alu
@@ -9,12 +9,12 @@ macro child_by($node, $field) {
 macro children_by($node, $field, $cursor) {
     $node.children_by_field_id($field as TSFieldId, $cursor)
 }
- 
+
 protocol NodeVisitorExt<Self, ReturnType> {
     fn visit_children(self: &mut Self, node: Node) -> ReturnType {
         let cursor = node.walk();
         defer cursor.free();
-        
+
         when ReturnType: () {
             for node in node.children(&cursor) {
                 self.visit(node);
@@ -49,7 +49,7 @@ protocol NodeVisitorExt<Self, ReturnType> {
             ReturnType::ok(())
         }
     }
-    
+
 }
 
 struct Error {}

--- a/src/aluminac/lib/node_kinds.alu
+++ b/src/aluminac/lib/node_kinds.alu
@@ -35,6 +35,7 @@ enum NodeKind {
     StructInitializer,
     Block,
     SliceOf,
+    TopLevelAttributes,
     FloatLiteral,
     ArrayOf,
     ScopedUseList,
@@ -50,11 +51,11 @@ enum NodeKind {
     TypeIdentifier,
     MacroInvocation,
     ConstDeclaration,
-    StructExpression,
     LoopExpression,
+    StructExpression,
     UseAsClause,
-    ProtocolDefinition,
     Parameter,
+    ProtocolDefinition,
     FieldExpression,
     PtrLiteral,
     EnumDefinition,
@@ -104,6 +105,7 @@ enum NodeKind {
     ForExpression,
     IntegerLiteral,
     StructField,
+    TopLevelAttributeItem,
     FunctionDefinition,
     ParameterList,
 }
@@ -160,11 +162,12 @@ enum FieldKind {
     Upper = 49u16,
 }
 
-static NODE_KINDS: [NodeKind; 237] = [
+static NODE_KINDS: [NodeKind; 242] = [
     NodeKind::Invalid,
     NodeKind::Identifier,
     NodeKind::DocComment,
     NodeKind::FileDocComment,
+    NodeKind::Invalid,
     NodeKind::Invalid,
     NodeKind::Invalid,
     NodeKind::Invalid,
@@ -272,6 +275,8 @@ static NODE_KINDS: [NodeKind; 237] = [
     NodeKind::Invalid,
     NodeKind::MacroIdentifier,
     NodeKind::SourceFile,
+    NodeKind::TopLevelAttributes,
+    NodeKind::TopLevelAttributeItem,
     NodeKind::Attributes,
     NodeKind::AttributeItem,
     NodeKind::MetaItem,
@@ -396,6 +401,8 @@ static NODE_KINDS: [NodeKind; 237] = [
     NodeKind::Invalid,
     NodeKind::Invalid,
     NodeKind::Invalid,
+    NodeKind::Invalid,
+    NodeKind::Invalid,
     NodeKind::PrimitiveType,
     NodeKind::TypeIdentifier,
 ];
@@ -487,6 +494,9 @@ protocol NodeVisitor<Self, ReturnType> {
     fn visit_slice_of(self: &mut Self, node: Node) -> ReturnType {
         panic!("unimplemented: visit_slice_of");
     }
+    fn visit_top_level_attributes(self: &mut Self, node: Node) -> ReturnType {
+        panic!("unimplemented: visit_top_level_attributes");
+    }
     fn visit_float_literal(self: &mut Self, node: Node) -> ReturnType {
         panic!("unimplemented: visit_float_literal");
     }
@@ -532,20 +542,20 @@ protocol NodeVisitor<Self, ReturnType> {
     fn visit_const_declaration(self: &mut Self, node: Node) -> ReturnType {
         panic!("unimplemented: visit_const_declaration");
     }
-    fn visit_struct_expression(self: &mut Self, node: Node) -> ReturnType {
-        panic!("unimplemented: visit_struct_expression");
-    }
     fn visit_loop_expression(self: &mut Self, node: Node) -> ReturnType {
         panic!("unimplemented: visit_loop_expression");
+    }
+    fn visit_struct_expression(self: &mut Self, node: Node) -> ReturnType {
+        panic!("unimplemented: visit_struct_expression");
     }
     fn visit_use_as_clause(self: &mut Self, node: Node) -> ReturnType {
         panic!("unimplemented: visit_use_as_clause");
     }
-    fn visit_protocol_definition(self: &mut Self, node: Node) -> ReturnType {
-        panic!("unimplemented: visit_protocol_definition");
-    }
     fn visit_parameter(self: &mut Self, node: Node) -> ReturnType {
         panic!("unimplemented: visit_parameter");
+    }
+    fn visit_protocol_definition(self: &mut Self, node: Node) -> ReturnType {
+        panic!("unimplemented: visit_protocol_definition");
     }
     fn visit_field_expression(self: &mut Self, node: Node) -> ReturnType {
         panic!("unimplemented: visit_field_expression");
@@ -694,6 +704,9 @@ protocol NodeVisitor<Self, ReturnType> {
     fn visit_struct_field(self: &mut Self, node: Node) -> ReturnType {
         panic!("unimplemented: visit_struct_field");
     }
+    fn visit_top_level_attribute_item(self: &mut Self, node: Node) -> ReturnType {
+        panic!("unimplemented: visit_top_level_attribute_item");
+    }
     fn visit_function_definition(self: &mut Self, node: Node) -> ReturnType {
         panic!("unimplemented: visit_function_definition");
     }
@@ -734,6 +747,7 @@ protocol NodeVisitor<Self, ReturnType> {
             NodeKind::StructInitializer => self.visit_struct_initializer(node),
             NodeKind::Block => self.visit_block(node),
             NodeKind::SliceOf => self.visit_slice_of(node),
+            NodeKind::TopLevelAttributes => self.visit_top_level_attributes(node),
             NodeKind::FloatLiteral => self.visit_float_literal(node),
             NodeKind::ArrayOf => self.visit_array_of(node),
             NodeKind::ScopedUseList => self.visit_scoped_use_list(node),
@@ -749,11 +763,11 @@ protocol NodeVisitor<Self, ReturnType> {
             NodeKind::TypeIdentifier => self.visit_type_identifier(node),
             NodeKind::MacroInvocation => self.visit_macro_invocation(node),
             NodeKind::ConstDeclaration => self.visit_const_declaration(node),
-            NodeKind::StructExpression => self.visit_struct_expression(node),
             NodeKind::LoopExpression => self.visit_loop_expression(node),
+            NodeKind::StructExpression => self.visit_struct_expression(node),
             NodeKind::UseAsClause => self.visit_use_as_clause(node),
-            NodeKind::ProtocolDefinition => self.visit_protocol_definition(node),
             NodeKind::Parameter => self.visit_parameter(node),
+            NodeKind::ProtocolDefinition => self.visit_protocol_definition(node),
             NodeKind::FieldExpression => self.visit_field_expression(node),
             NodeKind::PtrLiteral => self.visit_ptr_literal(node),
             NodeKind::EnumDefinition => self.visit_enum_definition(node),
@@ -803,6 +817,7 @@ protocol NodeVisitor<Self, ReturnType> {
             NodeKind::ForExpression => self.visit_for_expression(node),
             NodeKind::IntegerLiteral => self.visit_integer_literal(node),
             NodeKind::StructField => self.visit_struct_field(node),
+            NodeKind::TopLevelAttributeItem => self.visit_top_level_attribute_item(node),
             NodeKind::FunctionDefinition => self.visit_function_definition(node),
             NodeKind::ParameterList => self.visit_parameter_list(node),
             _ => self.visit_unknown(node),

--- a/src/aluminac/main.alu
+++ b/src/aluminac/main.alu
@@ -29,7 +29,7 @@ impl SampleVisitor {
 
         println!("function: {}", name.text(self.source));
         Result::ok(())
-    } 
+    }
 
     fn visit_macro_definition(self: &mut SampleVisitor, node: Node) -> Result<(), Error> {
         let name = child_by!(node, FieldKind::Name).unwrap();
@@ -51,7 +51,7 @@ impl SampleVisitor {
         println!("impl: {}", name.text(self.source));
         Result::ok(())
     }
-    
+
     fn visit_protocol_definition(self: &mut SampleVisitor, node: Node) -> Result<(), Error> {
         let name = child_by!(node, FieldKind::Name).unwrap();
 
@@ -62,7 +62,7 @@ impl SampleVisitor {
     fn visit_use_declaration(self: &mut SampleVisitor, node: Node) -> Result<(), Error> {
         Result::ok(())
     }
-    
+
     mixin NodeVisitor<SampleVisitor, Result<(), Error>>;
     mixin NodeVisitorExt<SampleVisitor, Result<(), Error>>;
 }
@@ -149,10 +149,10 @@ fn main() {
     parser.set_language(tree_sitter_alumina()).unwrap()
     let source = File::read_to_string(Path::new("./src/aluminac/main.alu")).unwrap();
     defer source.free();
-    
+
     let tree = parser.parse(source.as_slice());
     defer tree.free();
-    
+
     let root_node = tree.root_node().unwrap();
     let cursor = root_node.walk();
     defer cursor.free();

--- a/sysroot/__root__.alu
+++ b/sysroot/__root__.alu
@@ -3,17 +3,17 @@
 //! Welcome to the Alumina programming language!
 //!
 //! # Standard library structure
-//! This is the root module (`::`) of the standard library, all the code contained in these 
-//! modules is always available to programs and libraries written in Alumina. It consists of 
-//! [std], which is the bulk of the library and a couple of auxillary modules, such as [libc] 
+//! This is the root module (`::`) of the standard library, all the code contained in these
+//! modules is always available to programs and libraries written in Alumina. It consists of
+//! [std], which is the bulk of the library and a couple of auxillary modules, such as [libc]
 //! for bindings to the C standard library and [test] for the built-in mini unit testing framework.
 //!
 //! It is important to understand that the notion of an Alumina "library" is not very precise.
 //! The compilation unit is always the whole program, including the user code, the standard library.
-//! and any external libraries. In other words, modules are just namespaces. 
+//! and any external libraries. In other words, modules are just namespaces.
 //!
-//! This means that the modules do not have to form a directed graph and can freely depend 
-//! on one another. 
+//! This means that the modules do not have to form a directed graph and can freely depend
+//! on one another.
 //!
 //! # About the documentation
 //! The documentation is generated from the comments in the source code using the [alumina-doc]

--- a/sysroot/libc.alu
+++ b/sysroot/libc.alu
@@ -1004,3 +1004,78 @@ extern "C" fn strlen(s: &c_char) -> size_t;
     
     const S_IFMT: mode_t = 61440;
 }
+
+
+#[cfg(target_os = "android")] {
+    type pthread_t = c_long;
+
+    #[cfg(target_pointer_width = "32")]
+    struct pthread_attr_t {
+        flags: u32,
+        stack_base: &mut void,
+        stack_size: size_t,
+        guard_size: size_t,
+        sched_policy: i32,
+        sched_priority: i32,
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    struct pthread_attr_t {
+        flags: u32,
+        stack_base: &mut void,
+        stack_size: size_t,
+        guard_size: size_t,
+        sched_policy: i32,
+        sched_priority: i32,
+    }
+}
+
+#[cfg(target_os = "linux")] {
+    type pthread_t = c_ulong;
+
+    #[cfg(target_arch = "aarch64")]
+    struct pthread_attr_t {
+        __size: [usize; 8]
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "arm"))]
+    struct pthread_attr_t {
+        __size: [u32; 9]
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    struct pthread_attr_t {
+        #[cfg(target_pointer_width = "32")]
+        __size: [u32; 8],
+        #[cfg(target_pointer_width = "64")]
+        __size: [u64; 7]
+    }
+}
+
+#[cfg(target_os = "macos")] {
+    type pthread_t = uintptr_t;
+
+    #[cfg(target_pointer_width = "32")]
+    struct pthread_attr_t {
+        __sig: c_long,
+        __opaque: [c_char; 36]
+    }
+    
+    #[cfg(target_pointer_width = "64")]
+    struct pthread_attr_t {
+        __sig: c_long,
+        __opaque: [c_char; 56]
+    }
+}
+
+extern "C" fn pthread_create(
+    native: &mut pthread_t,
+    attr: &pthread_attr_t,
+    f: fn(&mut void) -> &mut void,
+    value: &mut void,
+) -> c_int;
+
+extern "C" fn pthread_join(native: pthread_t, value: &mut &mut void) -> c_int;
+extern "C" fn pthread_exit(value: &mut void) -> !;
+extern "C" fn pthread_kill(thread: pthread_t, sig: c_int) -> c_int;
+extern "C" fn pthread_self() -> pthread_t;

--- a/sysroot/libc.alu
+++ b/sysroot/libc.alu
@@ -1268,14 +1268,11 @@ extern "C" fn pthread_detach(thread: pthread_t) -> c_int;
 extern "C" fn pthread_mutex_lock(lock: &mut pthread_mutex_t) -> c_int;
 extern "C" fn pthread_mutex_trylock(lock: &mut pthread_mutex_t) -> c_int;
 extern "C" fn pthread_mutex_unlock(lock: &mut pthread_mutex_t) -> c_int;
-extern "C" fn pthread_mutex_timedlock(lock: &mut pthread_mutex_t, abstime: &timespec) -> c_int;
 
 extern "C" fn pthread_rwlock_rdlock(lock: &mut pthread_rwlock_t) -> c_int;
 extern "C" fn pthread_rwlock_tryrdlock(lock: &mut pthread_rwlock_t) -> c_int;
-extern "C" fn pthread_rwlock_timedrdlock(attr: &mut pthread_rwlock_t, abstime: &timespec) -> c_int;
 extern "C" fn pthread_rwlock_wrlock(lock: &mut pthread_rwlock_t) -> c_int;
 extern "C" fn pthread_rwlock_trywrlock(lock: &mut pthread_rwlock_t) -> c_int;
-extern "C" fn pthread_rwlock_timedwrlock(attr: &mut pthread_rwlock_t, abstime: &timespec) -> c_int;
 extern "C" fn pthread_rwlock_unlock(lock: &mut pthread_rwlock_t) -> c_int;
 
 extern "C" fn pthread_cond_wait(cond: &mut pthread_cond_t, lock: &mut pthread_mutex_t) -> c_int;

--- a/sysroot/libc.alu
+++ b/sysroot/libc.alu
@@ -1307,3 +1307,34 @@ fn pthread_rwlock_initializer() -> pthread_rwlock_t {
     ret
 }
 
+// Futex support
+#[cfg(any(target_os = "android", target_os = "linux"))]
+{
+    extern "C" fn syscall(num: c_long, ...) -> c_long;
+
+    const FUTEX_WAIT: c_int = 0;
+    const FUTEX_WAKE: c_int = 1;
+    const FUTEX_FD: c_int = 2;
+    const FUTEX_REQUEUE: c_int = 3;
+    const FUTEX_CMP_REQUEUE: c_int = 4;
+    const FUTEX_WAKE_OP: c_int = 5;
+    const FUTEX_LOCK_PI: c_int = 6;
+    const FUTEX_UNLOCK_PI: c_int = 7;
+    const FUTEX_TRYLOCK_PI: c_int = 8;
+    const FUTEX_WAIT_BITSET: c_int = 9;
+    const FUTEX_WAKE_BITSET: c_int = 10;
+    const FUTEX_WAIT_REQUEUE_PI: c_int = 11;
+    const FUTEX_CMP_REQUEUE_PI: c_int = 12;
+    const FUTEX_PRIVATE_FLAG: c_int = 128;
+    const FUTEX_CLOCK_REALTIME: c_int = 256;
+    const FUTEX_CMD_MASK: c_int = ~(FUTEX_PRIVATE_FLAG | FUTEX_CLOCK_REALTIME);
+
+    #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+    const SYS_futex: c_long = 240;
+    
+    #[cfg(target_arch = "aarch64")]
+    const SYS_futex: c_long = 98;
+    
+    #[cfg(target_arch = "x86_64")]
+    const SYS_futex: c_long = 202;
+}

--- a/sysroot/libc.alu
+++ b/sysroot/libc.alu
@@ -199,6 +199,7 @@ extern "C" fn realloc(ptr: &mut void, size: size_t) -> &mut void;
 extern "C" fn calloc(num: size_t, size: size_t) -> &mut void;
 extern "C" fn exit(ret: c_int) -> !;
 extern "C" fn _exit(ret: c_int) -> !;
+extern "C" fn abort() -> !;
 extern "C" fn strlen(s: &c_char) -> size_t;
 
 #[cfg(any(target_os="linux", target_os="macos", target_os="android"))]
@@ -839,6 +840,11 @@ extern "C" fn strlen(s: &c_char) -> size_t;
     const EWOULDBLOCK: c_int = EAGAIN;
     #[cfg(target_os="macos")]
     const EWOULDBLOCK: c_int = 35;
+    
+    #[cfg(any(target_os="linux", target_os="android"))]
+    const ETIMEDOUT: c_int = 110;
+    #[cfg(target_os="macos")]
+    const ETIMEDOUT: c_int = 60;
 
     const POLLIN: c_short = 0x1;
     const POLLPRI: c_short = 0x2;
@@ -1008,26 +1014,68 @@ extern "C" fn strlen(s: &c_char) -> size_t;
 
 #[cfg(target_os = "android")] {
     type pthread_t = c_long;
+    type pthread_mutexattr_t = c_long;
+    type pthread_rwlockattr_t = c_long;
+    type pthread_barrierattr_t = c_int;
+    type pthread_condattr_t = c_long;
 
     #[cfg(target_pointer_width = "32")]
-    struct pthread_attr_t {
-        flags: u32,
-        stack_base: &mut void,
-        stack_size: size_t,
-        guard_size: size_t,
-        sched_policy: i32,
-        sched_priority: i32,
+    {
+        struct pthread_attr_t {
+            flags: u32,
+            stack_base: &mut void,
+            stack_size: size_t,
+            guard_size: size_t,
+            sched_policy: i32,
+            sched_priority: i32,
+        }
+
+        struct pthread_mutex_t { value: c_int }
+
+        struct pthread_cond_t { value: c_int }
+    
+        struct pthread_rwlock_t {
+            lock: pthread_mutex_t,
+            cond: pthread_cond_t,
+            numLocks: c_int,
+            writerThreadId: c_int,
+            pendingReaders: c_int,
+            pendingWriters: c_int,
+            attr: i32,
+            __reserved: [c_char; 12],
+        }
     }
 
     #[cfg(target_pointer_width = "64")]
-    struct pthread_attr_t {
-        flags: u32,
-        stack_base: &mut void,
-        stack_size: size_t,
-        guard_size: size_t,
-        sched_policy: i32,
-        sched_priority: i32,
-    }
+    {
+        struct pthread_attr_t {
+            flags: u32,
+            stack_base: &mut void,
+            stack_size: size_t,
+            guard_size: size_t,
+            sched_policy: i32,
+            sched_priority: i32,
+        }
+        
+        struct pthread_mutex_t {
+            value: c_int,
+            __reserved: [c_char; 36],
+        }
+
+        struct pthread_cond_t {
+            value: c_int,
+            __reserved: [c_char; 44],
+        }
+
+        struct pthread_rwlock_t {
+            numLocks: c_int,
+            writerThreadId: c_int,
+            pendingReaders: c_int,
+            pendingWriters: c_int,
+            attr: i32,
+            __reserved: [c_char; 36],
+        }
+    }    
 }
 
 #[cfg(target_os = "linux")] {
@@ -1050,6 +1098,106 @@ extern "C" fn strlen(s: &c_char) -> size_t;
         #[cfg(target_pointer_width = "64")]
         __size: [u64; 7]
     }
+
+    type INNER_SIZEOF_PTHREAD_RWLOCKATTR_T = [u8; 8];
+    type INNER_SIZEOF_PTHREAD_COND_T = [u8; 48];
+
+    #[cfg(all(target_arch = "aarch64", target_pointer_width = "64"))]
+    {
+        type INNER_SIZEOF_PTHREAD_CONDATTR_T = [u8; 8];
+        type INNER_SIZEOF_PTHREAD_MUTEXATTR_T = [u8; 8];
+        type INNER_SIZEOF_PTHREAD_MUTEX_T = [u8; 48];
+        type INNER_SIZEOF_PTHREAD_RWLOCK_T = [u8; 56];
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        #[cfg(target_pointer_width = "64")] {
+            type INNER_SIZEOF_PTHREAD_CONDATTR_T = [u8; 4];
+            type INNER_SIZEOF_PTHREAD_MUTEXATTR_T = [u8; 4];
+            type INNER_SIZEOF_PTHREAD_MUTEX_T = [u8; 40];
+            type INNER_SIZEOF_PTHREAD_RWLOCK_T = [u8; 56];
+        }
+        
+        #[cfg(target_pointer_width = "32")] {
+            type INNER_SIZEOF_PTHREAD_CONDATTR_T = [u8; 4];
+            type INNER_SIZEOF_PTHREAD_MUTEXATTR_T = [u8; 4];
+            type INNER_SIZEOF_PTHREAD_MUTEX_T = [u8; 32];
+            type INNER_SIZEOF_PTHREAD_RWLOCK_T = [u8; 44];
+        }
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "arm"))] {
+        type INNER_SIZEOF_PTHREAD_CONDATTR_T = [u8; 4];
+        type INNER_SIZEOF_PTHREAD_MUTEXATTR_T = [u8; 4];
+        type INNER_SIZEOF_PTHREAD_MUTEX_T = [u8; 24];
+        type INNER_SIZEOF_PTHREAD_RWLOCK_T = [u8; 32];
+    }
+
+    #[cfg(target_arch = "x86")]
+    #[align(4)]
+    struct pthread_cond_t {
+        size: INNER_SIZEOF_PTHREAD_COND_T,
+    }
+    
+    #[cfg(not(target_arch = "x86"))]
+    #[align(8)]
+    struct pthread_cond_t {
+        size: INNER_SIZEOF_PTHREAD_COND_T,
+    }
+    
+    #[cfg(any(target_pointer_width = "64", not(any(target_arch = "arm", target_arch = "x86_64", target_arch = "x86")))]
+    #[align(8)]
+    struct pthread_mutex_t {
+        size: INNER_SIZEOF_PTHREAD_MUTEX_T,
+    }
+
+    #[cfg(all(target_pointer_width = "32", any(target_arch = "arm", target_arch = "x86_64", target_arch = "x86"))]
+    #[align(4)]
+    struct pthread_mutex_t {
+        size: INNER_SIZEOF_PTHREAD_MUTEX_T,
+    }
+
+    #[cfg(any(target_pointer_width = "64", not(any(target_arch = "arm", target_arch = "x86_64", target_arch = "x86")))]
+    #[align(8)]
+    struct pthread_rwlock_t {
+        size: INNER_SIZEOF_PTHREAD_RWLOCK_T,
+    }
+
+    #[cfg(all(target_pointer_width = "32", any(target_arch = "arm", target_arch = "x86_64", target_arch = "x86"))]
+    #[align(4)]
+    struct pthread_rwlock_t {
+        size: INNER_SIZEOF_PTHREAD_RWLOCK_T,
+    }
+
+    #[cfg(any(target_pointer_width = "32", target_arch = "x86_64", target_arch = "aarch64"))]
+    #[align(4)]
+    struct pthread_mutexattr_t {
+        size: INNER_SIZEOF_PTHREAD_MUTEXATTR_T,
+    }
+
+    #[cfg(not(any(target_pointer_width = "32", target_arch = "x86_64", target_arch = "aarch64")))]
+    #[align(8)]
+    struct pthread_mutexattr_t {
+        size: INNER_SIZEOF_PTHREAD_MUTEXATTR_T,
+    }
+
+    #[align(4)]
+    struct pthread_condattr_t {
+        size: INNER_SIZEOF_PTHREAD_CONDATTR_T,
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[align(4)]
+    struct pthread_rwlockattr_t {
+        size: INNER_SIZEOF_PTHREAD_RWLOCKATTR_T,
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[align(8)]
+    struct pthread_rwlockattr_t {
+        size: INNER_SIZEOF_PTHREAD_RWLOCKATTR_T,
+    }
 }
 
 #[cfg(target_os = "macos")] {
@@ -1066,6 +1214,42 @@ extern "C" fn strlen(s: &c_char) -> size_t;
         __sig: c_long,
         __opaque: [c_char; 56]
     }
+
+    type INNER_PTHREAD_MUTEX_SIZE = [u8; 56];
+    type INNER_PTHREAD_COND_SIZE = [u8; 40];
+    type INNER_PTHREAD_CONDATTR_SIZE = [u8;  8];
+    type INNER_PTHREAD_RWLOCK_SIZE  = [u8; 92];
+    type INNER_PTHREAD_RWLOCKATTR_SIZE = [u8; 16];
+
+    struct pthread_rwlock_t {
+        __sig: c_long,
+        __opaque: INNER_PTHREAD_RWLOCK_SIZE,
+    }
+
+    struct pthread_mutex_t {
+        __sig: c_long,
+        __opaque: INNER_PTHREAD_MUTEX_SIZE,
+    }
+
+    struct pthread_cond_t {
+        __sig: c_long,
+        __opaque: INNER_PTHREAD_COND_SIZE,
+    }
+
+    struct pthread_mutexattr_t {
+        __sig: c_long,
+        __opaque: [u8; 8],
+    }
+
+    struct pthread_condattr_t {
+        __sig: c_long,
+        __opaque: INNER_PTHREAD_CONDATTR_SIZE,
+    }
+
+    struct pthread_rwlockattr_t {
+        __sig: c_long,
+        __opaque: INNER_PTHREAD_RWLOCKATTR_SIZE,
+    }
 }
 
 extern "C" fn pthread_create(
@@ -1079,3 +1263,50 @@ extern "C" fn pthread_join(native: pthread_t, value: &mut &mut void) -> c_int;
 extern "C" fn pthread_exit(value: &mut void) -> !;
 extern "C" fn pthread_kill(thread: pthread_t, sig: c_int) -> c_int;
 extern "C" fn pthread_self() -> pthread_t;
+extern "C" fn pthread_detach(thread: pthread_t) -> c_int;
+
+extern "C" fn pthread_mutex_lock(lock: &mut pthread_mutex_t) -> c_int;
+extern "C" fn pthread_mutex_trylock(lock: &mut pthread_mutex_t) -> c_int;
+extern "C" fn pthread_mutex_unlock(lock: &mut pthread_mutex_t) -> c_int;
+extern "C" fn pthread_mutex_timedlock(lock: &mut pthread_mutex_t, abstime: &timespec) -> c_int;
+
+extern "C" fn pthread_rwlock_rdlock(lock: &mut pthread_rwlock_t) -> c_int;
+extern "C" fn pthread_rwlock_tryrdlock(lock: &mut pthread_rwlock_t) -> c_int;
+extern "C" fn pthread_rwlock_timedrdlock(attr: &mut pthread_rwlock_t, abstime: &timespec) -> c_int;
+extern "C" fn pthread_rwlock_wrlock(lock: &mut pthread_rwlock_t) -> c_int;
+extern "C" fn pthread_rwlock_trywrlock(lock: &mut pthread_rwlock_t) -> c_int;
+extern "C" fn pthread_rwlock_timedwrlock(attr: &mut pthread_rwlock_t, abstime: &timespec) -> c_int;
+extern "C" fn pthread_rwlock_unlock(lock: &mut pthread_rwlock_t) -> c_int;
+
+extern "C" fn pthread_cond_wait(cond: &mut pthread_cond_t, lock: &mut pthread_mutex_t) -> c_int;
+extern "C" fn pthread_cond_timedwait(cond: &mut pthread_cond_t, lock: &mut pthread_mutex_t, abstime: &timespec) -> c_int;
+extern "C" fn pthread_cond_signal(cond: &mut pthread_cond_t) -> c_int;
+extern "C" fn pthread_cond_broadcast(cond: &mut pthread_cond_t) -> c_int;
+
+extern "C" fn sched_yield() -> c_int;
+
+
+#[inline]
+fn pthread_mutex_initializer() -> pthread_mutex_t {
+    let ret = std::mem::zeroed::<pthread_mutex_t>();
+    #[cfg(target_os = "macos")]
+    ret.__sig = 0x32AAABA7;
+    ret
+}
+
+#[inline]
+fn pthread_cond_initializer() -> pthread_cond_t {
+    let ret = std::mem::zeroed::<pthread_cond_t>();
+    #[cfg(target_os = "macos")]
+    ret.__sig = 0x3CB0B1BB;
+    ret
+}
+
+#[inline]
+fn pthread_rwlock_initializer() -> pthread_rwlock_t {
+    let ret = std::mem::zeroed::<pthread_rwlock_t>();
+    #[cfg(target_os = "macos")]
+    ret.__sig = 0x2DA8B3B4;
+    ret
+}
+

--- a/sysroot/libc.alu
+++ b/sysroot/libc.alu
@@ -1,6 +1,6 @@
 //! "FFI" interfaces to libc.
 //!
-//! If compiled on a Linux target, this module assumes glibc. Mostly copied/adapted 
+//! If compiled on a Linux target, this module assumes glibc. Mostly copied/adapted
 //! from [Rust's libc crate](https://github.com/rust-lang/libc).
 
 type c_schar = i8;
@@ -75,7 +75,7 @@ type ssize_t = isize;
 
     #[cfg(target_pointer_width = "32")]
     type socklen_t = i32;
-    
+
     #[cfg(target_pointer_width = "64")]
     type socklen_t = u32;
 
@@ -97,7 +97,7 @@ type ssize_t = isize;
         type off_t = i64;
         type ino_t = u32;
     }
-    
+
     #[cfg(target_pointer_width = "64")]
     {
         type off_t = i32;
@@ -124,7 +124,7 @@ type ssize_t = isize;
         type wchar_t = i32;
         type clock_t = i64;
         type time_t = i64;
-        
+
         type nlink_t = u64;
         type blkcnt_t = i64;
         type blksize_t = i64;
@@ -153,7 +153,7 @@ type ssize_t = isize;
             type c_ulong = u32;
             type clock_t = i32;
             type time_t = i32;
-            
+
             type nlink_t = u32;
             type blkcnt_t = i64;
             type blksize_t = i32;
@@ -165,7 +165,7 @@ type ssize_t = isize;
             type c_ulong = u64;
             type clock_t = i64;
             type time_t = i64;
-            
+
             type nlink_t = u32;
             type blkcnt_t = i32;
             type blksize_t = i32;
@@ -231,7 +231,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
         struct sockaddr_storage {
             ss_family: sa_family_t,
             __ss_align: size_t,
-            
+
             #[cfg(target_pointer_width = "32")]
             __ss_pad2: [u8; 120],
             #[cfg(target_pointer_width = "64")]
@@ -324,7 +324,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
             d_type: c_uchar,
             d_name: [c_char; 256],
         }
-     
+
         struct dirent64 {
             d_ino: ino64_t,
             d_off: off64_t,
@@ -333,7 +333,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
             d_name: [c_char; 256],
         }
     }
-    
+
     #[cfg(target_os="macos")]
     struct dirent {
         d_ino: u64,
@@ -343,7 +343,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
         d_type: u8,
         d_name: [c_char; 1024],
     }
-    
+
     #[cfg(target_os="android")]
     {
         struct dirent {
@@ -369,14 +369,14 @@ extern "C" fn strlen(s: &c_char) -> size_t;
         events: c_short,
         revents: c_short,
     }
-    
+
     #[cfg(any(target_os="linux"))]
     extern "C" fn getrandom(buf: &mut void, buflen: size_t, flags: c_uint) -> ssize_t;
     extern "C" fn write(fd: c_int, buf: &void, len: size_t) -> ssize_t;
     extern "C" fn read(fd: c_int, buf: &mut void, len: size_t) -> ssize_t;
     extern "C" fn open(path: &c_char, oflag: c_int, mode: mode_t) -> c_int;
     extern "C" fn lseek(fd: c_int, offset: off_t, whence: c_int) -> off_t;
-    
+
     #[cfg(not(target_os="macos"))]
     extern "C" fn lseek64(fd: c_int, offset: off64_t, whence: c_int) -> off64_t;
 
@@ -458,7 +458,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
     ) -> c_int;
     extern "C" fn recv(socket: c_int, buf: &mut void, len: size_t, flags: c_int) -> ssize_t;
     extern "C" fn send(socket: c_int, buf: &void, len: size_t, flags: c_int) -> ssize_t;
-    
+
     extern "C" fn recvfrom(
         socket: c_int,
         buf: &mut void,
@@ -476,7 +476,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
         addr: &sockaddr,
         addrlen: socklen_t,
     ) -> ssize_t;
-    
+
     extern "C" fn getaddrinfo(
         node: &c_char,
         service: &c_char,
@@ -490,15 +490,15 @@ extern "C" fn strlen(s: &c_char) -> size_t;
         address: &mut sockaddr,
         address_len: &mut socklen_t
     ) -> c_int;
-    
+
     extern "C" fn getsockname(
         socket: c_int,
         address: &mut sockaddr,
         address_len: &mut socklen_t
     ) -> c_int;
     extern "C" fn bind(
-        socket: c_int, 
-        address: &sockaddr, 
+        socket: c_int,
+        address: &sockaddr,
         address_len: socklen_t
     ) -> c_int;
     extern "C" fn shutdown(socket: c_int, how: c_int) -> c_int;
@@ -508,7 +508,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
     extern "C" fn opendir(dirname: &c_char) -> &mut DIR;
     #[cfg(not(target_os="macos"))]
     extern "C" fn opendir(dirname: &c_char) -> &mut DIR;
-    
+
     #[cfg(target_os="macos")]
     #[link_name("_readdir$INODE64")]
     extern "C" fn readdir(dirp: &mut DIR) -> &mut dirent;
@@ -516,7 +516,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
     #[cfg(not(target_os="macos"))]
     extern "C" fn readdir(dirp: &mut DIR) -> &mut dirent;
     extern "C" fn closedir(dirp: &mut DIR) -> c_int;
-    
+
     #[cfg(not(target_os="macos"))]
     extern "C" fn readdir64(dirp: &mut DIR) -> &mut dirent64;
 
@@ -527,7 +527,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
     extern "C" fn stat(path: &c_char, buf: &mut t_stat) -> c_int;
     #[cfg(not(target_os="macos"))]
     extern "C" fn stat(path: &c_char, buf: &mut t_stat) -> c_int;
-    
+
     #[cfg(not(target_os="macos"))]
     extern "C" fn stat64(path: &c_char, buf: &mut t_stat64) -> c_int;
 
@@ -635,7 +635,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
         }
     }
 
-    #[cfg(all(target_os="android", target_arch = "aarch64"))] 
+    #[cfg(all(target_os="android", target_arch = "aarch64"))]
     {
         struct t_stat {
             st_dev: dev_t,
@@ -683,8 +683,8 @@ extern "C" fn strlen(s: &c_char) -> size_t;
             __unused5: c_uint,
         }
     }
-    
-    #[cfg(target_os="macos")] 
+
+    #[cfg(target_os="macos")]
     struct t_stat {
         st_dev: dev_t,
         st_mode: mode_t,
@@ -717,7 +717,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
     const STDIN_FILENO: c_int = 0;
     const STDOUT_FILENO: c_int = 1;
     const STDERR_FILENO: c_int = 2;
-    
+
     const SIGHUP: c_int = 1;
     const SIGINT: c_int = 2;
     const SIGQUIT: c_int = 3;
@@ -737,7 +737,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
     const SEEK_SET: c_int = 0;
     const SEEK_CUR: c_int = 1;
     const SEEK_END: c_int = 2;
-    
+
     const O_RDONLY: c_int = 0;
     const O_WRONLY: c_int = 1;
     const O_RDWR: c_int = 2;
@@ -759,7 +759,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
         const O_TRUNC: c_int = 512;
     }
 
-    #[cfg(target_os="macos")] 
+    #[cfg(target_os="macos")]
     {
         const O_ACCMODE: c_int = 0x3;
         const O_APPEND: c_int = 8;
@@ -840,7 +840,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
     const EWOULDBLOCK: c_int = EAGAIN;
     #[cfg(target_os="macos")]
     const EWOULDBLOCK: c_int = 35;
-    
+
     #[cfg(any(target_os="linux", target_os="android"))]
     const ETIMEDOUT: c_int = 110;
     #[cfg(target_os="macos")]
@@ -889,20 +889,20 @@ extern "C" fn strlen(s: &c_char) -> size_t;
         const FIONBIO: c_ulong = 0x8004667e;
         const FIOCLEX: c_ulong = 0x20006601;
     }
-    
+
     #[cfg(target_os = "android")]
     {
         const FIONBIO: c_int = 0x5421;
         const FIOCLEX: c_int = 0x5451;
     }
-    
+
     #[cfg(target_os = "linux")]
     {
         const FIONBIO: c_ulong = 0x5421;
         const FIOCLEX: c_ulong = 0x5451;
     }
 
-    #[cfg(any(target_os = "linux", target_os = "android"))] 
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         const AF_UNSPEC: c_int = 0;
         const AF_UNIX: c_int = 1;
@@ -945,7 +945,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
         const AF_ALG: c_int = 38;
     }
 
-    #[cfg(not(any(target_os = "linux", target_os = "android")))] 
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     {
         const AF_UNSPEC: c_int = 0;
         const AF_LOCAL: c_int = 1;
@@ -1007,7 +1007,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
     const S_IFREG: mode_t = 32768;
     const S_IFLNK: mode_t = 40960;
     const S_IFSOCK: mode_t = 49152;
-    
+
     const S_IFMT: mode_t = 61440;
 }
 
@@ -1033,7 +1033,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
         struct pthread_mutex_t { value: c_int }
 
         struct pthread_cond_t { value: c_int }
-    
+
         struct pthread_rwlock_t {
             lock: pthread_mutex_t,
             cond: pthread_cond_t,
@@ -1056,7 +1056,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
             sched_policy: i32,
             sched_priority: i32,
         }
-        
+
         struct pthread_mutex_t {
             value: c_int,
             __reserved: [c_char; 36],
@@ -1075,7 +1075,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
             attr: i32,
             __reserved: [c_char; 36],
         }
-    }    
+    }
 }
 
 #[cfg(target_os = "linux")] {
@@ -1118,7 +1118,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
             type INNER_SIZEOF_PTHREAD_MUTEX_T = [u8; 40];
             type INNER_SIZEOF_PTHREAD_RWLOCK_T = [u8; 56];
         }
-        
+
         #[cfg(target_pointer_width = "32")] {
             type INNER_SIZEOF_PTHREAD_CONDATTR_T = [u8; 4];
             type INNER_SIZEOF_PTHREAD_MUTEXATTR_T = [u8; 4];
@@ -1139,13 +1139,13 @@ extern "C" fn strlen(s: &c_char) -> size_t;
     struct pthread_cond_t {
         size: INNER_SIZEOF_PTHREAD_COND_T,
     }
-    
+
     #[cfg(not(target_arch = "x86"))]
     #[align(8)]
     struct pthread_cond_t {
         size: INNER_SIZEOF_PTHREAD_COND_T,
     }
-    
+
     #[cfg(any(target_pointer_width = "64", not(any(target_arch = "arm", target_arch = "x86_64", target_arch = "x86")))]
     #[align(8)]
     struct pthread_mutex_t {
@@ -1208,7 +1208,7 @@ extern "C" fn strlen(s: &c_char) -> size_t;
         __sig: c_long,
         __opaque: [c_char; 36]
     }
-    
+
     #[cfg(target_pointer_width = "64")]
     struct pthread_attr_t {
         __sig: c_long,
@@ -1331,10 +1331,10 @@ fn pthread_rwlock_initializer() -> pthread_rwlock_t {
 
     #[cfg(any(target_arch = "arm", target_arch = "x86"))]
     const SYS_futex: c_long = 240;
-    
+
     #[cfg(target_arch = "aarch64")]
     const SYS_futex: c_long = 98;
-    
+
     #[cfg(target_arch = "x86_64")]
     const SYS_futex: c_long = 202;
 }

--- a/sysroot/libm.alu
+++ b/sysroot/libm.alu
@@ -103,7 +103,7 @@ mod tests {
 
         let v_f32: f32 = 2.7182;
         let v_f64: f64 = 2.7182;
-        
+
         acos(v_f64);
         acosf(v_f32);
         acosh(v_f64);
@@ -189,7 +189,7 @@ mod tests {
         powf(v_f32, u_f32);
         remainder(v_f64, u_f64);
         remainderf(v_f32, u_f32);
-        
+
         let w_f32: f32 = 4.7182;
         let w_f64: f64 = 4.7182;
         fma(v_f64, u_f64, w_f64);

--- a/sysroot/std.alu
+++ b/sysroot/std.alu
@@ -1,6 +1,6 @@
 //! Standard library for the Alumina language.
 //!
-//! It is a collection of functions, macros, protocols and types that are essential for writing portable code. Follows a 
+//! It is a collection of functions, macros, protocols and types that are essential for writing portable code. Follows a
 //! similar scope and structure as the Rust standard library.
 
 /// Causes the compilation to fail if reached.
@@ -45,7 +45,7 @@ macro debug_assert_ne($lhs, $rhs) { #[cfg(debug)] assert_ne!($lhs, $rhs); }
 /// ```
 /// let number: i32 = 42;
 /// switch number % 3 {
-///     0 => "odd", 
+///     0 => "odd",
 ///     1 => "even",
 ///     2 => "what even?",
 ///     _ => unreachable!()
@@ -58,12 +58,12 @@ macro unreachable() {
     std::intrinsics::unreachable();
 }
 
-/// Returns the line in the source code at which the macro was invoked. 
+/// Returns the line in the source code at which the macro was invoked.
 ///
 /// If used within a macro, this will return the line of the outermost macro invocation.
 #[builtin] macro line() {  }
 
-/// Returns the column in the source code at which the macro was invoked. 
+/// Returns the column in the source code at which the macro was invoked.
 ///
 /// If used within a macro, this will return the line of the outermost macro invocation.
 #[builtin] macro column() {  }
@@ -80,7 +80,7 @@ macro unreachable() {
 
 /// Concatenates strings at compile time.
 ///
-/// This macro can be useful also as a guard that string is a compile-time constant. 
+/// This macro can be useful also as a guard that string is a compile-time constant.
 #[builtin] macro concat($parts...) {  }
 
 
@@ -89,8 +89,8 @@ macro dbg($fmt, $args...) {
     let f = panicking::internal::PanicFormatter {};
     fmt::writeln!(&f,
         concat!("[{}:{}:{}] ", $fmt),
-        file!(), 
-        line!(), 
+        file!(),
+        line!(),
         column!(),
         $args...
     )
@@ -136,7 +136,7 @@ mod internal {
     }
 }
 
-/// Contains various utility functions that are useful in the generic context where the type operated on is 
+/// Contains various utility functions that are useful in the generic context where the type operated on is
 /// not easily expressible.
 mod util {
     #[force_inline] fn identity<T>(t: T) -> T { t }

--- a/sysroot/std/builtins.alu
+++ b/sysroot/std/builtins.alu
@@ -2,8 +2,8 @@
 //!
 //! This module holds impl blocks for builtin types all items with `#[lang(builtin_X)]` are
 //! treated as X when lowering into IR, so they cannot actually exist as proper structs.
-//! 
-//! Builtin protocols also cannot be directly implemented by user code, even though 
+//!
+//! Builtin protocols also cannot be directly implemented by user code, even though
 //! they contain no associated functions. They are handled specially
 //! by the compiler.
 
@@ -13,7 +13,7 @@ use fmt::{Formatter};
 
 /// Unit type (`()`)
 ///
-/// Unit type (also called void type) is the return type of expressions that do not return 
+/// Unit type (also called void type) is the return type of expressions that do not return
 /// a value.
 #[lang(builtin_void)]
 struct void {}
@@ -27,7 +27,7 @@ impl void {
     fn compare(lhs: &void, rhs: &void) -> Ordering {
         Ordering::Equal
     }
-    
+
     #[force_inline]
     fn hash<H: Hasher<H>>(self: &void, hasher: &mut H) {
     }
@@ -70,12 +70,12 @@ impl bool {
 
 /// Never type (`!`)
 ///
-/// Never type is the type of expressions that never return. For example, 
+/// Never type is the type of expressions that never return. For example,
 /// ```
 ///`let a = loop {};  /// `a` is of type `!`
 /// ```
 ///
-/// It has a couple of interesting properties, notably it is a bottom type, 
+/// It has a couple of interesting properties, notably it is a bottom type,
 /// which means that values of never type can be coerced into any other type.
 #[lang(builtin_never)]
 struct never {}
@@ -83,15 +83,15 @@ impl never {
     fn equals(lhs: &!, rhs: &!) -> bool {
         std::intrinsics::unreachable()
     }
-    
+
     fn compare(lhs: &!, rhs: &!) -> Ordering {
         std::intrinsics::unreachable()
     }
-    
+
     fn hash<H: Hasher<H>>(self: &!, hasher: &mut H) {
         std::intrinsics::unreachable()
     }
-    
+
     fn fmt<F: Formatter<F>>(self: &!, formatter: &mut F) -> Result<(), fmt::Error> {
         std::intrinsics::unreachable()
     }
@@ -104,7 +104,7 @@ impl never {
 /// equality and comparison operators.
 protocol BuiltinComparable<Self: builtins::Numeric> {
     #[force_inline] fn equals(lhs: &Self, rhs: &Self) -> bool { *lhs == *rhs }
-    #[force_inline] fn not_equals(lhs: &Self, rhs: &Self) -> bool { *lhs != *rhs }    
+    #[force_inline] fn not_equals(lhs: &Self, rhs: &Self) -> bool { *lhs != *rhs }
     #[force_inline]
     fn compare(lhs: &Self, rhs: &Self) -> Ordering {
         if *lhs < *rhs {
@@ -266,7 +266,7 @@ impl u128 {
 /// Native unsigned integer (machine word)
 ///
 /// On 64-bit systems, `usize` is the same as `u64`. On 32-bit systems, `usize` is the same
-/// as `u32`. 
+/// as `u32`.
 #[lang(builtin_usize)]
 struct usize {}
 impl usize {
@@ -285,7 +285,7 @@ impl usize {
         #[cfg(target_pointer_width = "64")]
         {
             u64::max_value() as usize
-        }        
+        }
     }
 
     #[force_inline]
@@ -297,7 +297,7 @@ impl usize {
         #[cfg(target_pointer_width = "64")]
         {
             u64::min_value() as usize
-        }   
+        }
     }
 }
 
@@ -840,7 +840,7 @@ impl array<Arr: builtins::Array> {
 
 // The following are "type-operators", pseudo-types, implemented inside the compiler
 // that resolve to other types based on the type of the generic parameters. Ideally,
-// these would be implemented in the standard library, but the infer system is not 
+// these would be implemented in the standard library, but the infer system is not
 // yet sufficiently powerful for this.
 
 /// Signed integer type of the same size as the original type.
@@ -957,14 +957,14 @@ mod tests {
     #[test]
     fn test_signed_of() {
         use rtti::type_id;
-        
+
         assert_eq!(type_id::<signed_of<u8>>(), type_id::<i8>());
         assert_eq!(type_id::<signed_of<u16>>(), type_id::<i16>());
         assert_eq!(type_id::<signed_of<u32>>(), type_id::<i32>());
         assert_eq!(type_id::<signed_of<u64>>(), type_id::<i64>());
         assert_eq!(type_id::<signed_of<usize>>(), type_id::<isize>());
         assert_eq!(type_id::<signed_of<u128>>(), type_id::<i128>());
-     
+
         assert_eq!(type_id::<signed_of<i8>>(), type_id::<i8>());
         assert_eq!(type_id::<signed_of<i16>>(), type_id::<i16>());
         assert_eq!(type_id::<signed_of<i32>>(), type_id::<i32>());
@@ -976,7 +976,7 @@ mod tests {
     #[test]
     fn test_unsigned_of() {
         use rtti::type_id;
-        
+
         assert_eq!(type_id::<unsigned_of<u8>>(), type_id::<u8>());
         assert_eq!(type_id::<unsigned_of<u16>>(), type_id::<u16>());
         assert_eq!(type_id::<unsigned_of<u32>>(), type_id::<u32>());
@@ -995,7 +995,7 @@ mod tests {
     #[test]
     fn test_deref_of() {
         use rtti::type_id;
-        
+
         assert_eq!(type_id::<deref_of<&u8>>(), type_id::<u8>());
         assert_eq!(type_id::<deref_of<&mut u8>>(), type_id::<u8>());
 

--- a/sysroot/std/builtins/tuples.alu
+++ b/sysroot/std/builtins/tuples.alu
@@ -1,7 +1,7 @@
 //! Method implementations for tuple types
 //!
 //! As Alumina does not have variadic generics, only tuples up to 8 elements
-//! have methods. 
+//! have methods.
 //!
 //! This is ugly af, but without variadic generics, this is probably the best way
 //! without implementing it all inside the compiler
@@ -35,7 +35,7 @@ struct tuple_2 {}
 impl tuple_2 {
     #[inline]
     fn equals<
-        T1: Equatable<T1>, 
+        T1: Equatable<T1>,
         T2: Equatable<T2>
     >(lhs: &(T1, T2), rhs: &(T1, T2)) -> bool {
         lhs.0.equals(&rhs.0) && lhs.1.equals(&rhs.1)
@@ -43,7 +43,7 @@ impl tuple_2 {
 
     #[inline]
     fn compare<
-        T1: Comparable<T1>, 
+        T1: Comparable<T1>,
         T2: Comparable<T2>
     >(lhs: &(T1, T2), rhs: &(T1, T2)) -> Ordering {
         lexicographic_cmp!(lhs.0, rhs.0);
@@ -53,8 +53,8 @@ impl tuple_2 {
 
     #[inline]
     fn hash<
-        T1: Hashable<T1, H>, 
-        T2: Hashable<T2, H>, 
+        T1: Hashable<T1, H>,
+        T2: Hashable<T2, H>,
         H: Hasher<H>
     >(lhs: &(T1, T2), h: &mut H) {
         lhs.0.hash(h);
@@ -71,7 +71,7 @@ impl tuple_3 {
     #[inline]
     fn equals<
         T1: Equatable<T1>,
-        T2: Equatable<T2>, 
+        T2: Equatable<T2>,
         T3: Equatable<T3>
     >(lhs: &(T1, T2, T3), rhs: &(T1, T2, T3)) -> bool {
         lhs.0.equals(&rhs.0) && lhs.1.equals(&rhs.1) && lhs.2.equals(&rhs.2)
@@ -79,8 +79,8 @@ impl tuple_3 {
 
     #[inline]
     fn compare<
-        T1: Comparable<T1>, 
-        T2: Comparable<T2>, 
+        T1: Comparable<T1>,
+        T2: Comparable<T2>,
         T3: Comparable<T3>
     >(lhs: &(T1, T2, T3), rhs: &(T1, T2, T3)) -> Ordering {
         lexicographic_cmp!(lhs.0, rhs.0);
@@ -91,9 +91,9 @@ impl tuple_3 {
 
     #[inline]
     fn hash<
-        T1: Hashable<T1, H>, 
-        T2: Hashable<T2, H>, 
-        T3: Hashable<T3, H>, 
+        T1: Hashable<T1, H>,
+        T2: Hashable<T2, H>,
+        T3: Hashable<T3, H>,
         H: Hasher<H>
     >(lhs: &(T1, T2, T3), h: &mut H) {
         lhs.0.hash(h);
@@ -102,8 +102,8 @@ impl tuple_3 {
     }
 
     mixin<
-        T1: Equatable<T1>, 
-        T2: Equatable<T2>, 
+        T1: Equatable<T1>,
+        T2: Equatable<T2>,
         T3: Equatable<T3>
     > Equatable<(T1, T2, T3)>;
 
@@ -124,17 +124,17 @@ impl tuple_4 {
         T3: Equatable<T3>,
         T4: Equatable<T4>
     >(lhs: &(T1, T2, T3, T4), rhs: &(T1, T2, T3, T4)) -> bool {
-        lhs.0.equals(&rhs.0) && 
-            lhs.1.equals(&rhs.1) && 
-            lhs.2.equals(&rhs.2) && 
+        lhs.0.equals(&rhs.0) &&
+            lhs.1.equals(&rhs.1) &&
+            lhs.2.equals(&rhs.2) &&
             lhs.3.equals(&rhs.3)
     }
 
     #[inline]
     fn compare<
-        T1: Comparable<T1>, 
-        T2: Comparable<T2>, 
-        T3: Comparable<T3>, 
+        T1: Comparable<T1>,
+        T2: Comparable<T2>,
+        T3: Comparable<T3>,
         T4: Comparable<T4>
     >(lhs: &(T1, T2, T3, T4), rhs: &(T1, T2, T3, T4)) -> Ordering {
         lexicographic_cmp!(lhs.0, rhs.0);
@@ -146,10 +146,10 @@ impl tuple_4 {
 
     #[inline]
     fn hash<
-        T1: Hashable<T1, H>, 
-        T2: Hashable<T2, H>, 
+        T1: Hashable<T1, H>,
+        T2: Hashable<T2, H>,
         T3: Hashable<T3, H>,
-        T4: Hashable<T4, H>, 
+        T4: Hashable<T4, H>,
         H: Hasher<H>
     >(lhs: &(T1, T2, T3, T4), h: &mut H) {
         lhs.0.hash(h);
@@ -159,9 +159,9 @@ impl tuple_4 {
     }
 
     mixin<
-        T1: Equatable<T1>, 
-        T2: Equatable<T2>, 
-        T3: Equatable<T3>, 
+        T1: Equatable<T1>,
+        T2: Equatable<T2>,
+        T3: Equatable<T3>,
         T4: Equatable<T4>
     > Equatable<(T1, T2, T3, T4)>;
 
@@ -178,25 +178,25 @@ struct tuple_5 {}
 impl tuple_5 {
     #[inline]
     fn equals<
-        T1: Equatable<T1>, 
-        T2: Equatable<T2>, 
-        T3: Equatable<T3>, 
-        T4: Equatable<T4>, 
+        T1: Equatable<T1>,
+        T2: Equatable<T2>,
+        T3: Equatable<T3>,
+        T4: Equatable<T4>,
         T5: Equatable<T5>
     >(lhs: &(T1, T2, T3, T4, T5), rhs: &(T1, T2, T3, T4, T5)) -> bool {
-        lhs.0.equals(&rhs.0) && 
-            lhs.1.equals(&rhs.1) && 
-            lhs.2.equals(&rhs.2) && 
-            lhs.3.equals(&rhs.3) && 
+        lhs.0.equals(&rhs.0) &&
+            lhs.1.equals(&rhs.1) &&
+            lhs.2.equals(&rhs.2) &&
+            lhs.3.equals(&rhs.3) &&
             lhs.4.equals(&rhs.4)
     }
 
     #[inline]
     fn compare<
-        T1: Comparable<T1>, 
-        T2: Comparable<T2>, 
-        T3: Comparable<T3>, 
-        T4: Comparable<T4>, 
+        T1: Comparable<T1>,
+        T2: Comparable<T2>,
+        T3: Comparable<T3>,
+        T4: Comparable<T4>,
         T5: Comparable<T5>
     >(lhs: &(T1, T2, T3, T4, T5), rhs: &(T1, T2, T3, T4, T5)) -> Ordering {
         lexicographic_cmp!(lhs.0, rhs.0);
@@ -209,11 +209,11 @@ impl tuple_5 {
 
     #[inline]
     fn hash<
-        T1: Hashable<T1, H>, 
-        T2: Hashable<T2, H>, 
-        T3: Hashable<T3, H>, 
-        T4: Hashable<T4, H>, 
-        T5: Hashable<T5, H>, 
+        T1: Hashable<T1, H>,
+        T2: Hashable<T2, H>,
+        T3: Hashable<T3, H>,
+        T4: Hashable<T4, H>,
+        T5: Hashable<T5, H>,
         H: Hasher<H>
     >(lhs: &(T1, T2, T3, T4, T5), h: &mut H) {
         lhs.0.hash(h);
@@ -224,9 +224,9 @@ impl tuple_5 {
     }
 
     mixin<
-        T1: Equatable<T1>, 
-        T2: Equatable<T2>, 
-        T3: Equatable<T3>, 
+        T1: Equatable<T1>,
+        T2: Equatable<T2>,
+        T3: Equatable<T3>,
         T4: Equatable<T4>,
         T5: Equatable<T5>
     > Equatable<(T1, T2, T3, T4, T5)>;
@@ -245,34 +245,34 @@ struct tuple_6 {}
 impl tuple_6 {
     #[inline]
     fn equals<
-        T1: Equatable<T1>, 
-        T2: Equatable<T2>, 
-        T3: Equatable<T3>, 
-        T4: Equatable<T4>, 
-        T5: Equatable<T5>, 
+        T1: Equatable<T1>,
+        T2: Equatable<T2>,
+        T3: Equatable<T3>,
+        T4: Equatable<T4>,
+        T5: Equatable<T5>,
         T6: Equatable<T6>
     >(
-        lhs: &(T1, T2, T3, T4, T5, T6), 
+        lhs: &(T1, T2, T3, T4, T5, T6),
         rhs: &(T1, T2, T3, T4, T5, T6)
     ) -> bool {
-        lhs.0.equals(&rhs.0) && 
-            lhs.1.equals(&rhs.1) && 
-            lhs.2.equals(&rhs.2) && 
-            lhs.3.equals(&rhs.3) && 
-            lhs.4.equals(&rhs.4) && 
+        lhs.0.equals(&rhs.0) &&
+            lhs.1.equals(&rhs.1) &&
+            lhs.2.equals(&rhs.2) &&
+            lhs.3.equals(&rhs.3) &&
+            lhs.4.equals(&rhs.4) &&
             lhs.5.equals(&rhs.5)
     }
 
     #[inline]
     fn compare<
-        T1: Comparable<T1>, 
-        T2: Comparable<T2>, 
-        T3: Comparable<T3>, 
-        T4: Comparable<T4>, 
-        T5: Comparable<T5>, 
+        T1: Comparable<T1>,
+        T2: Comparable<T2>,
+        T3: Comparable<T3>,
+        T4: Comparable<T4>,
+        T5: Comparable<T5>,
         T6: Comparable<T6>
     >(
-        lhs: &(T1, T2, T3, T4, T5, T6), 
+        lhs: &(T1, T2, T3, T4, T5, T6),
         rhs: &(T1, T2, T3, T4, T5, T6)
     ) -> Ordering {
         lexicographic_cmp!(lhs.0, rhs.0);
@@ -286,12 +286,12 @@ impl tuple_6 {
 
     #[inline]
     fn hash<
-        T1: Hashable<T1, H>, 
-        T2: Hashable<T2, H>, 
-        T3: Hashable<T3, H>, 
-        T4: Hashable<T4, H>, 
-        T5: Hashable<T5, H>, 
-        T6: Hashable<T6, H>, 
+        T1: Hashable<T1, H>,
+        T2: Hashable<T2, H>,
+        T3: Hashable<T3, H>,
+        T4: Hashable<T4, H>,
+        T5: Hashable<T5, H>,
+        T6: Hashable<T6, H>,
         H: Hasher<H>
     >(lhs: &(T1, T2, T3, T4, T5, T6), h: &mut H) {
         lhs.0.hash(h);
@@ -303,9 +303,9 @@ impl tuple_6 {
     }
 
     mixin<
-        T1: Equatable<T1>, 
-        T2: Equatable<T2>, 
-        T3: Equatable<T3>, 
+        T1: Equatable<T1>,
+        T2: Equatable<T2>,
+        T3: Equatable<T3>,
         T4: Equatable<T4>,
         T5: Equatable<T5>,
         T6: Equatable<T6>
@@ -326,37 +326,37 @@ struct tuple_7 {}
 impl tuple_7 {
     #[inline]
     fn equals<
-        T1: Equatable<T1>, 
-        T2: Equatable<T2>, 
-        T3: Equatable<T3>, 
-        T4: Equatable<T4>, 
-        T5: Equatable<T5>, 
-        T6: Equatable<T6>, 
+        T1: Equatable<T1>,
+        T2: Equatable<T2>,
+        T3: Equatable<T3>,
+        T4: Equatable<T4>,
+        T5: Equatable<T5>,
+        T6: Equatable<T6>,
         T7: Equatable<T7>
     >(
-        lhs: &(T1, T2, T3, T4, T5, T6, T7), 
+        lhs: &(T1, T2, T3, T4, T5, T6, T7),
         rhs: &(T1, T2, T3, T4, T5, T6, T7)
     ) -> bool {
-        lhs.0.equals(&rhs.0) && 
-            lhs.1.equals(&rhs.1) && 
-            lhs.2.equals(&rhs.2) && 
-            lhs.3.equals(&rhs.3) && 
-            lhs.4.equals(&rhs.4) && 
-            lhs.5.equals(&rhs.5) && 
+        lhs.0.equals(&rhs.0) &&
+            lhs.1.equals(&rhs.1) &&
+            lhs.2.equals(&rhs.2) &&
+            lhs.3.equals(&rhs.3) &&
+            lhs.4.equals(&rhs.4) &&
+            lhs.5.equals(&rhs.5) &&
             lhs.6.equals(&rhs.6)
     }
 
     #[inline]
     fn compare<
-        T1: Comparable<T1>, 
-        T2: Comparable<T2>, 
-        T3: Comparable<T3>, 
-        T4: Comparable<T4>, 
-        T5: Comparable<T5>, 
-        T6: Comparable<T6>, 
+        T1: Comparable<T1>,
+        T2: Comparable<T2>,
+        T3: Comparable<T3>,
+        T4: Comparable<T4>,
+        T5: Comparable<T5>,
+        T6: Comparable<T6>,
         T7: Comparable<T7>
     >(
-        lhs: &(T1, T2, T3, T4, T5, T6, T7), 
+        lhs: &(T1, T2, T3, T4, T5, T6, T7),
         rhs: &(T1, T2, T3, T4, T5, T6, T7)
     ) -> Ordering {
         lexicographic_cmp!(lhs.0, rhs.0);
@@ -371,13 +371,13 @@ impl tuple_7 {
 
     #[inline]
     fn hash<
-        T1: Hashable<T1, H>, 
-        T2: Hashable<T2, H>, 
-        T3: Hashable<T3, H>, 
-        T4: Hashable<T4, H>, 
-        T5: Hashable<T5, H>, 
-        T6: Hashable<T6, H>, 
-        T7: Hashable<T7, H>, 
+        T1: Hashable<T1, H>,
+        T2: Hashable<T2, H>,
+        T3: Hashable<T3, H>,
+        T4: Hashable<T4, H>,
+        T5: Hashable<T5, H>,
+        T6: Hashable<T6, H>,
+        T7: Hashable<T7, H>,
         H: Hasher<H>
     >(lhs: &(T1, T2, T3, T4, T5, T6, T7), h: &mut H) {
         lhs.0.hash(h);
@@ -390,9 +390,9 @@ impl tuple_7 {
     }
 
     mixin<
-        T1: Equatable<T1>, 
-        T2: Equatable<T2>, 
-        T3: Equatable<T3>, 
+        T1: Equatable<T1>,
+        T2: Equatable<T2>,
+        T3: Equatable<T3>,
         T4: Equatable<T4>,
         T5: Equatable<T5>,
         T6: Equatable<T6>,
@@ -415,40 +415,40 @@ struct tuple_8 {}
 impl tuple_8 {
     #[inline]
     fn equals<
-        T1: Equatable<T1>, 
-        T2: Equatable<T2>, 
-        T3: Equatable<T3>, 
-        T4: Equatable<T4>, 
-        T5: Equatable<T5>, 
-        T6: Equatable<T6>, 
-        T7: Equatable<T7>, 
+        T1: Equatable<T1>,
+        T2: Equatable<T2>,
+        T3: Equatable<T3>,
+        T4: Equatable<T4>,
+        T5: Equatable<T5>,
+        T6: Equatable<T6>,
+        T7: Equatable<T7>,
         T8: Equatable<T8>
     >(
-        lhs: &(T1, T2, T3, T4, T5, T6, T7, T8), 
+        lhs: &(T1, T2, T3, T4, T5, T6, T7, T8),
         rhs: &(T1, T2, T3, T4, T5, T6, T7, T8)
     ) -> bool {
-        lhs.0.equals(&rhs.0) && 
-            lhs.1.equals(&rhs.1) && 
-            lhs.2.equals(&rhs.2) && 
-            lhs.3.equals(&rhs.3) && 
-            lhs.4.equals(&rhs.4) && 
-            lhs.5.equals(&rhs.5) && 
-            lhs.6.equals(&rhs.6) && 
+        lhs.0.equals(&rhs.0) &&
+            lhs.1.equals(&rhs.1) &&
+            lhs.2.equals(&rhs.2) &&
+            lhs.3.equals(&rhs.3) &&
+            lhs.4.equals(&rhs.4) &&
+            lhs.5.equals(&rhs.5) &&
+            lhs.6.equals(&rhs.6) &&
             lhs.7.equals(&rhs.7)
     }
 
     #[inline]
     fn compare<
-        T1: Comparable<T1>, 
-        T2: Comparable<T2>, 
-        T3: Comparable<T3>, 
-        T4: Comparable<T4>, 
-        T5: Comparable<T5>, 
-        T6: Comparable<T6>, 
-        T7: Comparable<T7>, 
+        T1: Comparable<T1>,
+        T2: Comparable<T2>,
+        T3: Comparable<T3>,
+        T4: Comparable<T4>,
+        T5: Comparable<T5>,
+        T6: Comparable<T6>,
+        T7: Comparable<T7>,
         T8: Comparable<T8>
     >(
-        lhs: &(T1, T2, T3, T4, T5, T6, T7, T8), 
+        lhs: &(T1, T2, T3, T4, T5, T6, T7, T8),
         rhs: &(T1, T2, T3, T4, T5, T6, T7, T8)
     ) -> Ordering {
         lexicographic_cmp!(lhs.0, rhs.0);
@@ -464,14 +464,14 @@ impl tuple_8 {
 
     #[inline]
     fn hash<
-        T1: Hashable<T1, H>, 
-        T2: Hashable<T2, H>, 
-        T3: Hashable<T3, H>, 
-        T4: Hashable<T4, H>, 
-        T5: Hashable<T5, H>, 
-        T6: Hashable<T6, H>, 
-        T7: Hashable<T7, H>, 
-        T8: Hashable<T8, H>, 
+        T1: Hashable<T1, H>,
+        T2: Hashable<T2, H>,
+        T3: Hashable<T3, H>,
+        T4: Hashable<T4, H>,
+        T5: Hashable<T5, H>,
+        T6: Hashable<T6, H>,
+        T7: Hashable<T7, H>,
+        T8: Hashable<T8, H>,
         H: Hasher<H>
     >(lhs: &(T1, T2, T3, T4, T5, T6, T7, T8), h: &mut H) {
         lhs.0.hash(h);
@@ -485,9 +485,9 @@ impl tuple_8 {
     }
 
     mixin<
-        T1: Equatable<T1>, 
-        T2: Equatable<T2>, 
-        T3: Equatable<T3>, 
+        T1: Equatable<T1>,
+        T2: Equatable<T2>,
+        T3: Equatable<T3>,
         T4: Equatable<T4>,
         T5: Equatable<T5>,
         T6: Equatable<T6>,

--- a/sysroot/std/cmp.alu
+++ b/sysroot/std/cmp.alu
@@ -1,4 +1,4 @@
-//! Equality and comparison 
+//! Equality and comparison
 
 /// Types that can be compared for equality.
 ///
@@ -31,7 +31,7 @@ protocol Comparable<Self: Equatable<Self>> {
     ///
     /// See [Comparable] for details.
     fn compare(lhs: &Self, rhs: &Self) -> Ordering;
-    
+
     /// Returns `true` if `lhs` is strictly less than `rhs`, `false` otherwise
     #[force_inline]
     fn less_than(lhs: &Self, rhs: &Self) -> bool {
@@ -72,7 +72,7 @@ protocol Comparable<Self: Equatable<Self>> {
 ///     c: u8,
 ///     d: u8,
 /// }
-/// 
+///
 /// impl IPv4 {
 ///     fn compare(lhs: &IPv4, rhs: &IPv4) -> Ordering {
 ///         lexicographic_cmp!(lhs.a, rhs.a);
@@ -112,7 +112,7 @@ fn min<T: Comparable<T>>(a: T, b: T) -> T {
     }
 }
 
-/// This module contains the target functions for operator overloading 
+/// This module contains the target functions for operator overloading
 mod internal {
     #[force_inline]
     #[lang(operator_eq)]
@@ -149,5 +149,5 @@ mod internal {
     fn operator_gte<T: Comparable<T>>(lhs: &T, rhs: &T) -> bool {
         lhs.greater_than_or_equal(rhs)
     }
-} 
+}
 

--- a/sysroot/std/collections.alu
+++ b/sysroot/std/collections.alu
@@ -32,7 +32,7 @@ fn sort_by<T, F: Callable<(&T), K>, K: Comparable<K>>(arr: &mut [T], key: F) {
     if arr.len <= 1 {
         return;
     }
-    
+
     let p = partition_by(arr, key);
     sort_by(arr[..p], key);
     sort_by(arr[p+1..], key);

--- a/sysroot/std/collections/hashmap.alu
+++ b/sysroot/std/collections/hashmap.alu
@@ -14,11 +14,11 @@ const INITIAL_SIZE: usize = 32;
 ///
 /// let map = HashMap::new::<i32, i32>();
 /// defer map.free();
-/// 
+///
 /// map.insert(1, 2);
 /// map.insert(2, 4);
 /// map.insert(3, 5);
-/// 
+///
 /// assert!(map.get(1) == Option::some(2));
 /// assert!(map.get(2) == Option::some(4));
 /// assert!(map.get(3) == Option::some(5));
@@ -37,7 +37,7 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
         with_capacity(0)
     }
 
-    /// Creates an empty hash map that can store up to `capacity` items without 
+    /// Creates an empty hash map that can store up to `capacity` items without
     /// reallocating.
     fn with_capacity(capacity: usize) -> HashMap<K, V, H> {
         with_size(capacity * 4 / 3 + 1)
@@ -55,13 +55,13 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
     }
 
     /// Reserves space for at least `additional` more elements to be inserted without
-    /// reallocating. 
+    /// reallocating.
     ///
     /// This follows the amortized growth strategy.
-    fn reserve(self: &mut HashMap<K, V, H>, additional: usize) -> bool {            
+    fn reserve(self: &mut HashMap<K, V, H>, additional: usize) -> bool {
         // We keep the load factor below 0.75.
         let new_length = self._length + additional;
-        if new_length * 4 > self._buckets.len * 3 { 
+        if new_length * 4 > self._buckets.len * 3 {
             self.rehash(cmp::max(self._buckets.len * 2, new_length * 2));
             return true;
         }
@@ -69,9 +69,9 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
     }
 
     /// Resizes the underlying array to exactly the given `new_capacity`.
-    /// 
-    /// Note that this could lead to poor performance if the resulting load factor 
-    /// is close to 1. 
+    ///
+    /// Note that this could lead to poor performance if the resulting load factor
+    /// is close to 1.
     fn rehash(self: &mut HashMap<K, V, H>, new_capacity: usize) {
         debug_assert!(self._length <= new_capacity);
 
@@ -175,7 +175,7 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
     }
 
     fn _insert(self: &mut HashMap<K, V, H>, item: (K, V), grow: bool) -> Option<V> {
-        let initial_index = (hash_of::<K, H>(item.0) as usize) % self._buckets.len; 
+        let initial_index = (hash_of::<K, H>(item.0) as usize) % self._buckets.len;
         let index = initial_index;
 
         loop {
@@ -213,7 +213,7 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
             return Option::none();
         }
 
-        let initial_index = (hash_of::<K, H>(key) as usize) % self._buckets.len; 
+        let initial_index = (hash_of::<K, H>(key) as usize) % self._buckets.len;
         let index = initial_index;
 
         loop {
@@ -259,9 +259,9 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
 }
 
 impl HashMap<
-    K: Hashable<K, H> + Equatable<K>, 
+    K: Hashable<K, H> + Equatable<K>,
     V,
-    I: Iterator<I, (K, V)>, 
+    I: Iterator<I, (K, V)>,
     H: Hasher<H> = DefaultHash
 > {
     /// Creates a hash map from an iterator of key-value pairs
@@ -287,7 +287,7 @@ impl HashMap<
     /// of key-value pairs.
     fn extend(self: &mut HashMap<K, V, H>, iter: &mut I) {
         self.reserve(iter.size_hint().unwrap_or(0));
-        
+
         if self._buckets.len == 0 {
             self.rehash(INITIAL_SIZE);
         }
@@ -326,7 +326,7 @@ impl HashMapRefIterator<K, V> {
         }
         Option::none()
     }
-    
+
     /// @ iter::DoubleEndedIterator::next_back
     fn next_back(self: &mut HashMapRefIterator<K, V>) -> Option<(&K, &V)> {
         use option::try;
@@ -338,7 +338,7 @@ impl HashMapRefIterator<K, V> {
         }
         Option::none()
     }
-    
+
     mixin iter::Iterator<HashMapRefIterator<K, V>, (&K, &V)>;
     mixin iter::IteratorExt<HashMapRefIterator<K, V>, (&K, &V)>;
     mixin iter::DoubleEndedIterator<HashMapRefIterator<K, V>, (&K, &V)>;
@@ -361,7 +361,7 @@ impl HashMapMutIterator<K, V> {
         }
         Option::none()
     }
-    
+
     /// @ iter::DoubleEndedIterator::next_back
     fn next_back(self: &mut HashMapMutIterator<K, V>) -> Option<(&K, &mut V)> {
         use option::try;
@@ -373,7 +373,7 @@ impl HashMapMutIterator<K, V> {
         }
         Option::none()
     }
-    
+
     mixin iter::Iterator<HashMapMutIterator<K, V>, (&K, &mut V)>;
     mixin iter::IteratorExt<HashMapMutIterator<K, V>, (&K, &mut V)>;
     mixin iter::DoubleEndedIterator<HashMapMutIterator<K, V>, (&K, &mut V)>;
@@ -396,7 +396,7 @@ impl HashMapIterator<K, V> {
         }
         Option::none()
     }
-    
+
     /// @ iter::DoubleEndedIterator::next_back
     fn next_back(self: &mut HashMapIterator<K, V>) -> Option<(K, V)> {
         use option::try;
@@ -418,7 +418,7 @@ impl HashMapIterator<K, V> {
 #[cfg(all(test, test_std))]
 mod tests {
     struct DummyHasher {
-        state: u64    
+        state: u64
     }
 
     impl DummyHasher {
@@ -444,7 +444,7 @@ mod tests {
     fn test_hashmap_new() {
         let map = HashMap::new::<i32, i32>();
         defer map.free();
-        
+
         assert!(map.len() == 0);
     }
 
@@ -558,7 +558,7 @@ mod tests {
         assert!(iter.next() == Option::some((3, 5)));
         assert!(iter.next() == Option::some((2, 4)));
         assert!(iter.next() == Option::some((1, 2)));
-        assert!(iter.next() == Option::none());        
+        assert!(iter.next() == Option::none());
     }
 
     #[test]
@@ -586,7 +586,7 @@ mod tests {
         let iter = map.iter_ref().rev();
         let v = iter.next().unwrap();
         assert_eq!(*v.0, 3);
-        assert_eq!(*v.1, 5);        
+        assert_eq!(*v.1, 5);
         let v = iter.next().unwrap();
         assert_eq!(*v.0, 2);
         assert_eq!(*v.1, 4);
@@ -628,14 +628,14 @@ mod tests {
         defer map.free();
 
         map.reserve(100);
-        
+
         let ptr = map._buckets.ptr;
         for i in 0..100 {
             map.insert(i, i);
         }
 
         // Did not reallocate
-        assert_eq!(map._buckets.ptr, ptr);        
+        assert_eq!(map._buckets.ptr, ptr);
     }
 
     #[test]

--- a/sysroot/std/collections/hashset.alu
+++ b/sysroot/std/collections/hashset.alu
@@ -111,7 +111,7 @@ impl HashSet<K: Hashable<K, H> + Equatable<K>, I: Iterator<I, K>, H: Hasher<H> =
 
     fn extend(self: &mut HashSet<K, H>, iter: &mut I) {
         self.reserve(iter.size_hint().unwrap_or(0));
-        
+
         loop {
             let item = iter.next();
             if item.is_some {
@@ -139,7 +139,7 @@ impl HashSetIterator<K> {
     mixin iter::Iterator<HashSetIterator<K>, K>;
     mixin iter::IteratorExt<HashSetIterator<K>, K>;
     mixin iter::DoubleEndedIterator<HashSetIterator<K>, K>;
-    mixin iter::DoubleEndedIteratorExt<HashSetIterator<K>, K>;    
+    mixin iter::DoubleEndedIteratorExt<HashSetIterator<K>, K>;
 }
 
 struct HashSetRefIterator<K> {
@@ -158,7 +158,7 @@ impl HashSetRefIterator<K> {
     mixin iter::Iterator<HashSetRefIterator<K>, &K>;
     mixin iter::IteratorExt<HashSetRefIterator<K>, &K>;
     mixin iter::DoubleEndedIterator<HashSetRefIterator<K>, &K>;
-    mixin iter::DoubleEndedIteratorExt<HashSetRefIterator<K>, &K>;        
+    mixin iter::DoubleEndedIteratorExt<HashSetRefIterator<K>, &K>;
 }
 
 #[cfg(all(test, test_std))]
@@ -168,7 +168,7 @@ mod tests {
     #[test]
     fn test_hashset_new() {
         let set = HashSet::new::<i32>();
-        defer set.free(); 
+        defer set.free();
 
         assert!(set.empty());
         assert_eq!(set.len(), 0);
@@ -177,7 +177,7 @@ mod tests {
     #[test]
     fn test_hashset_with_capacity() {
         let set = HashSet::with_capacity::<i32>(10);
-        defer set.free(); 
+        defer set.free();
 
         assert!(set.empty());
         assert_eq!(set.len(), 0);
@@ -186,7 +186,7 @@ mod tests {
     #[test]
     fn test_hashset_insert() {
         let set = HashSet::new::<i32>();
-        defer set.free(); 
+        defer set.free();
 
         assert!(set.insert(1));
         assert!(!set.insert(1));
@@ -196,7 +196,7 @@ mod tests {
     #[test]
     fn test_hashset_remove() {
         let set = HashSet::new::<i32>();
-        defer set.free(); 
+        defer set.free();
 
         assert!(set.insert(1));
         assert!(set.remove(1));
@@ -207,7 +207,7 @@ mod tests {
     #[test]
     fn test_hashset_contains() {
         let set = HashSet::new::<i32>();
-        defer set.free(); 
+        defer set.free();
 
         assert!(!set.contains(1));
         assert!(set.insert(1));
@@ -217,7 +217,7 @@ mod tests {
     #[test]
     fn test_hashset_len() {
         let set = HashSet::new::<i32>();
-        defer set.free(); 
+        defer set.free();
 
         assert_eq!(set.len(), 0);
         assert!(set.insert(1));
@@ -228,7 +228,7 @@ mod tests {
     #[test]
     fn test_hashset_empty() {
         let set = HashSet::new::<i32>();
-        defer set.free(); 
+        defer set.free();
 
         assert!(set.empty());
         assert!(set.insert(1));
@@ -240,7 +240,7 @@ mod tests {
     #[test]
     fn test_hashset_clear() {
         let set = HashSet::new::<i32>();
-        defer set.free(); 
+        defer set.free();
 
         assert!(set.insert(1));
         assert!(set.insert(2));
@@ -253,7 +253,7 @@ mod tests {
     #[test]
     fn test_hashset_iter() {
         let set = HashSet::with_capacity::<i32, DummyHasher>(10);
-        defer set.free(); 
+        defer set.free();
 
         assert!(set.insert(1));
         assert!(set.insert(2));
@@ -274,7 +274,7 @@ mod tests {
     #[test]
     fn test_hashset_iter_ref() {
         let set = HashSet::with_capacity::<i32, DummyHasher>(10);
-        defer set.free(); 
+        defer set.free();
 
         assert!(set.insert(1));
         assert!(set.insert(2));
@@ -295,14 +295,14 @@ mod tests {
     #[test]
     fn test_hashset_move() {
         let set = HashSet::new::<i32>();
-        defer set.free(); 
+        defer set.free();
 
         assert!(set.insert(1));
         assert!(set.insert(2));
         assert!(set.insert(3));
 
         let set2 = set.move();
-        defer set2.free(); 
+        defer set2.free();
 
         assert_eq!(set2.len(), 3);
         assert!(set2.contains(1));
@@ -314,7 +314,7 @@ mod tests {
     #[test]
     fn test_hashset_from_iter() {
         let set: HashSet<i32> = HashSet::from_iter(&[1, 2, 3].iter());
-        defer set.free(); 
+        defer set.free();
 
         assert_eq!(set.len(), 3);
         assert!(set.contains(1));
@@ -325,7 +325,7 @@ mod tests {
     #[test]
     fn test_hashset_extend() {
         let set = HashSet::new::<i32>();
-        defer set.free(); 
+        defer set.free();
 
         set.extend(&[1, 2, 3].iter());
         assert_eq!(set.len(), 3);

--- a/sysroot/std/collections/vector.alu
+++ b/sysroot/std/collections/vector.alu
@@ -4,7 +4,7 @@
 /// ```
 /// let vec = Vector::new::<i32>();
 /// defer vec.free();
-/// 
+///
 /// vec.push(1);
 /// assert_eq!(vec.len(), 1);
 /// assert_eq!(vec.as_slice(), &[1]);
@@ -33,7 +33,7 @@ impl Vector<T> {
 
     /// Create a vector from a raw slice and a length.
     ///
-    /// The slice must be allocated with [mem::alloc] and its length must be greater 
+    /// The slice must be allocated with [mem::alloc] and its length must be greater
     /// than or equal to `length`.
     fn from_raw(data: &mut [T], length: usize) {
         Vector {
@@ -89,7 +89,7 @@ impl Vector<T> {
     /// Extend the vector with the elements from an iterator.
     fn extend<I: Iterator<I, T>>(self: &mut Vector<T>, iter: &mut I) {
         self.reserve(iter.size_hint().unwrap_or(0));
-        
+
         loop {
             let item = iter.next();
             if item.is_some {
@@ -426,10 +426,10 @@ mod tests {
     fn test_vector_move() {
         let vec = Vector::from_slice(&[1, 2, 3]);
         defer vec.free();
-        
+
         let vec2 = vec.move();
         defer vec2.free();
-        
+
         assert_eq!(vec.len(), 0);
         assert_eq!(vec2.len(), 3);
         assert_eq!(vec2.as_slice(), &[1, 2, 3]);

--- a/sysroot/std/ffi.alu
+++ b/sysroot/std/ffi.alu
@@ -21,7 +21,7 @@ macro c_str($s) {
 impl CString {
     fn new(s: &[u8]) -> CString {
         use std::mem::{slice, alloc, copy_nonoverlapping};
-        
+
         let ptr = libc::malloc(s.len + 1) as &mut libc::c_char;
         s.copy_nonoverlapping(ptr as &mut u8);
         *(ptr + s.len) = 0;

--- a/sysroot/std/fmt.alu
+++ b/sysroot/std/fmt.alu
@@ -26,7 +26,7 @@ impl Error {
 
 /// A sink for string formatting operations
 ///
-/// 
+///
 protocol Formatter<Self> {
     /// Write a string
     fn write_str(self: &mut Self, buf: &[u8]) -> Result;
@@ -44,17 +44,17 @@ protocol Formatter<Self> {
 /// struct Point3D { x: i32, y: i32, z: i32 }
 /// impl Point3D {
 ///     use std::fmt::{Formatter, Result, write};
-///     
+///
 ///     fn fmt<F: Formatter<F>>(self: &Point3D, f: &mut F) -> Result {
 ///         write!(f, "({}, {}, {})", self.x, self.y, self.z)
 ///     }
 /// }
-/// 
+///
 /// // prints "You are at (1, 2, 3)"
 /// println!("You are at {}", Point3D { x: 1, y: 2, z: 3 });
 /// ```
 protocol Formattable<Self, F: Formatter<F> = internal::NullFormatter> {
-    /// Write the object into a given formatter. 
+    /// Write the object into a given formatter.
     ///
     /// See [Formattable] for details.
     fn fmt(self: &Self, f: &mut F) -> Result;
@@ -62,21 +62,21 @@ protocol Formattable<Self, F: Formatter<F> = internal::NullFormatter> {
 
 
 /// Write a formatted string into a given formatter.
-/// 
+///
 /// # Example
 /// ```
 /// use std::fmt::{write, SliceFormatter};
 /// let buf: [u8; 64];
 /// let fmt = SliceFormatter::new(buf.as_slice_mut());
-///     
+///
 /// write!(&fmt, "{} + {} = {}", 1, 2, 3);
-/// 
+///
 /// assert_eq!(fmt.as_slice()[0..9], "1 + 2 = 3");
-/// ``` 
+/// ```
 macro write($fmt, $fmt_str, $arg...) {
     internal::printf(
-        concat!($fmt_str), 
-        &[internal::FormatArg::new(&$arg)...], 
+        concat!($fmt_str),
+        &[internal::FormatArg::new(&$arg)...],
         $fmt
     )
 }
@@ -84,8 +84,8 @@ macro write($fmt, $fmt_str, $arg...) {
 /// Write a formatted string and a newline into a given formatter.
 macro writeln($fmt, $fmt_str, $arg...) {
     internal::printf(
-        concat!($fmt_str, "\n"), 
-        &[internal::FormatArg::new(&$arg)...], 
+        concat!($fmt_str, "\n"),
+        &[internal::FormatArg::new(&$arg)...],
         $fmt
     )
 }
@@ -101,7 +101,7 @@ macro writeln($fmt, $fmt_str, $arg...) {
 ///
 /// assert_eq!(s.as_slice(), "1 + 2 = 3");
 /// ```
-macro format($fmt_str, $arg...) { 
+macro format($fmt_str, $arg...) {
     let vec = collections::Vector::with_capacity::<u8>($fmt_str.len);
     let ret = fmt::write!(&vec, $fmt_str, $arg...);
     if ret.is_ok {
@@ -125,7 +125,7 @@ macro format($fmt_str, $arg...) {
 ///
 /// assert_eq!(f, "1 + 2 = 3");
 /// ```
-macro format_in($buf, $fmt_str, $arg...) { 
+macro format_in($buf, $fmt_str, $arg...) {
     let fmt = SliceFormatter::new($buf);
     let ret = fmt::write!(&fmt, $fmt_str, $arg...);
     if ret.is_ok {
@@ -215,10 +215,10 @@ mod internal {
 
     fn format_integer<T: builtins::Integer, F: Formatter<F>>(val: T, radix: u16, pad: usize, fmt: &mut F) -> Result {
         assert!(radix >= 2 && radix <= 36);
-        
+
         let buf: [u8; 128];
         let buf = buf.as_slice_mut();
-        
+
         when T: builtins::Signed {
             if val < 0 {
                 fmt.write_char('-')?;
@@ -231,7 +231,7 @@ mod internal {
         loop {
             buf[buf.len - i - 1] = string::RADIX_DIGITS[(val_u % (radix as builtins::unsigned_of<T>)) as usize];
             val_u /= radix as builtins::unsigned_of<T>;
-            
+
             if val_u == 0 {
                 while i + 1 < pad {
                     fmt.write_char('0')?;
@@ -249,7 +249,7 @@ mod internal {
     fn format_float<T: builtins::FloatingPoint, F: Formatter<F>>(val: T, fmt: &mut F, precision: u16) -> Result {
         // TODO: this is very very VERY bad, replace with Grisu3 or Dragon4 or alike. Correct float parsing
         // and formatting is a complicated thing. Using libc instead is an option, but that has a
-        // host of other problems: locale-awareness (ideally, Alumina's stdlib is locale-invariant), 
+        // host of other problems: locale-awareness (ideally, Alumina's stdlib is locale-invariant),
         // use of C-strings, varargs, etc. etc.
 
         debug_assert!(precision <= 18);
@@ -267,7 +267,7 @@ mod internal {
         }
 
         let (integral, frac) = val.modf();
-        
+
         let steps = 0usize;
         while integral >= 1.0e18 {
             integral /= 1.0e18;
@@ -308,7 +308,7 @@ mod internal {
         BRACE_OPEN,
         BRACE_CLOSE,
     }
-    
+
     fn printf<F: Formatter<F>>(fmt_str: &[u8], args: &[FormatArg<F>], fmt: &mut F) -> Result {
         let i = 0usize;
 
@@ -450,7 +450,7 @@ mod internal {
 /// # Example
 /// ```
 /// use std::fmt::hex;
-/// 
+///
 /// println!("{}", 42.hex()); // prints '2a'
 /// ```
 fn hex<T: builtins::Integer>(val: T) -> internal::NumFormatAdapter<T> {
@@ -462,7 +462,7 @@ fn hex<T: builtins::Integer>(val: T) -> internal::NumFormatAdapter<T> {
 /// # Example
 /// ```
 /// use std::fmt::bin;
-/// 
+///
 /// println!("{}", 42.bin()); // prints '101010'
 /// ```
 fn bin<T: builtins::Integer>(val: T) -> internal::NumFormatAdapter<T> {
@@ -474,7 +474,7 @@ fn bin<T: builtins::Integer>(val: T) -> internal::NumFormatAdapter<T> {
 /// # Example
 /// ```
 /// use std::fmt::oct;
-/// 
+///
 /// println!("{}", 42.oct()); // prints '52'
 /// ```
 fn oct<T: builtins::Integer>(val: T) -> internal::NumFormatAdapter<T> {
@@ -486,7 +486,7 @@ fn oct<T: builtins::Integer>(val: T) -> internal::NumFormatAdapter<T> {
 /// # Example
 /// ```
 /// use std::fmt::zero_pad;
-/// 
+///
 /// println!("{}", 42.zero_pad(5)); // prints '00042'
 /// ```
 fn zero_pad<T: builtins::Integer>(val: T, pad: usize) -> internal::NumFormatAdapter<T> {
@@ -502,7 +502,7 @@ fn precision<T: builtins::FloatingPoint>(val: T, prec: u16) -> internal::FloatFo
 /// # Example
 /// ```
 /// use std::fmt::repeat;
-/// 
+///
 /// println!("{}", "ha".repeat(3)); // prints 'hahaha'
 /// ```
 fn repeat<T: Formattable<T>>(inner: T, times: usize) -> internal::RepeatAdapter<T> {
@@ -514,7 +514,7 @@ fn repeat<T: Formattable<T>>(inner: T, times: usize) -> internal::RepeatAdapter<
 /// # Example
 /// ```
 /// use std::fmt::pad_with;
-/// 
+///
 /// println!("{}", "ha".pad_with(5, ' ')); // prints '   ha'
 /// ```
 fn pad_with<T: Formattable<T>>(val: T, len: usize, pad: u8) -> internal::GenericPadAdapter<T> {
@@ -529,14 +529,14 @@ mod tests {
     macro fmt($args...) {
         format_in!(&BUF, $args...).unwrap()
     }
-    
+
     #[test]
     fn test_format_integer() {
         assert_eq!(fmt!("{}", u8::max_value()), "255");
         assert_eq!(fmt!("{}", -23847), "-23847");
         assert_eq!(fmt!("{}", i64::min_value()), "-9223372036854775808");
         assert_eq!(
-            fmt!("{}", i128::min_value()), 
+            fmt!("{}", i128::min_value()),
             "-170141183460469231731687303715884105728"
         );
     }
@@ -569,7 +569,7 @@ mod tests {
     fn test_format_float() {
         // These tests do not assert that float formatting logic is correct. It is in fact
         // very incorrect.
-        
+
         assert_eq!(fmt!("{}", f64::nan()), "NaN");
         assert_eq!(fmt!("{}", f64::infinity()), "Inf");
         assert_eq!(fmt!("{}", f64::neg_infinity()), "-Inf");
@@ -583,7 +583,7 @@ mod tests {
         assert_eq!(fmt!("{}", 0.0001.precision(5)), "0.00010");
         assert_eq!(fmt!("{}", 0.00001.precision(5)), "0.00001");
         assert_eq!(fmt!("{}", 0.000001.precision(5)), "0.00000");
-        
+
         assert_eq!(fmt!("{}", 1.0.precision(1)), "1.0");
         assert_eq!(fmt!("{}", 11.0.precision(1)), "11.0");
         assert_eq!(fmt!("{}", 111.0.precision(1)), "111.0");
@@ -600,7 +600,7 @@ mod tests {
         assert_eq!(fmt!("{}", 11111111111111.0.precision(1)), "11111111111111.0");
         assert_eq!(fmt!("{}", 111111111111111.0.precision(1)), "111111111111111.0");
         assert_eq!(fmt!("{}", 1111111111111111.0.precision(1)), "1111111111111111.0");
-        
+
         assert_eq!(fmt!("{}", 10.0.precision(1)), "10.0");
         assert_eq!(fmt!("{}", 100.0.precision(1)), "100.0");
         assert_eq!(fmt!("{}", 1000.0.precision(1)), "1000.0");
@@ -635,7 +635,7 @@ mod tests {
         assert_eq!(fmt!("{}", 999999999999.0.precision(1)), "999999999999.0");
         assert_eq!(fmt!("{}", 9999999999999.0.precision(1)), "9999999999999.0");
         assert_eq!(fmt!("{}", 99999999999999.0.precision(1)), "99999999999999.0");
-        assert_eq!(fmt!("{}", 999999999999999.0.precision(1)), "999999999999999.0"); 
+        assert_eq!(fmt!("{}", 999999999999999.0.precision(1)), "999999999999999.0");
 
     }
 }

--- a/sysroot/std/fs.alu
+++ b/sysroot/std/fs.alu
@@ -5,7 +5,7 @@
     use unix::{
         OpenOptions, File, DirIterator, DirEntry, FileType,
         DirBuilder,  read_directory, create_directory,
-        FileAttr, remove_file, remove_directory 
+        FileAttr, remove_file, remove_directory
     }
 }
 
@@ -36,7 +36,7 @@ impl PathSegmentKind {
 
 struct PathSegment {
     kind: PathSegmentKind,
-    value: &[u8] 
+    value: &[u8]
 }
 
 impl PathSegment {
@@ -362,15 +362,15 @@ mod tests {
         let path = Path::new("home").iter();
         assert_eq!(path.next(), Option::some(PathSegment { kind: PathSegmentKind::Normal, value: "home" }));
         assert_eq!(path.next(), Option::none());
-        
+
         let path = Path::new("home///").iter();
         assert_eq!(path.next(), Option::some(PathSegment { kind: PathSegmentKind::Normal, value: "home" }));
-        assert_eq!(path.next(), Option::none());        
+        assert_eq!(path.next(), Option::none());
 
         let path = Path::new("home///alumina").iter();
         assert_eq!(path.next(), Option::some(PathSegment { kind: PathSegmentKind::Normal, value: "home" }));
         assert_eq!(path.next(), Option::some(PathSegment { kind: PathSegmentKind::Normal, value: "alumina" }));
-        assert_eq!(path.next(), Option::none());    
+        assert_eq!(path.next(), Option::none());
     }
 
     use fmt::format_in;
@@ -384,7 +384,7 @@ mod tests {
             let path = Path::new($path);
             let ret = format_in!(buf, "{}", path).unwrap();
             assert_eq!(ret, $expected);
-        }    
+        }
 
         chk!("", "");
         chk!("/", "/");
@@ -395,7 +395,7 @@ mod tests {
         chk!("foo/bar/", "foo/bar");
         chk!("foo/////bar/", "foo/bar");
         chk!("./../////bar/", "./../bar");
-    } 
+    }
 
     #[test]
     fn test_is_absolute() {
@@ -405,14 +405,14 @@ mod tests {
         assert!(Path::new("").is_relative());
         assert!(Path::new("./foo").is_relative());
         assert!(Path::new("foo").is_relative());
-    } 
+    }
 
     #[test]
     fn test_strip_prefix() {
         assert_eq!(Path::new("").strip_prefix(Path::new("")), Option::some(Path::new("")));
         assert_eq!(Path::new("/foo/bar").strip_prefix(Path::new("/")), Option::some(Path::new("foo/bar")));
         assert_eq!(Path::new("/foo/bar").strip_prefix(Path::new("/foo/")), Option::some(Path::new("bar")));
-        
+
         assert_eq!(Path::new("/foo/bar").strip_prefix(Path::new("/quux")), Option::none());
         assert_eq!(Path::new("foo/bar").strip_prefix(Path::new("/")), Option::none());
     }
@@ -426,7 +426,7 @@ mod tests {
         let path_buf = PathBuf::from_iter(&Path::new("/hello/world/").iter().chain(&Path::new("foo/bar/").iter()));
         defer path_buf.free();
         assert_eq!(path_buf.as_path(), Path::new("/hello/world/foo/bar"));
-        
+
         let path_buf = PathBuf::from_iter(&Path::new("/hello/world/").iter().chain(&Path::new("/foo/bar/").iter()));
         defer path_buf.free();
         assert_eq!(path_buf.as_path(), Path::new("/foo/bar"));

--- a/sysroot/std/fs/unix.alu
+++ b/sysroot/std/fs/unix.alu
@@ -116,7 +116,7 @@ impl OpenOptions {
 /// # Example
 /// ```
 /// use std::fs::{DirBuilder, Path};
-/// 
+///
 /// DirBuilder::new()
 ///     .recursive(true)
 ///     .create(Path::new("/home/alumina/a/b/c/d/e/f"))
@@ -150,7 +150,7 @@ impl DirBuilder {
     fn _mkdir(self: &DirBuilder, path: Path) -> Result<(), Error> {
         let path = ffi::CString::new(path.inner);
         defer path.free();
-        
+
         errno_try!(libc::mkdir(path.ptr, self._mode));
         Result::ok(())
     }
@@ -249,7 +249,7 @@ impl File {
 
         #[cfg(target_os = "macos")]
         errno_try!(libc::fstat(self.fd.value, &result.inner));
-                
+
         #[cfg(not(target_os = "macos"))]
         errno_try!(libc::fstat64(self.fd.value, &result.inner));
 
@@ -272,11 +272,11 @@ impl File {
 
         let file = File::open(path)?;
         defer file.close();
-        
+
         let attrs = file.attributes()?;
-        
+
         let string: StringBuf = StringBuf::with_capacity(attrs.size() as usize);
-        defer string.free();                
+        defer string.free();
 
         let ret = file.read_to_end(&string)?;
 
@@ -334,7 +334,7 @@ impl DirIterator {
             let ent = libc::readdir(self.inner);
             #[cfg(not(target_os = "macos"))]
             let ent = libc::readdir64(self.inner);
-            
+
             if ent == null {
                 let err = Error::from_errno();
                 if err.inner.errno == 0 {
@@ -403,7 +403,7 @@ impl DirEntry {
 ///
 /// let dir = read_directory("/home/alumina")?
 /// defer dir.close()?;
-/// 
+///
 /// for item in dir {
 ///     let item = item?;
 ///     println!("{}: {}", item.name(), item.file_type());
@@ -446,7 +446,7 @@ impl FileType {
             FileType::Regular => write!(fmt, "regular"),
             FileType::Link => write!(fmt, "link"),
             FileType::Socket => write!(fmt, "socket"),
-            _ => write!(fmt, "unknown"),            
+            _ => write!(fmt, "unknown"),
         }
     }
 
@@ -474,7 +474,7 @@ impl FileAttr {
 
         #[cfg(target_os = "macos")]
         errno_try!(libc::stat(path.ptr, &result.inner));
-                
+
         #[cfg(not(target_os = "macos"))]
         errno_try!(libc::stat64(path.ptr, &result.inner));
 
@@ -496,7 +496,7 @@ mod tests {
     use fmt::{hex, pad, zero_pad, format, format_in};
     use collections::{free_all, sort_by};
     use string::StringBuf;
-    
+
     static BUF: [u8; 1024];
     static BUF1: [u8; 1024];
 
@@ -516,7 +516,7 @@ mod tests {
             random::OsRng::new().next_u64().hex().zero_pad(16)
         ).unwrap()));
 
-        tmpdir        
+        tmpdir
     }
 
     #[test]
@@ -535,7 +535,7 @@ mod tests {
 
         let read = file.read(buf).unwrap();
         assert_eq!(buf[..read] as &[u8], "Hello, world!");
-        
+
         file.seek(SeekFrom::Beginning, 7).unwrap();
 
         let read = file.read(buf).unwrap();
@@ -561,7 +561,7 @@ mod tests {
     fn test_read_directory() {
         let path = mktemp();
         defer path.free();
-        
+
         create_directory(path.as_path()).unwrap();
 
         (0..5).iter().foreach(|&path, i: i32| {
@@ -598,7 +598,7 @@ mod tests {
     fn test_create_remove_directory() {
         let path = mktemp();
         defer path.free();
-        
+
         create_directory(path.as_path()).unwrap();
         remove_directory(path.as_path()).unwrap();
 
@@ -614,7 +614,7 @@ mod tests {
     fn test_remove_file() {
         let path = mktemp();
         defer path.free();
-        
+
         File::create(path.as_path()).unwrap().close();
         remove_file(path.as_path()).unwrap();
     }

--- a/sysroot/std/hash/xxhash.alu
+++ b/sysroot/std/hash/xxhash.alu
@@ -54,7 +54,7 @@ impl Xxh64 {
             mem_size: 0,
         }
     }
-    
+
     #[no_inline]
     fn write(self: &mut Xxh64, input: &[u8]) {
         use std::mem::copy_nonoverlapping;
@@ -101,14 +101,14 @@ impl Xxh64 {
             input.copy_nonoverlapping(&self.mem[0] as &mut u8);
             self.mem_size = input.len;
         }
-    }    
+    }
 
     fn finish(self: &mut Xxh64) -> u64 {
         let result: u64;
 
         if self.total_len >= CHUNK_SIZE {
-            result = (self.v1.rotate_left(1)) + 
-                (self.v2.rotate_left(7)) + 
+            result = (self.v1.rotate_left(1)) +
+                (self.v2.rotate_left(7)) +
                 (self.v3.rotate_left(12)) +
                 (self.v4.rotate_left(18));
 
@@ -129,18 +129,18 @@ impl Xxh64 {
             remainder = remainder[8..];
             result = (result.rotate_left(27)) * PRIME_1 + PRIME_4
         }
-    
+
         if remainder.len >= 4 {
             result ^= (*(remainder.ptr as &u32) as u64) * PRIME_1;
             remainder = remainder[4..];
             result = (result.rotate_left(23)) * PRIME_2 + PRIME_3;
         }
-    
+
         for byte in remainder {
             result ^= (byte as u64) * PRIME_5;
             result = (result.rotate_left(11)) * PRIME_1;
         }
-    
+
         avalanche(result)
     }
 }

--- a/sysroot/std/io.alu
+++ b/sysroot/std/io.alu
@@ -108,7 +108,7 @@ protocol Readable<Self> {
                 buf._length = buf.len() + read;
             }
 
-            // Optimization for the case where the initial vector had exactly 
+            // Optimization for the case where the initial vector had exactly
             // enough capacity - avoid doubling the vector if the next read will
             // return EOF by using a small stack buffer instead.
             if buf.capacity() == buf.len() && buf.capacity() == start_cap {
@@ -133,7 +133,7 @@ protocol Writable<Self> {
     fn write(self: &mut Self, buf: &[u8]) -> Result<usize, Error>;
 
     /// Writes all the bytes in the buffer to the stream.
-    /// 
+    ///
     /// If EOF is reached, returns `Error::eof()`.
     fn write_all(self: &mut Self, buf: &[u8]) -> Result<(), Error> {
 
@@ -149,7 +149,7 @@ protocol Writable<Self> {
     }
 
     /// Flush the stream
-    /// 
+    ///
     /// This may be a no-op, depending on the stream.
     fn flush(self: &mut Self) -> Result<(), Error>;
 }
@@ -167,11 +167,11 @@ protocol Seekable<Self> {
     ///
     /// Returns the new position in the stream from the beginning.
     fn seek(self: &mut Self, whence: SeekFrom, offset: i64) -> Result<u64, Error>;
-    
+
     /// Rewind the stream to the beginning.
     fn rewind(self: &mut Self) -> Result<(), Error> {
         self.seek(SeekFrom::Beginning, 0)?;
-        
+
         Result::ok(())
     }
 
@@ -200,7 +200,7 @@ impl SliceReader {
     /// @ Readable::read
     fn read(self: &mut SliceReader, buf: &mut [u8]) -> Result<usize, Error> {
         let len = cmp::min(buf.len, self.slice.len - self.pos);
-        
+
         if len > 0 {
             self.slice[self.pos..self.pos + len].copy_nonoverlapping(&buf[0]);
             self.pos += len;
@@ -227,7 +227,7 @@ impl SliceReader {
             SeekFrom::End => self.slice.len as i64 + offset,
             _ => unreachable!()
         };
-        
+
         if new_offset < 0 || (new_offset as usize) > self.slice.len {
             Result::err(Error::eof())
         } else {
@@ -423,7 +423,7 @@ impl BufferedWriter<W: Writable<W>> {
         if buf.len > self.buf.len - self.pos {
             self._flush_buffer()?;
         }
-     
+
         if buf.len >= self.buf.len  {
             // Bypass the buffer if we need to write more than buffer size
             self.inner.write(buf)
@@ -473,7 +473,7 @@ impl BufferedWriter<W: Writable<W>> {
 
     fn _flush_buffer(self: &mut BufferedWriter<W>) -> result::Result<(), Error> {
         // This will return an EOF error, if we are not able to write everything.
-        // since we have accepted bytes that are not written to the underlying 
+        // since we have accepted bytes that are not written to the underlying
         // writer and not signalled an EOF.
         self.inner.write_all(self.buf[..self.pos])?;
         self.pos = 0;
@@ -533,7 +533,7 @@ const DEFAULT_BUFFER_SIZE: usize = 8192;
 fn copy<S: Readable<S>, D: Writable<D>>(src: &mut S, dst: &mut D) -> result::Result<u64, Error> {
     let buf = mem::alloc::<u8>(DEFAULT_BUFFER_SIZE);
     defer mem::free(buf);
-    
+
     copy_using(src, dst, buf)
 }
 
@@ -550,9 +550,9 @@ fn copy_using<S: Readable<S>, D: Writable<D>>(src: &mut S, dst: &mut D, buffer: 
     }
 
     Result::ok(read)
-}    
+}
 
-/// Reads a single byte from the stream. 
+/// Reads a single byte from the stream.
 ///
 /// Returns `Error::eof` if the stream has no bytes left.
 fn read_byte<R: Readable<R>>(reader: &mut R) -> result::Result<u8, Error> {
@@ -618,7 +618,7 @@ impl LineIterator<R: BufferedReadable<R>> {
     fn with_capacity(reader: &mut R, capacity: usize) -> LineIterator<R> {
         with_line_buffer(reader, collections::Vector::with_capacity(capacity))
     }
-    
+
     /// @ std::iter::Iterator::next
     fn next(self: &mut LineIterator<R>) -> Option<Result<&[u8], Error>> {
         self.line_buf.clear();
@@ -690,7 +690,7 @@ mod tests {
 
     #[test]
     fn test_slice_reader() {
-        let text = SliceReader::new("Lorem ipsum dolor sit amet");        
+        let text = SliceReader::new("Lorem ipsum dolor sit amet");
         assert_eq!(read_n!(text, 12), "Lorem ipsum ");
         assert_eq!(read_n!(text, 14), "dolor sit amet");
         assert_eq!(read_n!(text, 100), "");
@@ -712,15 +712,15 @@ mod tests {
 
     #[test]
     fn test_slice_reader_seek() {
-        let text = SliceReader::new("Lorem ipsum dolor sit amet");        
+        let text = SliceReader::new("Lorem ipsum dolor sit amet");
         assert_eq!(read_n!(text, 12), "Lorem ipsum ");
 
         assert_eq!(text.seek(SeekFrom::Beginning, 1).unwrap(), 1);
         assert_eq!(read_n!(text, 12), "orem ipsum d");
-        
+
         assert_eq!(text.seek(SeekFrom::Current, -5).unwrap(), 8);
         assert_eq!(read_n!(text, 12), "sum dolor si");
-        
+
         assert_eq!(text.seek(SeekFrom::End, -12).unwrap(), 14);
         assert_eq!(read_n!(text, 12), "lor sit amet");
     }
@@ -729,7 +729,7 @@ mod tests {
     #[test]
     fn test_lines() {
         let text = SliceReader::new("Lorem\nipsum\ndolor\nsit\namet");
-        let iter = lines(&text); 
+        let iter = lines(&text);
         defer iter.free();
 
         assert_eq!(iter.next(), Option::some(Result::ok("Lorem")));
@@ -740,7 +740,7 @@ mod tests {
         assert_eq!(iter.next(), Option::none());
     }
 
-    
+
     #[test]
     fn test_read_byte() {
         let text = SliceReader::new("foo");
@@ -748,12 +748,12 @@ mod tests {
         assert_eq!(text.read_byte(), Result::ok('f'));
         assert_eq!(text.read_byte(), Result::ok('o'));
         assert_eq!(text.read_byte(), Result::ok('o'));
-        assert_eq!(text.read_byte(), Result::err(Error::eof()));        
+        assert_eq!(text.read_byte(), Result::err(Error::eof()));
     }
 
     #[test]
     fn test_copy() {
-        let src = SliceReader::new("Lorem ipsum dolor sit amet"); 
+        let src = SliceReader::new("Lorem ipsum dolor sit amet");
         let dst: StringBuf = StringBuf::new();
 
         copy(&src, &StringWriter::new(&dst)).unwrap();

--- a/sysroot/std/io.alu
+++ b/sysroot/std/io.alu
@@ -11,15 +11,11 @@ use fmt::{write, writeln};
 
 /// Buffer for formatted standard I/O.
 ///
-/// We use a single small static buffer for convenience stdio formatting macros.
+/// We use a single small thread local buffer for convenience stdio formatting macros.
 /// This buffer has limited purpose (if you need a larger buffer, use [io::StdioStream] directly).
 /// As many formatters write individual characters, doing a syscall for every one would be
 /// a performance killer.
-///
-/// Once we have multi-threading, stdio formatting will have to be synchronized or `FMT_BUF`
-/// made thread-local. Having a static buffer is also a concern if the macros recurse, as
-/// the buffer will be overwritten.
-static FMT_BUF: [u8; 128];
+#[thread_local] static FMT_BUF: [u8; 128];
 
 /// Prints a formatted string to standard output.
 ///

--- a/sysroot/std/io.alu
+++ b/sysroot/std/io.alu
@@ -15,7 +15,7 @@ use fmt::{write, writeln};
 /// This buffer has limited purpose (if you need a larger buffer, use [io::StdioStream] directly).
 /// As many formatters write individual characters, doing a syscall for every one would be
 /// a performance killer.
-#[thread_local] static FMT_BUF: [u8; 128];
+#[thread_local] static FMT_BUF: [u8; 256];
 
 /// Prints a formatted string to standard output.
 ///

--- a/sysroot/std/io/unix.alu
+++ b/sysroot/std/io/unix.alu
@@ -169,7 +169,7 @@ impl FileDescriptor {
     fn set_nonblocking(self: &mut FileDescriptor, nonblocking: bool) -> Result<(), Error> {
         #[cfg(target_os = "linux")] {
             let nonblocking =  if nonblocking { 1 as libc::c_int } else { 0 as libc::c_int };
-            errno_try!(libc::ioctl(self.value, libc::FIONBIO, &nonblocking));    
+            errno_try!(libc::ioctl(self.value, libc::FIONBIO, &nonblocking));
         }
 
         #[cfg(not(target_os = "linux"))] {
@@ -193,11 +193,11 @@ impl FileDescriptor {
         #[cfg(not(target_os = "linux"))] {
             errno_try!(libc::ioctl(self.value, libc::FIOCLEX));
         }
-        
+
         #[cfg(target_os = "linux")] {
             let previous = errno_try!(libc::fcntl(self.value, libc::F_GETFD));
             let new = previous | libc::FD_CLOEXEC;
-    
+
             if new != previous {
                 errno_try!(libc::fcntl(self.value, libc::F_SETFD, new));
             }
@@ -253,7 +253,7 @@ impl StdioStream {
     /// @ std::mem::Movable::move
     fn move(self: &mut StdioStream) -> StdioStream {
         StdioStream { fd: self.fd.move() }
-    }    
+    }
 
     mixin FdReadWrite<StdioStream>;
     mixin Readable<StdioStream>;
@@ -269,10 +269,10 @@ impl Pipe {
     /// Create an anonymous pipe pair.
     fn anonymous() -> result::Result<(Pipe, Pipe), Error> {
         let fds: [libc::c_int; 2];
-    
+
         #[cfg(target_os = "linux")]
         errno_try!(libc::pipe2(&fds[0], libc::O_CLOEXEC));
-        
+
         #[cfg(not(target_os = "linux"))]
         errno_try!(libc::pipe(&fds[0]));
 

--- a/sysroot/std/io/unix.alu
+++ b/sysroot/std/io/unix.alu
@@ -28,6 +28,14 @@ impl Error {
         }
     }
 
+    /// Create `Error` from the last OS error (`errno`)
+    fn from_errno_custom(errno: libc::c_int) -> Error {
+        Error {
+            kind: ErrorKind::Os,
+            inner: ErrorInner { errno: errno },
+        }
+    }
+
     /// Create `Error` from the code returned by [libc::getaddrinfo].
     fn from_gai(gai_err: libc::c_int) -> Error {
         Error {

--- a/sysroot/std/iter.alu
+++ b/sysroot/std/iter.alu
@@ -7,16 +7,16 @@
 //! for i in 0..10 {
 //!     println!("{}", i);
 //! }
-//! 
+//!
 //! for i in &["a", "b", "c"] {
 //!     println!("{}", i);
 //! }
 //! ```
 //!
-//! There is distinction between an [iterable type](Iterable) and an [iterator](Iterator). Iterators are 
-//! consumable objects that can only be used to iterate once. Iterable types are ones that can 
+//! There is distinction between an [iterable type](Iterable) and an [iterator](Iterator). Iterators are
+//! consumable objects that can only be used to iterate once. Iterable types are ones that can
 //! produce an iterator when needed.
-//! 
+//!
 //! Iterators can also be combined to create more complex types of iterators. See [IteratorExt] protocol
 //! for a reference of methods that can be used to combine iterators.
 
@@ -34,13 +34,13 @@ protocol Iterator<Self, T> {
     ///
     /// If the iterator has reached the end, it returns none.
     fn next(self: &mut Self) -> Option<T>;
-    
+
     /// Returns the number of remaining elements, if available.
     ///
-    /// This is used for efficiently pre-allocating storage in collections 
+    /// This is used for efficiently pre-allocating storage in collections
     /// that are created from iterators to avoid copies.
     ///
-    /// It the number of remaining elements is unknown, the method should 
+    /// It the number of remaining elements is unknown, the method should
     /// return `Option::none()`.
     fn size_hint(self: &Self) -> Option<usize> {
         Option::none()
@@ -59,7 +59,7 @@ protocol DoubleEndedIterator<Self: Iterator<Self, T>, T> {
 protocol DoubleEndedIteratorExt<Self: DoubleEndedIterator<Self, T>, T> {
     /// "Reverse" the iterator.
     ///
-    /// `rev` returns a wrapper over an iterator that has `next` and `next_back` methods 
+    /// `rev` returns a wrapper over an iterator that has `next` and `next_back` methods
     /// reversed.
     fn rev(self: &mut Self) -> RevIterator<Self, T> {
         RevIterator { it: self }
@@ -79,7 +79,7 @@ protocol IterableMut<Self, It: Iterator<It, &mut T>, T> {
 }
 
 /// Reverse iterator.
-/// 
+///
 /// See [DoubleEndedIteratorExt::rev].
 struct RevIterator<It: DoubleEndedIterator<It, T>, T> {
     it: &mut It
@@ -285,7 +285,7 @@ impl SkipIterator<It: Iterator<It, T>, T> {
 
     /// @ Iterator::size_hint
     fn size_hint(self: &SkipIterator<It, T>) -> Option<usize> {
-        self.it.size_hint().map(|=self, v: usize| -> usize { 
+        self.it.size_hint().map(|=self, v: usize| -> usize {
             if self.n > v {
                 0
             } else {
@@ -324,7 +324,7 @@ impl StepByIterator<It: Iterator<It, T>, T> {
 
     /// @ Iterator::size_hint
     fn size_hint(self: &StepByIterator<It, T>) -> Option<usize> {
-        self.it.size_hint().map(|=self, v: usize| -> usize { 
+        self.it.size_hint().map(|=self, v: usize| -> usize {
             (v + self.index) / self.n
         })
     }
@@ -352,7 +352,7 @@ impl FusedIterator<It: Iterator<It, T>, T> {
             v
         }
     }
-    
+
     /// @ Iterator::size_hint
     fn size_hint(self: &FusedIterator<It, T>) -> Option<usize> {
         if self.done {
@@ -424,7 +424,7 @@ impl EnumerateIterator<It: Iterator<It, T>, T> {
     /// @ Iterator::next
     fn next(self: &mut EnumerateIterator<It, T>) -> Option<(usize, T)> {
         use option::try;
-        
+
         let val = self.it.next()?;
         let res = (self.n, val);
         self.n += 1;
@@ -601,7 +601,7 @@ impl PeekableIterator<It: Iterator<It, T>, T> {
             self.it.next()
         }
     }
-    
+
     /// Return the next element in the iterator without consuming it.
     fn peek(self: &mut PeekableIterator<It, T>) -> Option<T> {
         if !self.peeked.is_some {
@@ -609,7 +609,7 @@ impl PeekableIterator<It: Iterator<It, T>, T> {
         }
         self.peeked
     }
-    
+
     /// @ Iterator::size_hint
     fn size_hint(self: &PeekableIterator<It, T>) -> Option<usize> {
         self.it.size_hint().map(|=self, x: usize| -> usize {
@@ -620,7 +620,7 @@ impl PeekableIterator<It: Iterator<It, T>, T> {
             }
         })
     }
-    
+
     mixin Iterator<PeekableIterator<It, T>, T>;
     mixin IteratorExt<PeekableIterator<It, T>, T>;
 }
@@ -629,7 +629,7 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// Return self.
     ///
     /// Each iterator is itself an iterable object, though only once. This
-    /// helper function is there so that iterators can be used ergonomically 
+    /// helper function is there so that iterators can be used ergonomically
     /// in for loops (which de-sugar to a call to `.iter()`)
     fn iter(self: &mut Self) -> &mut Self {
         self
@@ -648,16 +648,16 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     }
 
     /// Returns an iterator that yields all elements of `self` and then all elements of `other`.
-    /// # Example    
+    /// # Example
     /// ```
     /// let range = (0..2).iter().chain(&(10..12).iter());
     /// assert_eq!(range.size_hint(), Option::some(4usize));
-    /// 
+    ///
     /// assert_eq!(range.next(), Option::some(0));
     /// assert_eq!(range.next(), Option::some(1));
     /// assert_eq!(range.next(), Option::some(10));
     /// assert_eq!(range.next(), Option::some(11));
-    /// assert_eq!(range.next(), Option::none());    
+    /// assert_eq!(range.next(), Option::none());
     /// ```
     fn chain<Other: Iterator<Other, T>>(self: &mut Self, other: &mut Other) -> ChainIterator<Self, Other, T> {
         ChainIterator {
@@ -675,11 +675,11 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// ```
     /// let range = (0..5).iter().skip(2);
     /// assert_eq!(range.size_hint(), Option::some(3usize));
-    /// 
+    ///
     /// assert_eq!(range.next(), Option::some(2));
     /// assert_eq!(range.next(), Option::some(3));
     /// assert_eq!(range.next(), Option::some(4));
-    /// assert_eq!(range.next(), Option::none());    
+    /// assert_eq!(range.next(), Option::none());
     /// ```
     fn skip(self: &mut Self, n: usize) -> SkipIterator<Self, T> {
         SkipIterator {
@@ -695,11 +695,11 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// ```
     /// let range = (0..5).iter().step_by(2);
     /// assert_eq!(range.size_hint(), Option::some(3usize));
-    /// 
+    ///
     /// assert_eq!(range.next(), Option::some(0));
     /// assert_eq!(range.next(), Option::some(2));
     /// assert_eq!(range.next(), Option::some(4));
-    /// assert_eq!(range.next(), Option::none());    
+    /// assert_eq!(range.next(), Option::none());
     /// ```
     fn step_by(self: &mut Self, n: usize) -> StepByIterator<Self, T> {
         assert!(n > 0);
@@ -717,10 +717,10 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// ```
     /// let range = (0..5).iter().take(2);
     /// assert_eq!(range.size_hint(), Option::some(2usize));
-    /// 
+    ///
     /// assert_eq!(range.next(), Option::some(0));
     /// assert_eq!(range.next(), Option::some(1));
-    /// assert_eq!(range.next(), Option::none());    
+    /// assert_eq!(range.next(), Option::none());
     /// ```
     fn take(self: &mut Self, n: usize) -> TakeIterator<Self, T> {
         TakeIterator {
@@ -735,12 +735,12 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// ```
     /// let range = (10..15).iter().enumerate();
     /// assert_eq!(range.size_hint(), Option::some(5usize));
-    /// 
+    ///
     /// assert_eq!(range.next(), Option::some((0usize, 10)));
     /// assert_eq!(range.next(), Option::some((1usize, 11)));
     /// assert_eq!(range.next(), Option::some((2usize, 12)));
     /// assert_eq!(range.next(), Option::some((3usize, 13)));
-    /// assert_eq!(range.next(), Option::some((4usize, 14)));    
+    /// assert_eq!(range.next(), Option::some((4usize, 14)));
     /// assert_eq!(range.next(), Option::none());
     /// ```
     fn enumerate(self: &mut Self) -> EnumerateIterator<Self, T> {
@@ -754,7 +754,7 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     fn last(self: &mut Self) -> Option<T> {
         when Self: DoubleEndedIterator<Self, T> {
             self.next_back()
-        } else {       
+        } else {
             let value: Option<T> = Option::none();
             loop {
                 let next = self.next();
@@ -793,7 +793,7 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
             func: func,
         }
     }
-    
+
     /// Returns an iterator that yields the elements while a predicate is true.
     ///
     /// # Example
@@ -804,12 +804,12 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// assert_eq!(range.next(), Option::some(0));
     /// assert_eq!(range.next(), Option::some(1));
     /// assert_eq!(range.next(), Option::some(2));
-    /// assert_eq!(range.next(), Option::none());    
+    /// assert_eq!(range.next(), Option::none());
     /// ```
     fn take_while<F: Callable<(T), bool>>(iter: &mut Self, fun: F) -> TakeWhileIterator<Self, F, T> {
         TakeWhileIterator { it: iter, fun: fun }
     }
-    
+
     /// Returns an iterator that skips the elements while a predicate is true.
     /// # Example
     /// ```
@@ -823,13 +823,13 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     fn skip_while<F: Callable<(T), bool>>(iter: &mut Self, fun: F) -> SkipWhileIterator<Self, F, T> {
         SkipWhileIterator { it: iter, fun: fun, finished: false }
     }
-    
+
     /// Returns an iterator that transforms the elements of this iterator.
     /// # Example
     /// ```
     /// let range = (0..5).iter().map(|x: i32| -> i32 { x * 2 });
     /// assert_eq!(range.size_hint(), Option::some(5usize));
-    /// 
+    ///
     /// assert_eq!(range.next(), Option::some(0));
     /// assert_eq!(range.next(), Option::some(2));
     /// assert_eq!(range.next(), Option::some(4));
@@ -840,7 +840,7 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     fn map<U, F: Callable<(T), U>>(iter: &mut Self, fun: F) -> MapIterator<Self, F, T, U> {
         MapIterator { it: iter, fun: fun }
     }
-    
+
     /// Executes a function on each element of this iterator.
     fn foreach<F: Callable<(T), ()>>(iter: &mut Self, fun: F) {
         loop {
@@ -858,20 +858,20 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// ```
     /// let range = (0..5).iter().filter(|x: i32| -> bool { x % 2 == 0 });
     /// assert_eq!(range.size_hint(), Option::none());
-    /// 
+    ///
     /// assert_eq!(range.next(), Option::some(0));
     /// assert_eq!(range.next(), Option::some(2));
     /// assert_eq!(range.next(), Option::some(4));
-    /// assert_eq!(range.next(), Option::none());    
+    /// assert_eq!(range.next(), Option::none());
     /// ```
     fn filter<F: Callable<(T), bool>>(iter: &mut Self, fun: F) -> FilterIterator<Self, F, T> {
         FilterIterator { it: iter, fun: fun }
     }
-    
+
     fn filter_map<U, F: Callable<(T), Option<U>>>(iter: &mut Self, fun: F) -> FilterMapIterator<Self, F, T, U> {
         FilterMapIterator { it: iter, fun: fun }
     }
-    
+
     fn reduce<U, F: Callable<(U, T), U>>(iter: &mut Self, initial: U, func: F) -> U {
         loop {
             let next = iter.next();
@@ -882,7 +882,7 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
         }
         initial
     }
-    
+
     fn all<F: Callable<(T), bool>>(iter: &mut Self, fun: F) -> bool {
         loop {
             let next = iter.next();
@@ -895,7 +895,7 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
         }
         true
     }
-    
+
     fn any<F: Callable<(T), bool>>(iter: &mut Self, fun: F) -> bool {
         loop {
             let next = iter.next();
@@ -937,11 +937,11 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
         }
     }
 
-    
+
     fn group_by<F: Callable<(T), K>, K: cmp::Equatable<K>>(self: &mut Self, func: F) -> GroupByIterator<Self, F, T, K> {
         GroupByIterator {
             it: self.peekable(),
-            last_group: Option::none(),    
+            last_group: Option::none(),
             func: func
         }
     }
@@ -977,7 +977,7 @@ impl FromFnIterator<F: Callable<(), Option<T>>, T> {
     }
 
     mixin Iterator<FromFnIterator<F, T>, T>;
-    mixin IteratorExt<FromFnIterator<F, T>, T>;   
+    mixin IteratorExt<FromFnIterator<F, T>, T>;
 }
 
 /// Returns an iterator that produces no elements.
@@ -1218,7 +1218,7 @@ impl RangeIter<T: Integer> {
             Option::some(0usize)
         }
     }
-    
+
     mixin Iterator<RangeIter<T>, T>;
     mixin IteratorExt<RangeIter<T>, T>;
     mixin DoubleEndedIterator<RangeIter<T>, T>;
@@ -1415,7 +1415,7 @@ mod tests {
         assert_eq!(range.next(), Option::some((1usize, 11)));
         assert_eq!(range.next(), Option::some((2usize, 12)));
         assert_eq!(range.next(), Option::some((3usize, 13)));
-        assert_eq!(range.next(), Option::some((4usize, 14)));    
+        assert_eq!(range.next(), Option::some((4usize, 14)));
         assert_eq!(range.next(), Option::none());
     }
 
@@ -1519,7 +1519,7 @@ mod tests {
         let range = (0..3).iter().peekable();
         assert_eq!(range.size_hint(), Option::some(3usize));
         assert_eq!(range.peek(), Option::some(0));
-        
+
         assert_eq!(range.size_hint(), Option::some(3usize));
         assert_eq!(range.next(), Option::some(0));
         assert_eq!(range.next(), Option::some(1));

--- a/sysroot/std/math.alu
+++ b/sysroot/std/math.alu
@@ -150,4 +150,3 @@ mod tests {
         assert_eq!(1f64.exp(), E);
     }
 }
- 

--- a/sysroot/std/mem.alu
+++ b/sysroot/std/mem.alu
@@ -3,7 +3,7 @@
 use builtins::Pointer;
 use std::option::Option;
 
-/// Types that can be "freed". 
+/// Types that can be "freed".
 ///
 /// Usually these types contain something that is heap-allocated.
 protocol Freeable<Self> {
@@ -33,7 +33,7 @@ protocol Movable<Self> {
 
 /// Types that be copied (usually heap-allocated types)
 protocol Copyable<Self> {
-    /// 
+    ///
     fn clone(self: &Self) -> Self;
 }
 
@@ -56,7 +56,7 @@ protocol AsSliceMut<Self, T> {
 ///
 /// Slice fat "pointers" are just regular structs that compiler handles in a special way with regards
 /// to syntax, implicit coercion and type inference. They are generic over the pointer-to-element type
-/// rather than the element type itself. This is an implementation detail to ensure that `&mut [T]` and 
+/// rather than the element type itself. This is an implementation detail to ensure that `&mut [T]` and
 /// `&[T]` are distinguished without having to have two distinct types for mutable and const slices.
 #[lang(slice)]
 struct slice<Ptr: Pointer> {
@@ -119,7 +119,7 @@ impl slice {
         if lhs.len != rhs.len {
             return false;
         }
-        
+
         when T: ZeroSized {
             true
         } else when T: Primitive {
@@ -165,7 +165,7 @@ impl slice {
             lhs.len.compare(&rhs.len)
         }
     }
-    
+
     /// @ std::hash::Hashable::hash
     fn hash<T: Hashable<T, H>, Ptr: PointerOf<T>, H: Hasher<H>>(self: &slice<Ptr>, hasher: &mut H) {
         when T: ZeroSized {
@@ -185,7 +185,7 @@ impl slice {
     fn fmt<Ptr: PointerOf<u8>, F: fmt::Formatter<F>>(self: &slice<Ptr>, f: &mut F) -> Result<(), fmt::Error> {
         f.write_str(*self)
     }
-    
+
     mixin<T: Equatable<T>, Ptr: PointerOf<T>> Equatable<slice<Ptr>>;
     mixin<T: Comparable<T>, Ptr: PointerOf<T>> Comparable<slice<Ptr>>;
 }
@@ -275,8 +275,8 @@ impl SliceRefIterator<Ptr: Pointer> {
 }
 
 mod internal {
-    use builtins::{Primitive, Pointer}; 
-    
+    use builtins::{Primitive, Pointer};
+
     #[force_inline]
     #[lang(slice_index)]
     fn slice_index<Ptr: Pointer>(a: slice<Ptr>, idx: usize) -> Ptr {
@@ -284,7 +284,7 @@ mod internal {
 
         a.ptr + idx
     }
-    
+
     #[force_inline]
     #[lang(slice_range_index)]
     fn slice_range_index<Ptr: Pointer, T>(a: slice<Ptr>, range: T) -> slice<Ptr> {

--- a/sysroot/std/net.alu
+++ b/sysroot/std/net.alu
@@ -13,7 +13,7 @@ use unix::{
 use address::{AddrKind, IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 /// Create a buffered reader/writer pair for a socket.
-fn buffered(self: &mut TcpStream, read_buf_size: usize, write_buf_size: usize) 
+fn buffered(self: &mut TcpStream, read_buf_size: usize, write_buf_size: usize)
     -> (io::BufferedReader<TcpStream>, io::BufferedWriter<TcpStream>) {
     let reader = io::BufferedReader::new(self, read_buf_size);
     let writer = io::BufferedWriter::new(self, write_buf_size);

--- a/sysroot/std/net/address.alu
+++ b/sysroot/std/net/address.alu
@@ -55,12 +55,12 @@ impl Ipv6Addr {
         Ipv6Addr { inner: addr }
     }
 
-    /// 
+    ///
     fn to_segments(self: &Ipv6Addr) -> [u16; 8] {
         use internal::htons;
 
         let as_u16 = &self.inner.s6_addr as &[u16; 8];
-        
+
         [
             htons((*as_u16)[0]),
             htons((*as_u16)[1]),
@@ -72,7 +72,7 @@ impl Ipv6Addr {
             htons((*as_u16)[7]),
         ]
     }
-    
+
     /// Extract IPv4 address from an IPv6 address if it's a v4-mapped or v4-compat address
     ///
     /// Returns `Option::none()` if the address is not a v4-mapped or v4-compat address.
@@ -130,7 +130,7 @@ impl Ipv6Addr {
     /// @ std::fmt::Formattable::fmt
     fn fmt<F: fmt::Formatter<F>>(self: &Ipv6Addr, f: &mut F) -> Result<(), fmt::Error> {
         use fmt::{hex, zero_pad, write};
- 
+
         // IPv4-compatible formats
         let segments = self.to_segments();
         if *self != Ipv6Addr::localhost() && *self != Ipv6Addr::unspecified() {
@@ -143,11 +143,11 @@ impl Ipv6Addr {
                 }
             }
         }
-        
+
         // Find first longest consecutive sequence of zero segments.
         let longest: Option<(usize, usize)> = Option::none();
         let current: Option<(usize, usize)> = Option::none();
-    
+
         for i in 0usize..8 {
             if segments[i] == 0 {
                 if !current.is_some {
@@ -270,13 +270,13 @@ impl Ipv4Addr {
 
     fn fmt<F: fmt::Formatter<F>>(self: &Ipv4Addr, f: &mut F) -> Result<(), fmt::Error> {
         use fmt::{hex, zero_pad, write};
-        
+
         let octets = self.to_octets();
-        write!(f, 
-            "{}.{}.{}.{}", 
-            octets[0], 
-            octets[1], 
-            octets[2], 
+        write!(f,
+            "{}.{}.{}.{}",
+            octets[0],
+            octets[1],
+            octets[2],
             octets[3]
         )
     }
@@ -289,7 +289,7 @@ impl Ipv4Addr {
 }
 
 union IpAddrInner {
-    v6: Ipv6Addr,    
+    v6: Ipv6Addr,
     v4: Ipv4Addr,
 }
 
@@ -331,7 +331,7 @@ impl IpAddr {
 }
 
 union SocketAddrInner {
-    v6: libc::sockaddr_in6,    
+    v6: libc::sockaddr_in6,
     v4: libc::sockaddr_in,
 }
 
@@ -358,9 +358,9 @@ impl SocketAddr {
             _ => unreachable!()
         }
 
-        SocketAddr { 
-            kind: addr.kind, 
-            inner: inner 
+        SocketAddr {
+            kind: addr.kind,
+            inner: inner
         }
     }
 
@@ -371,9 +371,9 @@ impl SocketAddr {
         sockaddr.sin6_addr = addr.inner;
         sockaddr.sin6_flowinfo = flowinfo;
         sockaddr.sin6_scope_id = scope_id;
-        
-        SocketAddr { 
-            kind: AddrKind::V6, 
+
+        SocketAddr {
+            kind: AddrKind::V6,
             inner: SocketAddrInner { v6: sockaddr }
         }
     }
@@ -429,7 +429,7 @@ impl SocketAddr {
 
             let segments = s.split("%");
             let address = Ipv6Addr::parse(segments.next()?)?;
-            
+
             let remainder = segments.next();
             let scope_id = if remainder.is_some {
                 u32::parse(remainder.inner)?
@@ -456,7 +456,7 @@ impl SocketAddr {
             AddrKind::V6 => {
                 if self.inner.v6.sin6_scope_id != 0 {
                     write!(f, "[{}%{}]:{}", self.ip(), self.inner.v6.sin6_scope_id, self.port())
-                } else {   
+                } else {
                     write!(f, "[{}]:{}", self.ip(), self.port())
                 }
             }
@@ -480,7 +480,7 @@ mod internal {
         use option::try;
         use string::split;
         let segments = s.split(":");
-        
+
         let result: [u16; 8] = mem::zeroed();
         if s.len == 0 {
             return Option::some((result, 0usize));
@@ -521,7 +521,7 @@ mod internal {
             return Option::none();
         }
 
-        Option::some((result, len))        
+        Option::some((result, len))
     }
 
     fn htons(i: u16) -> u16 {
@@ -550,7 +550,7 @@ mod tests {
         assert_eq!(fmt_ipv6!(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1), "2001:db8::1");
         assert_eq!(fmt_ipv6!(8, 9, 10, 11, 12, 13, 14, 15), "8:9:a:b:c:d:e:f");
         assert_eq!(
-            fmt_ipv6!(0x1111, 0x2222, 0x3333, 0x4444, 0x5555, 0x6666, 0x7777, 0x8888), 
+            fmt_ipv6!(0x1111, 0x2222, 0x3333, 0x4444, 0x5555, 0x6666, 0x7777, 0x8888),
             "1111:2222:3333:4444:5555:6666:7777:8888"
         );
         assert_eq!(fmt_ipv6!(0xae, 0, 0, 0, 0, 0xffff, 0x0102, 0x0304), "ae::ffff:102:304");
@@ -581,19 +581,19 @@ mod tests {
     fn test_socket_addr() {
         let addr = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
         let addr = SocketAddr::new(IpAddr::v6(addr), 80);
-        
+
         assert_eq!(fmt!("{}", addr), "[2001:db8::1]:80");
     }
 
     #[test]
     fn test_socket_addr_with_scope_id() {
         let addr = SocketAddr::with_flowinfo_and_scope(
-            Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1), 
+            Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1),
             80,
             0,
             1337
         );
-        
+
         assert_eq!(fmt!("{}", addr), "[2001:db8::1%1337]:80");
     }
 

--- a/sysroot/std/net/unix.alu
+++ b/sysroot/std/net/unix.alu
@@ -45,7 +45,7 @@ fn addr_to_family(addr: &SocketAddr) -> (libc::c_int, libc::socklen_t) {
 /// use std::net::NameLookup;
 /// let addresses = NameLookup::resolve("www.alumina-lang.net", 443).unwrap();
 /// defer addresses.free();
-/// 
+///
 /// for addr in addresses {
 ///     println!("{}", addr);
 /// }
@@ -61,13 +61,13 @@ impl NameLookup {
     fn resolve(host: &[u8], port: u16) -> Result<NameLookup, Error> {
         let host = ffi::CString::new(host);
         defer host.free();
-    
+
         let hints = mem::zeroed::<libc::addrinfo>();
         hints.ai_socktype = libc::SOCK_STREAM;
-    
+
         let res: &mut libc::addrinfo = null;
         let ret = libc::getaddrinfo(host.ptr, null, &hints, &res);
-        
+
         if ret == 0 {
             Result::ok(NameLookup {
                 original: res,
@@ -104,7 +104,7 @@ impl NameLookup {
             } else {
                 // Ignore addresses that are not IPv6 or IPv4.
                 return self.next();
-            }            
+            }
         }
     }
 
@@ -133,7 +133,7 @@ impl Socket {
     fn new(family: libc::c_int, type: libc::c_int) -> Result<Socket, Error> {
         let fd: FileDescriptor;
 
-        #[cfg(any(target_os = "android", target_os = "linux"))] 
+        #[cfg(any(target_os = "android", target_os = "linux"))]
         fd = FileDescriptor::new(errno_try!(libc::socket(family, type | libc::O_CLOEXEC, 0)));
 
         #[cfg(not(any(target_os = "android", target_os = "linux")))]
@@ -141,14 +141,14 @@ impl Socket {
             fd = FileDescriptor::new(errno_try!(libc::socket(family, type, 0)));
             fd.set_cloexec()?;
         }
-        
+
         Result::ok(Socket { fd: fd })
     }
-    
+
     fn as_fd(self: &Socket) -> FileDescriptor {
         self.fd
     }
-    
+
     fn shutdown(self: &Socket, how: Shutdown) -> Result<(), Error> {
         errno_try!(libc::shutdown(self.fd.value, how as libc::c_int));
         Result::ok(())
@@ -235,10 +235,10 @@ impl TcpStream {
 
         let sock = Socket::new(family, libc::SOCK_STREAM)?;
         defer sock.close();
-        
+
         errno_try!(libc::connect(
-            sock.fd.value, 
-            &addr.inner as &libc::sockaddr, 
+            sock.fd.value,
+            &addr.inner as &libc::sockaddr,
             addr_len as libc::socklen_t
         ));
 
@@ -256,7 +256,7 @@ impl TcpStream {
     fn socket_addr(self: &TcpStream) -> Result<SocketAddr, Error> {
         self.socket.socket_addr()
     }
-    
+
     fn shutdown(self: &TcpStream, how: Shutdown) -> Result<(), Error> {
         self.socket.shutdown(how)
     }
@@ -299,15 +299,15 @@ impl TcpListener {
 
         let sock = Socket::new(family, libc::SOCK_STREAM)?;
         defer sock.close();
-        
+
         errno_try!(libc::bind(
-            sock.fd.value, 
-            &addr.inner as &libc::sockaddr, 
+            sock.fd.value,
+            &addr.inner as &libc::sockaddr,
             addr_len
         ));
 
         errno_try!(libc::listen(
-            sock.fd.value, 
+            sock.fd.value,
             128
         ));
 
@@ -321,23 +321,23 @@ impl TcpListener {
     fn accept(self: &TcpListener) -> Result<(TcpStream, SocketAddr), Error> {
         let storage = mem::zeroed::<libc::sockaddr_storage>();
         let len: libc::socklen_t = mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
-        
+
         let fd: FileDescriptor;
 
-        #[cfg(any(target_os = "android", target_os = "linux"))] 
+        #[cfg(any(target_os = "android", target_os = "linux"))]
         fd = FileDescriptor::new(errno_try!(libc::accept4(
-            self.socket.fd.value, 
-            &storage as &mut libc::sockaddr, 
+            self.socket.fd.value,
+            &storage as &mut libc::sockaddr,
             &len,
             libc::O_CLOEXEC
         )));
-    
+
 
         #[cfg(not(any(target_os = "android", target_os = "linux")))]
         {
             fd = FileDescriptor::new(errno_try!(libc::accept(
                 self.socket.fd.value,
-                &storage as &mut libc::sockaddr, 
+                &storage as &mut libc::sockaddr,
                 &len
             )));
             fd.set_cloexec()?;
@@ -385,10 +385,10 @@ impl UdpSocket {
 
         let sock = Socket::new(family, libc::SOCK_DGRAM)?;
         defer sock.close();
-        
+
         errno_try!(libc::bind(
-            sock.fd.value, 
-            &addr.inner as &libc::sockaddr, 
+            sock.fd.value,
+            &addr.inner as &libc::sockaddr,
             addr_len
         ));
 
@@ -399,8 +399,8 @@ impl UdpSocket {
         let (family, addr_len) = addr_to_family(addr);
 
         errno_try!(libc::connect(
-            self.socket.fd.value, 
-            &addr.inner as &libc::sockaddr, 
+            self.socket.fd.value,
+            &addr.inner as &libc::sockaddr,
             addr_len as libc::socklen_t
         ));
 
@@ -498,7 +498,7 @@ mod tests {
     #[test]
     fn test_basic_tcp() {
         let addr = SocketAddr::parse("[::1]:0").unwrap();
-        let listener = TcpListener::bind(&addr).unwrap();  
+        let listener = TcpListener::bind(&addr).unwrap();
         defer listener.close();
 
         let local_addr = listener.socket_addr().unwrap();
@@ -523,7 +523,7 @@ mod tests {
     #[test]
     fn test_basic_udp() {
         let addr = SocketAddr::parse("[::1]:0").unwrap();
-        let peer1 = UdpSocket::bind(&addr).unwrap();  
+        let peer1 = UdpSocket::bind(&addr).unwrap();
         defer peer1.close();
 
         let peer1_addr = peer1.socket_addr().unwrap();
@@ -544,7 +544,7 @@ mod tests {
     #[test]
     fn test_udp_connect() {
         let addr = SocketAddr::parse("[::1]:0").unwrap();
-        let peer1 = UdpSocket::bind(&addr).unwrap();  
+        let peer1 = UdpSocket::bind(&addr).unwrap();
         defer peer1.close();
 
         let buf: [u8; 128];
@@ -554,7 +554,7 @@ mod tests {
             let addr = SocketAddr::parse("[::1]:0").unwrap();
             let peer2 = UdpSocket::bind(&addr).unwrap();
             defer peer2.close();
-            
+
             peer2.connect(&peer1_addr).unwrap();
             peer2.send("Hello, world!").unwrap();
 
@@ -575,7 +575,7 @@ mod tests {
     #[test]
     fn test_udp_peek() {
         let addr = SocketAddr::parse("[::1]:0").unwrap();
-        let peer1 = UdpSocket::bind(&addr).unwrap();  
+        let peer1 = UdpSocket::bind(&addr).unwrap();
         defer peer1.close();
 
         let peer1_addr = peer1.socket_addr().unwrap();

--- a/sysroot/std/option.alu
+++ b/sysroot/std/option.alu
@@ -225,7 +225,7 @@ impl Option {
         }
     }
 
-    fn fmt<T: Formattable<T, F>, F: Formatter<F>>(self: &Option<T>, formatter: &mut F) -> Result<(), fmt::Error> {
+    fn fmt<T: Formattable<T, F>, F: Formatter<F>>(self: &Option<T>, formatter: &mut F) -> fmt::Result {
         if self.is_some {
             write!(formatter, "some({})", self.inner)
         } else {

--- a/sysroot/std/option.alu
+++ b/sysroot/std/option.alu
@@ -2,8 +2,8 @@
 
 /// Extract the value or short-circuit the calling function.
 ///
-/// When expression is suffixed with `?`, this is de-sugared to an invocation of `try` macro on the 
-/// expression. 
+/// When expression is suffixed with `?`, this is de-sugared to an invocation of `try` macro on the
+/// expression.
 ///
 /// Expands to the following expression
 /// ```
@@ -20,10 +20,10 @@
 /// ```
 /// fn maybe_sum(maybe_a: Option<i32>, maybe_b: Option<i32>) -> Option<i32> {
 ///     use std::option::try;
-/// 
+///
 ///     let a = maybe_a?; // `return Option::none()` when `a` is empty.
 ///     let b = maybe_b?; // `return Option::none()` when `a` is empty.
-/// 
+///
 ///     Option::some(a + b)
 /// }
 /// ```
@@ -62,7 +62,7 @@ impl Option<T> {
     #[force_inline]
     fn some(inner: T) -> Option<T> {
         Option::<T> {
-            is_some: true, 
+            is_some: true,
             inner: inner
         }
     }
@@ -87,7 +87,7 @@ impl Option<T> {
         }
     }
 
-    /// Returns a value, if present, panic otherwise. 
+    /// Returns a value, if present, panic otherwise.
     fn unwrap(self: Option<T>) -> T {
         if self.is_some {
             self.inner
@@ -122,7 +122,7 @@ impl Option<T> {
     /// ```
     /// let a = Option::some(42).map(|v: i32| -> i32 { i + 1 });
     /// let b = Option::none::<i32>().map(|v: i32| -> i32 { i + 1 });
-    /// 
+    ///
     /// assert_eq!(a, Option::some(43));
     /// assert_eq!(b, Option::none());
     /// ```
@@ -141,14 +141,14 @@ impl Option<T> {
     /// # Example
     /// ```
     /// let a = Option::some(42)
-    ///     .and_then(|v: i32| -> Option<i32> { 
+    ///     .and_then(|v: i32| -> Option<i32> {
     ///         if v == 0 {
     ///             Option::none()
     ///         } else {
     ///             Option::some(v + 1)
     ///         }
     ///     });
-    /// 
+    ///
     /// assert_eq!(a, Option::some(43));
     /// ```
     fn and_then<Tm, F: builtins::Callable<(T), Option<Tm>>>(self: Option<T>, func: F) -> Option<Tm> {
@@ -194,7 +194,7 @@ impl Option {
     use std::cmp::{Equatable, Comparable, Ordering};
     use std::fmt::{write, Formatter, Formattable};
     use std::mem::{Freeable, Movable};
-    
+
     /// Convert `Option<Result<T, E>>` to `Result<Option<T>, E>`
     fn transpose<T, E>(self: Option<Result<T, E>>) -> Result<Option<T>, E> {
         if self.is_some {
@@ -307,7 +307,7 @@ mod tests {
     fn option_iter() {
         let opt1 = Option::some(42);
         let opt2 = Option::none::<i32>();
-        
+
         let iter = opt1.iter();
         assert!(iter.next() == opt1);
         assert!(iter.next() == opt2);
@@ -343,7 +343,7 @@ mod tests {
     #[test]
     fn option_unwrap() {
         let opt1 = Option::some(42);
-        
+
         assert!(opt1.unwrap() == 42);
     }
 

--- a/sysroot/std/option.alu
+++ b/sysroot/std/option.alu
@@ -168,6 +168,15 @@ impl Option<T> {
         }
     }
 
+    /// Returns pointer to inner or a null pointer if not present.
+    fn as_ptr(self: &Option<T>) -> &T {
+        if self.is_some {
+            &self.inner
+        } else {
+            null as &T
+        }
+    }
+
     fn iter(self: &Option<T>) -> Option<T> {
         *self
     }

--- a/sysroot/std/panicking.alu
+++ b/sysroot/std/panicking.alu
@@ -5,7 +5,7 @@
 /// Use this macro to bail on conditions that the program cannot reasonably be expected to
 /// recover from (e.g. when a condition means a certain programming bug).
 ///
-/// Since panics cannot be recovered from, prefer to use [structured error handling](std::result::Result) as 
+/// Since panics cannot be recovered from, prefer to use [structured error handling](std::result::Result) as
 /// a general purpose failure handling mechanism.
 ///
 /// When compiled in debug mode, `panic` prints the provided message along with the stack trace (on platforms
@@ -15,26 +15,26 @@
 /// ```
 /// let value = 42;
 /// switch value % 2 {
-///     0 => println!("even"),    
-///     1 => println!("odd"),    
-///     _ => panic!("{} is somehow neither odd nor even", value),    
+///     0 => println!("even"),
+///     1 => println!("odd"),
+///     _ => panic!("{} is somehow neither odd nor even", value),
 /// }
 /// ```
-/// 
+///
 /// Expressions that panic have a [never type](std::builtins::never).
 macro panic($reason, $args...) {
     internal::panic_impl(
-        concat!($reason), 
-        file!(), 
-        line!(), 
+        concat!($reason),
+        file!(),
+        line!(),
         column!(),
         &[internal::FormatArg::new(&$args)...]
     )
 }
 
 struct PanicInfo {
-    file: &[u8], 
-    line: i32, 
+    file: &[u8],
+    line: i32,
     column: i32,
     message: &[u8],
     args: &[fmt::internal::FormatArg<internal::PanicFormatter>]
@@ -80,8 +80,8 @@ mod internal {
     fn print_panic_message(info: &PanicInfo) -> Result<(), fmt::Error> {
         let formatter = PanicFormatter {};
         printf(
-            "panic at {}:{}:{}: ", 
-            &[FormatArg::new(&info.file), FormatArg::new(&info.line), FormatArg::new(&info.column)], 
+            "panic at {}:{}:{}: ",
+            &[FormatArg::new(&info.file), FormatArg::new(&info.line), FormatArg::new(&info.column)],
             &formatter
         )?;
         printf(info.message, info.args, &formatter)?;
@@ -93,10 +93,10 @@ mod internal {
     #[cold]
     #[no_inline]
     fn panic_impl(
-        fmt_str: &[u8], 
-        file: &[u8], 
-        line: i32, 
-        column: i32, 
+        fmt_str: &[u8],
+        file: &[u8],
+        line: i32,
+        column: i32,
         args: &[FormatArg<PanicFormatter>]
     ) -> ! {
         #[cfg(panic_trap)]
@@ -112,17 +112,17 @@ mod internal {
             }
 
             let panic_info = PanicInfo {
-                file: file, 
-                line: line, 
-                column: column, 
-                message: fmt_str, 
+                file: file,
+                line: line,
+                column: column,
+                message: fmt_str,
                 args: args
             };
-            
+
             if PANIC_HOOK.is_some {
                 PANIC_HOOK.inner.1(PANIC_HOOK.inner.0, &panic_info);
             }
-    
+
             // Swallow errors from print_panic_message, because at this point, what can we do, panic?
             // We still bail early if it fails.
             let _ = print_panic_message(&panic_info);
@@ -132,7 +132,7 @@ mod internal {
                 let size = backtrace(&buf[0], 128);
                 backtrace_symbols_fd(&buf[0] as &mut &void, size, libc::STDERR_FILENO);
             }
-            
+
             libc::abort();
         }
     }

--- a/sysroot/std/panicking.alu
+++ b/sysroot/std/panicking.alu
@@ -41,6 +41,7 @@ struct PanicInfo {
 
 mod internal {
     use fmt::{Formatter, internal::{printf, FormatArg}};
+    use sync::{Atomic, Ordering};
 
     // libc runtime backtrace support
     #[cfg(all(debug, not(no_backtrace), not(target_os = "android")))]
@@ -69,7 +70,7 @@ mod internal {
     }
     
     #[thread_local] static PANICKING: bool;
-    #[thread_local] static THREAD_PANIC_INFO: &mut PanicInfo;
+    #[thread_local] static THREAD_PANIC_INFO: Atomic<&mut PanicInfo>;
 
     fn print_panic_message( 
         fmt_str: &[u8], 
@@ -91,7 +92,6 @@ mod internal {
         Result::ok(())
     }
 
-    #[cfg(not(panic_trap))]
     #[cold]
     #[no_inline]
     fn panic_impl(
@@ -104,21 +104,25 @@ mod internal {
         #[cfg(panic_trap)]
         std::intrinsics::trap();
 
-        #[cfg(not(panic_trap))] {
+        #[cfg(panic_abort)]
+        libc::abort();
+
+        #[cfg(all(not(panic_trap), not(panic_abort)))] {
             if mem::replace(&PANICKING, true) {
                 // If we panic during a panic handler, nuclear abort.
                 std::intrinsics::trap();
             }
 
             #[cfg(threading)] {
-                if THREAD_PANIC_INFO != null {
+                let panic_info = THREAD_PANIC_INFO.exchange(null, Ordering::SeqCst);
+                if panic_info != null {
                     // If we are in a "managed" thread, we don't abort the process, but rather we just
                     // populate the panic info that was put there by the thread constructor. This allows
                     // the panic to be handled when the thread is joined.
-                    THREAD_PANIC_INFO.file = file;
-                    THREAD_PANIC_INFO.line = line;
-                    THREAD_PANIC_INFO.column = column;
-                    libc::pthread_exit(THREAD_PANIC_INFO as &mut void);
+                    panic_info.file = file;
+                    panic_info.line = line;
+                    panic_info.column = column;
+                    libc::pthread_exit(panic_info as &mut void);
                 }
             }
     
@@ -132,7 +136,7 @@ mod internal {
                 backtrace_symbols_fd(&buf[0] as &mut &void, size, libc::STDERR_FILENO);
             }
             
-            libc::_exit(-1);
+            libc::abort();
         }
     }
 }

--- a/sysroot/std/panicking.alu
+++ b/sysroot/std/panicking.alu
@@ -32,11 +32,17 @@ macro panic($reason, $args...) {
     )
 }
 
+struct PanicInfo {
+    file: &[u8], 
+    line: i32, 
+    column: i32,
+    message: &[u8],
+}
+
 mod internal {
     use fmt::{Formatter, internal::{printf, FormatArg}};
 
     // libc runtime backtrace support
-
     #[cfg(all(debug, not(no_backtrace), not(target_os = "android")))]
     {
         extern "C" fn backtrace(buffer: &mut &mut void, size: libc::c_int) -> libc::c_int;
@@ -62,9 +68,10 @@ mod internal {
         mixin Formatter<PanicFormatter>;
     }
     
-    static PANICKING: bool;
+    #[thread_local] static PANICKING: bool;
+    #[thread_local] static THREAD_PANIC_INFO: &mut PanicInfo;
 
-    fn print_panic_message(
+    fn print_panic_message( 
         fmt_str: &[u8], 
         file: &[u8], 
         line: i32, 
@@ -96,17 +103,28 @@ mod internal {
     ) -> ! {
         #[cfg(panic_trap)]
         std::intrinsics::trap();
-        
+
         #[cfg(not(panic_trap))] {
             if mem::replace(&PANICKING, true) {
                 // If we panic during a panic handler, nuclear abort.
                 std::intrinsics::trap();
             }
+
+            #[cfg(threading)] {
+                if THREAD_PANIC_INFO != null {
+                    // If we are in a "managed" thread, we don't abort the process, but rather we just
+                    // populate the panic info that was put there by the thread constructor. This allows
+                    // the panic to be handled when the thread is joined.
+                    THREAD_PANIC_INFO.file = file;
+                    THREAD_PANIC_INFO.line = line;
+                    THREAD_PANIC_INFO.column = column;
+                    libc::pthread_exit(THREAD_PANIC_INFO as &mut void);
+                }
+            }
     
             // Swallow errors from print_panic_message, because at this point, what can we do, panic?
             // We still bail early if it fails.
             let _ = print_panic_message(fmt_str, file, line, column, args);
-    
             #[cfg(all(debug, not(no_backtrace), not(target_os = "android")))]
             {
                 let buf: [&mut void; 128];

--- a/sysroot/std/panicking.alu
+++ b/sysroot/std/panicking.alu
@@ -37,6 +37,7 @@ struct PanicInfo {
     line: i32, 
     column: i32,
     message: &[u8],
+    args: &[fmt::internal::FormatArg<internal::PanicFormatter>]
 }
 
 mod internal {
@@ -68,25 +69,22 @@ mod internal {
         }
         mixin Formatter<PanicFormatter>;
     }
-    
-    #[thread_local] static PANICKING: bool;
-    #[thread_local] static THREAD_PANIC_INFO: Atomic<&mut PanicInfo>;
 
-    fn print_panic_message( 
-        fmt_str: &[u8], 
-        file: &[u8], 
-        line: i32, 
-        column: i32, 
-        args: &[FormatArg<PanicFormatter>]
-    ) -> Result<(), fmt::Error> {
+    #[thread_local] static PANICKING: bool;
+    #[thread_local] static PANIC_HOOK: Option<(&mut void, fn(&mut void, &PanicInfo))>;
+
+    fn set_panic_hook(arg: &mut void, f: fn(&mut void, &PanicInfo)) {
+        PANIC_HOOK = Option::some((arg, f));
+    }
+
+    fn print_panic_message(info: &PanicInfo) -> Result<(), fmt::Error> {
         let formatter = PanicFormatter {};
-        
         printf(
             "panic at {}:{}:{}: ", 
-            &[FormatArg::new(&file), FormatArg::new(&line), FormatArg::new(&column)], 
+            &[FormatArg::new(&info.file), FormatArg::new(&info.line), FormatArg::new(&info.column)], 
             &formatter
         )?;
-        printf(fmt_str, args, &formatter)?;
+        printf(info.message, info.args, &formatter)?;
         formatter.write_char('\n')?;
 
         Result::ok(())
@@ -113,22 +111,21 @@ mod internal {
                 std::intrinsics::trap();
             }
 
-            #[cfg(threading)] {
-                let panic_info = THREAD_PANIC_INFO.exchange(null, Ordering::SeqCst);
-                if panic_info != null {
-                    // If we are in a "managed" thread, we don't abort the process, but rather we just
-                    // populate the panic info that was put there by the thread constructor. This allows
-                    // the panic to be handled when the thread is joined.
-                    panic_info.file = file;
-                    panic_info.line = line;
-                    panic_info.column = column;
-                    libc::pthread_exit(panic_info as &mut void);
-                }
+            let panic_info = PanicInfo {
+                file: file, 
+                line: line, 
+                column: column, 
+                message: fmt_str, 
+                args: args
+            };
+            
+            if PANIC_HOOK.is_some {
+                PANIC_HOOK.inner.1(PANIC_HOOK.inner.0, &panic_info);
             }
     
             // Swallow errors from print_panic_message, because at this point, what can we do, panic?
             // We still bail early if it fails.
-            let _ = print_panic_message(fmt_str, file, line, column, args);
+            let _ = print_panic_message(&panic_info);
             #[cfg(all(debug, not(no_backtrace), not(target_os = "android")))]
             {
                 let buf: [&mut void; 128];

--- a/sysroot/std/prelude.alu
+++ b/sysroot/std/prelude.alu
@@ -1,6 +1,6 @@
 //! Items available everywhere without having to `use` them
 //!
-//! This file is the similar to the Rust's "prelude", items defined here are 
+//! This file is the similar to the Rust's "prelude", items defined here are
 //! available in the root lexical-scope, so they are available everywhere (but can be
 //! shadowed by local definitions).
 //!

--- a/sysroot/std/process/unix.alu
+++ b/sysroot/std/process/unix.alu
@@ -118,7 +118,7 @@ impl Child {
         }
 
         // Close all the pipes if we were able to read them
-        // to end. If any of the ?'s above bailed early, 
+        // to end. If any of the ?'s above bailed early,
         // we leave them open, as it may have been something
         // transient and a retry might succeed.
         self.close();
@@ -425,7 +425,7 @@ impl Command {
                 let msg = mem::slice::from_raw(&res.inner.err as &u8, mem::size_of::<Error>());
                 fail_tx.write_all(msg).unwrap();
                 libc::_exit(1);
-            } 
+            }
 
             unreachable!()
         }
@@ -439,7 +439,7 @@ mod internal {
     use string::StringBuf;
 
     extern "C" static environ: &&libc::c_char;
-    
+
     fn maybe_read_to_end<S1: Readable<S1>>(src: &mut S1, dst: &mut StringBuf) -> Result<bool, Error> {
         let maybe_n = src.read_to_end(dst);
         if maybe_n.is_ok {
@@ -448,7 +448,7 @@ mod internal {
             let error = maybe_n.unwrap_err();
             let as_errno = error.as_errno();
 
-            if as_errno == Option::some(libc::EWOULDBLOCK) || 
+            if as_errno == Option::some(libc::EWOULDBLOCK) ||
                 as_errno == Option::some(libc::EAGAIN) {
                 Result::ok(false)
             } else {
@@ -457,16 +457,16 @@ mod internal {
         }
     }
 
-    /// Reads two pipes (or any other stream) into respecitve buffers at the same time. 
+    /// Reads two pipes (or any other stream) into respecitve buffers at the same time.
     ///
     /// It uses [libc::poll] to make sure one pipe is not blocked by the other.
     fn read_to_end_2<
-        S1: Readable<S1> + AsFileDescriptor<S1>, 
-        S2: Readable<S2> + AsFileDescriptor<S2>, 
+        S1: Readable<S1> + AsFileDescriptor<S1>,
+        S2: Readable<S2> + AsFileDescriptor<S2>,
     >(
-        src1: &mut S1, 
-        dst1: &mut StringBuf, 
-        src2: &mut S2, 
+        src1: &mut S1,
+        dst1: &mut StringBuf,
+        src2: &mut S2,
         dst2: &mut StringBuf
     ) -> result::Result<(), Error> {
         let s1 = src1.as_fd();
@@ -504,12 +504,12 @@ mod internal {
         kind: Stdio,
         pair: Option<(Pipe, Pipe)>
     }
-    
+
     impl IoRedirection {
         fn new(is_stdin: bool, kind: Stdio) -> Result<IoRedirection, Error> {
             let pair: Option<(Pipe, Pipe)> = if kind == Stdio::Piped {
                 let (rx, tx) = Pipe::anonymous()?;
-    
+
                 if is_stdin {
                     Option::some((tx, rx))
                 } else {
@@ -518,45 +518,45 @@ mod internal {
             } else {
                 Option::none()
             };
-    
+
             let res = IoRedirection {
                 pair: pair,
                 kind: kind
             };
-    
+
             Result::ok(res)
         }
-    
+
         fn close(self: &mut IoRedirection) -> Result<(), Error> {
             if self.pair.is_some {
                 self.pair.inner.0.close()?;
                 self.pair.inner.1.close()?;
-            } 
-                
+            }
+
             Result::ok(())
         }
-    
+
         fn install(self: &mut IoRedirection, fd: libc::c_int) -> Result<(), Error> {
             use std::fs::{File, OpenOptions};
-    
+
             switch self.kind {
                 Stdio::Piped => {
                     let (_, tgt) = self.pair.unwrap();
-    
+
                     errno_try!(libc::dup2(tgt.fd.value, fd));
                 },
                 Stdio::Null => {
                     let dev_zero = File::open_with(Path::new("/dev/null"), OpenOptions::new().read(true).write(true))?;
                     defer dev_zero.close();
-    
+
                     errno_try!(std::libc::dup2(dev_zero.fd.value, fd));
                 },
                 _ => {}
             };
-    
+
             Result::ok(())
         }
-    
+
         fn into_inner(self: &mut IoRedirection) -> Option<Pipe> {
             if self.pair.is_some {
                 Option::some(self.pair.inner.0.move())

--- a/sysroot/std/random.alu
+++ b/sysroot/std/random.alu
@@ -6,7 +6,7 @@ use std::builtins::{Unsigned, Integer, FloatingPoint};
 protocol RandomNumberGenerator<Self> {
     /// Generate a 32-bit integer.
     fn next_u32(self: &mut Self) -> u32;
-    
+
     /// Generate a 64-bit integer.
     fn next_u64(self: &mut Self) -> u64;
 
@@ -38,7 +38,7 @@ protocol RandomNumberGenerator<Self> {
 /// PCG-32 random number generator
 ///
 /// A small-state general purpose random number generator ([https://www.pcg-random.org/]).
-/// 
+///
 /// Not suitable for cryptographic purposes.
 struct Pcg32  {
     state: u64,
@@ -62,7 +62,7 @@ impl Pcg32 {
         seed[0..8].copy_nonoverlapping(&pcg.state as &mut u8);
         seed[8..16].copy_nonoverlapping(&pcg.increment as &mut u8);
         pcg.increment = pcg.increment | 1;
-        
+
         pcg.state = pcg.state + pcg.increment;
         pcg.step();
         pcg
@@ -97,7 +97,7 @@ impl Pcg32 {
 {
     /// RNG backed by a OS-provided random number generation facility
     ///
-    /// On Linux, this is based on `getrandom` syscall, on other UNIX-like platforms, this 
+    /// On Linux, this is based on `getrandom` syscall, on other UNIX-like platforms, this
     /// reads the bytes from `/dev/urandom`.
     ///
     /// # Usage notes
@@ -117,13 +117,13 @@ impl Pcg32 {
         #[cfg(not(target_os = "linux"))]
         fn new() -> OsRng {
             use fs::Path;
-            
+
             OsRng {
                 file: fs::File::open(Path::new("/dev/urandom"))
                 .unwrap()
             }
         }
-        
+
         /// Create a new instance of OsRng
         #[cfg(target_os = "linux")]
         fn new() -> OsRng {
@@ -231,7 +231,7 @@ fn next_float<Rng: RandomNumberGenerator<Rng>, T: FloatingPoint>(rng: &mut Rng) 
         let scale = 1.0f64 / ((1u64 << 53) as f64);
         let x = rng.next_u64() >> 11;
         (x as f64) * scale
-    } 
+    }
 }
 
 /// Generate a random number between `lower` (inclusive) and `upper` (exclusive)
@@ -256,7 +256,7 @@ fn range_inclusive<Rng: RandomNumberGenerator<Rng>, T: Integer>(rng: &mut Rng, l
     if range == 0 {
         next_integer::<Rng, unsigned_of<T>>(rng) as T
     } else {
-        let ret = (lower as unsigned_of<T>) + uniform(rng, range);        
+        let ret = (lower as unsigned_of<T>) + uniform(rng, range);
         ret as T
     }
 }

--- a/sysroot/std/random.alu
+++ b/sysroot/std/random.alu
@@ -163,14 +163,9 @@ impl Pcg32 {
         mixin RandomNumberGenerator<OsRng>;
     }
 
-
-    /// A convenience pre-seeded random number generator. It is
-    /// seeded using `OsRng` and ready to be used.
-    ///
-    /// Not thread safe.
-    static DEFAULT_RNG: Pcg32 = internal::seed_default_rng();
-
     mod internal {
+        #[thread_local] static DEFAULT_RNG: Option<Pcg32>;
+
         fn seed_default_rng() -> Pcg32 {
             let seed: [u8; 16];
             let seeder = OsRng::new();
@@ -181,6 +176,16 @@ impl Pcg32 {
         }
     }
 
+}
+
+/// A thread-local RNG that's seeded from the operating system.
+///
+/// Lazily initialized on first access from each thread.
+fn thread_rng() -> &mut Pcg32 {
+    if !internal::DEFAULT_RNG.is_some {
+        internal::DEFAULT_RNG = Option::some(internal::seed_default_rng());
+    }
+    &internal::DEFAULT_RNG.inner
 }
 
 /// Generate a random integer of any unsigned integer type

--- a/sysroot/std/result.alu
+++ b/sysroot/std/result.alu
@@ -2,8 +2,8 @@
 
 /// Extract the success value or short-circuit the calling function.
 ///
-/// When expression is suffixed with `?`, this is de-sugared to an invocation of `try` macro on the 
-/// expression. 
+/// When expression is suffixed with `?`, this is de-sugared to an invocation of `try` macro on the
+/// expression.
 ///
 /// Expands to the following expression
 /// ```
@@ -27,7 +27,7 @@ macro try($res) {
 /// Type for operations that can fail.
 ///
 /// `Result` is the type that can be used to express fallible operations in the type system.
-/// Alumina does not have exceptions. Value `Result<T, E>` can be either a successfull value of 
+/// Alumina does not have exceptions. Value `Result<T, E>` can be either a successfull value of
 /// type `T` or an error value `E`, usually in some form representing the failure that happened.
 ///
 /// # Example
@@ -36,9 +36,9 @@ macro try($res) {
 ///     ELF,
 ///     PE
 /// }
-/// 
+///
 /// struct Error {}
-/// 
+///
 /// fn executable_type(contents: &[u8]) -> Result<ExecutableType, Error> {
 ///     use std::string::starts_with;
 ///     if contents.starts_with("MZ") {
@@ -50,9 +50,9 @@ macro try($res) {
 ///         Result::err(Error {})
 ///     }
 /// }
-/// 
+///
 /// let result = executable_type();
-/// 
+///
 /// if !result.is_ok {
 ///     eprintln!("Invalid executable");
 /// } else {
@@ -60,8 +60,8 @@ macro try($res) {
 ///     // do something with it
 /// }
 /// ```
-/// 
-/// `Result` is commonly used with the [try operator](try) (`?`) so that fallible functions can 
+///
+/// `Result` is commonly used with the [try operator](try) (`?`) so that fallible functions can
 /// be composed easily by bailing early.
 struct Result<T, E> {
     is_ok: bool,
@@ -80,7 +80,7 @@ impl Result<T, E> {
     #[force_inline]
     fn ok(ok: T) -> Result<T, E> {
         Result::<T, E> {
-            is_ok: true, 
+            is_ok: true,
             inner: ResultT::<T, E> {
                 ok: ok
             }
@@ -91,7 +91,7 @@ impl Result<T, E> {
     #[force_inline]
     fn err(err: E) -> Result<T, E> {
         Result::<T, E> {
-            is_ok: false, 
+            is_ok: false,
             inner: ResultT::<T, E> {
                 err: err
             }
@@ -144,14 +144,14 @@ impl Result<T, E> {
 
     /// Transform the success value inside the `Result` by calling the provided function.
     ///
-    /// If the error value is present, function is not called and the original error is 
+    /// If the error value is present, function is not called and the original error is
     /// passed through.
     ///
     /// # Example
     /// ```
     /// let a: Result<i32, ()> = Result::ok(42).map(|v: i32| -> i32 { i + 1 });
     /// let b: Result<i32, ()> = Result::err(()).map(|v: i32| -> i32 { i + 1 });
-    /// 
+    ///
     /// assert_eq!(a, Result::ok(43));
     /// assert_eq!(b, Result::err(()));
     /// ```
@@ -165,14 +165,14 @@ impl Result<T, E> {
 
     /// Transform the error value inside the `Result` by calling the provided function.
     ///
-    /// If the success value is present, function is not called and the original error is 
+    /// If the success value is present, function is not called and the original error is
     /// passed through.
     ///
     /// # Example
     /// ```
     /// let a: Result<(), i32> = Result::err(42).map(|v: i32| -> i32 { i + 1 });
     /// let b: Result<(), i32> = Result::ok(()).map(|v: i32| -> i32 { i + 1 });
-    /// 
+    ///
     /// assert_eq!(a, Result::err(43));
     /// assert_eq!(b, Result::ok(()));
     /// ```

--- a/sysroot/std/result.alu
+++ b/sysroot/std/result.alu
@@ -200,7 +200,7 @@ impl Result {
     use std::mem::{Freeable, Movable};
 
     /// @ std::fmt::Formattable::fmt
-    fn fmt<T: Formattable<T, F>, E: Formattable<E, F>, F: Formatter<F>>(self: &Result<T, E>, formatter: &mut F) {
+    fn fmt<T: Formattable<T, F>, E: Formattable<E, F>, F: Formatter<F>>(self: &Result<T, E>, formatter: &mut F) -> fmt::Result {
         if self.is_ok {
             write!(formatter, "ok({})", self.inner.ok)
         } else {

--- a/sysroot/std/rtti.alu
+++ b/sysroot/std/rtti.alu
@@ -19,9 +19,9 @@ mod tests {
     fn test_type_name() {
         assert_eq!(type_name::<u8>(), "u8");
         assert_eq!(type_name::<u16>(), "u16");
-        
+
         // inception
         assert_eq!(type_name::<type_name<type_name<u32>>>(), "type_name<type_name<u32>>");
-        
+
     }
 }

--- a/sysroot/std/runtime.alu
+++ b/sysroot/std/runtime.alu
@@ -11,8 +11,10 @@ mod internal {
     {
         /// Minimal support for testing in the compiler. 
         ///
-        /// During AST construction, compiler will collect all the methods with #[test] attribute and
+        /// During AST construction, compiler will collect all the methods with `#[test]` attribute and
         /// make them available via this intrinsic.
+        ///
+        /// Do not use directly, use the [TEST_CASES] static instead.
         extern "intrinsic" fn test_cases() -> &[TestCaseMeta];
 
         // `test_cases()` call can be lowered at at any point during the IR lowering processed, ensure
@@ -41,10 +43,32 @@ mod internal {
         }
     }
 
-    macro argc_argv_to_slice($argc, $argv) {
+    const STACK_ARGS_MAX: usize = 1024;
+
+    /// Converts `argc` and `argv` into a `&[&[u8]]` slice of strings.
+    ///
+    /// It allocates the memory for the slice on the stack, hence a macro. This is done to avoid
+    /// a dependency on `malloc` for simple programs, but it is potentially problematic if a large 
+    /// number of arguments is passed as a significant portion of the stack space will be consumed.
+    /// The size of the slice is `argc * sizeof(usize) * 2` as only the pointers and lengths are 
+    /// stored in the slice, the contents of the arguments stays in the memory region pointed to by
+    /// `argv`.
+    ///
+    /// If number of arguments exceeds [STACK_ARGS_MAX], the function will fall back to using malloc.
+    ///
+    /// This is not great and probably a reason why Rust has `env::args()` instead of an argument
+    /// to the `main` function, but I kind of like the C-style arguments to main, so for now this
+    /// is the approach. 
+    macro argc_argv_to_slice($argc, $argv) { 
         let argc = $argc as usize;
         let argv = $argv as &&u8;
-        let args = aligned_alloca(size_of::<&[u8]>() * (argc), align_of::<&[u8]>() * 8) as &mut &[u8];
+        
+        let args = if argc > STACK_ARGS_MAX {
+            aligned_alloca(size_of::<&[u8]>() * argc, align_of::<&[u8]>() * 8) as &mut &[u8]
+        } else {
+            libc::malloc(size_of::<&[u8]>() * argc) as &mut &[u8] // will leak
+        };
+
         let args_ptr = args;
         while *argv != null {
             *args_ptr = slice::from_raw(*argv, libc::strlen(*argv as &libc::c_char) as usize);
@@ -59,8 +83,9 @@ mod internal {
         use thread::internal::{THREAD_INFO, ThreadInfo};
 
         // ThreadInfo for main thread is not freed when program is exiting. Calling
-        // C main in a loop would cause a memory leak.
-        assert!(THREAD_INFO == null);
+        // C main in a loop would cause a memory leak. Calling user main recursively
+        // is fine. 
+        debug_assert!(THREAD_INFO == null);
 
         let info = ThreadInfo::new();
         info.id = libc::pthread_self();

--- a/sysroot/std/runtime.alu
+++ b/sysroot/std/runtime.alu
@@ -9,7 +9,7 @@ mod internal {
 
     #[cfg(all(test))]
     {
-        /// Minimal support for testing in the compiler. 
+        /// Minimal support for testing in the compiler.
         ///
         /// During AST construction, compiler will collect all the methods with `#[test]` attribute and
         /// make them available via this intrinsic.
@@ -23,7 +23,7 @@ mod internal {
         static TEST_CASES: &[TestCaseMeta] = test_cases();
 
         #[lang(test_case_meta)]
-        struct TestCaseMeta { 
+        struct TestCaseMeta {
             path: &[u8],
             name: &[u8],
             attributes: &[&[u8]],
@@ -48,9 +48,9 @@ mod internal {
     /// Converts `argc` and `argv` into a `&[&[u8]]` slice of strings.
     ///
     /// It allocates the memory for the slice on the stack, hence a macro. This is done to avoid
-    /// a dependency on `malloc` for simple programs, but it is potentially problematic if a large 
+    /// a dependency on `malloc` for simple programs, but it is potentially problematic if a large
     /// number of arguments is passed as a significant portion of the stack space will be consumed.
-    /// The size of the slice is `argc * sizeof(usize) * 2` as only the pointers and lengths are 
+    /// The size of the slice is `argc * sizeof(usize) * 2` as only the pointers and lengths are
     /// stored in the slice, the contents of the arguments stays in the memory region pointed to by
     /// `argv`.
     ///
@@ -58,11 +58,11 @@ mod internal {
     ///
     /// This is not great and probably a reason why Rust has `env::args()` instead of an argument
     /// to the `main` function, but I kind of like the C-style arguments to main, so for now this
-    /// is the approach. 
-    macro argc_argv_to_slice($argc, $argv) { 
+    /// is the approach.
+    macro argc_argv_to_slice($argc, $argv) {
         let argc = $argc as usize;
         let argv = $argv as &&u8;
-        
+
         let args = if argc > STACK_ARGS_MAX {
             aligned_alloca(size_of::<&[u8]>() * argc, align_of::<&[u8]>() * 8) as &mut &[u8]
         } else {
@@ -84,7 +84,7 @@ mod internal {
 
         // ThreadInfo for main thread is not freed when program is exiting. Calling
         // C main in a loop would cause a memory leak. Calling user main recursively
-        // is fine. 
+        // is fine.
         debug_assert!(THREAD_INFO == null);
 
         let info = ThreadInfo::new();
@@ -97,7 +97,7 @@ mod internal {
         /// Program entrypoint glue.
         ///
         /// This is the entrypoint for the program. It is called by the C runtime after static
-        /// initialization. It converts the `argc` and `argv` arguments to a slice of strings 
+        /// initialization. It converts the `argc` and `argv` arguments to a slice of strings
         /// and calls the user-defined `main` function.
         #[export]
         #[codegen(c_main)]

--- a/sysroot/std/runtime.alu
+++ b/sysroot/std/runtime.alu
@@ -54,6 +54,19 @@ mod internal {
         slice::from_raw(args as &&[u8], argc)
     }
 
+    #[cfg(threading)]
+    fn setup_main_thread() {
+        use thread::internal::{THREAD_INFO, ThreadInfo};
+
+        // ThreadInfo for main thread is not freed when program is exiting. Calling
+        // C main in a loop would cause a memory leak.
+        assert!(THREAD_INFO == null);
+
+        let info = ThreadInfo::new();
+        info.id = libc::pthread_self();
+        THREAD_INFO = info;
+    }
+
     #[cfg(not(custom_entrypoint))]
     {
         /// Program entrypoint glue.
@@ -66,6 +79,9 @@ mod internal {
         #[lang(entrypoint_glue)]
         fn main<UserMain>(argc: libc::c_int, argv: &&libc::c_char) -> libc::c_int {
             let func: UserMain;
+
+            #[cfg(threading)]
+            setup_main_thread();
 
             let ret = when arguments_of<UserMain>: (&[&[u8]]) {
                 func(argc_argv_to_slice!(argc, argv))

--- a/sysroot/std/string.alu
+++ b/sysroot/std/string.alu
@@ -190,7 +190,7 @@ impl SplitIterator {
 /// # Example
 /// ```
 /// use std::string::split;
-/// 
+///
 /// let iter = "192.168.0.1".split(".");
 /// assert_eq!(iter.next(), Option::some("192"));
 /// assert_eq!(iter.next(), Option::some("168"));
@@ -212,7 +212,7 @@ impl ReplaceAdapter {
     use std::fmt::{write, Error, Formatter};
 
     fn fmt<F: Formatter<F>>(self: &ReplaceAdapter, f: &mut F) -> Result<(), Error> {
-        let first = true;    
+        let first = true;
         for chunk in self.inner.split(self.needle) {
             if first {
                 first = false;
@@ -240,7 +240,7 @@ fn replace(self: &[u8], needle: &[u8], replacement: &[u8]) -> StringBuf {
 /// # Example
 /// ```
 /// use std::string::replace_fmt;
-/// 
+///
 /// // Prints "I like cake"
 /// println!("{}", "I like pie".replace_fmt("pie", "cake"));
 /// ```
@@ -285,7 +285,7 @@ fn join<It: iter::Iterator<It, &[u8]>>(self: &[u8], iter: &mut It) -> StringBuf 
 /// # Example
 /// ```
 /// use std::string::join_fmt;
-/// 
+///
 /// // Prints 192.168.0.1
 /// println!("{}", ".".join_fmt(&["192", "168", "0", "1"].iter()));
 /// ```
@@ -325,10 +325,10 @@ fn parse_integer<T: builtins::Integer>(s: &[u8], radix: u16) -> Option<T> {
             return Option::none();
         }
 
-        let a = result * radix; 
+        let a = result * radix;
         if a / radix != result {
             return Option::none();
-        } 
+        }
         let b = a + digit;
         if b < a {
             return Option::none();
@@ -395,7 +395,7 @@ mod tests {
     fn test_parse_integer() {
         assert_eq!(parse_integer::<usize>("0", 10), Option::some(0usize));
         assert_eq!(parse_integer::<isize>("0", 10), Option::some(0isize));
-        
+
         assert_eq!(parse_integer::<usize>("-0", 10), Option::none());
         assert_eq!(parse_integer::<isize>("-0", 10), Option::some(0isize));
 
@@ -404,7 +404,7 @@ mod tests {
 
         assert_eq!(parse_integer::<usize>("", 10), Option::none());
         assert_eq!(parse_integer::<usize>("abcdes", 10), Option::none());
-        assert_eq!(parse_integer::<usize>("-243", 10), Option::none());  
+        assert_eq!(parse_integer::<usize>("-243", 10), Option::none());
 
         // Unsigned overflow
         assert_eq!(parse_integer::<u8>("256", 10), Option::none());
@@ -414,10 +414,10 @@ mod tests {
         assert_eq!(parse_integer::<u16>("65536", 10), Option::none());
 
         // Signed overflow
-        assert_eq!(parse_integer::<i8>("127", 10), Option::some(127i8));  
-        assert_eq!(parse_integer::<i8>("128", 10), Option::none());  
-        assert_eq!(parse_integer::<i8>("-128", 10), Option::some(-128 as i8));  
-        assert_eq!(parse_integer::<i8>("-129", 10), Option::none());  
+        assert_eq!(parse_integer::<i8>("127", 10), Option::some(127i8));
+        assert_eq!(parse_integer::<i8>("128", 10), Option::none());
+        assert_eq!(parse_integer::<i8>("-128", 10), Option::some(-128 as i8));
+        assert_eq!(parse_integer::<i8>("-129", 10), Option::none());
         assert_eq!(
             parse_integer::<i128>("170141183460469231731687303715884105727", 10),
             Option::some(170141183460469231731687303715884105727i128)
@@ -430,11 +430,11 @@ mod tests {
 
     #[test]
     fn test_parse_integer_radix() {
-        assert_eq!(parse_integer::<u8>("ff", 16), Option::some(255u8));       
-        assert_eq!(parse_integer::<u32>("11111111111111111111111111111111", 2), Option::some(u32::max_value()));       
+        assert_eq!(parse_integer::<u8>("ff", 16), Option::some(255u8));
+        assert_eq!(parse_integer::<u32>("11111111111111111111111111111111", 2), Option::some(u32::max_value()));
         assert_eq!(parse_integer::<u32>("DeAdBeEf", 16), Option::some(3735928559u32));
 
-        assert_eq!(parse_integer::<u8>("ff", 10), Option::none());       
+        assert_eq!(parse_integer::<u8>("ff", 10), Option::none());
     }
 
     #[test]
@@ -523,7 +523,7 @@ mod tests {
         assert_eq!(f.as_slice(), "192::168::0::1");
     }
 */
-    #[test] 
+    #[test]
     fn test_replace() {
         let f = "192.168.0.1".replace(".", "::");
         defer f.free();

--- a/sysroot/std/sync.alu
+++ b/sysroot/std/sync.alu
@@ -678,7 +678,9 @@ mod test {
     fn test_mutex() {
         let a = Mutex::new();
         a.lock();
-        assert_eq!(a.try_lock(), false);
+        thread::spawn(|&a| {
+            assert_eq!(a.try_lock(), false);
+        }).join().unwrap();
         a.unlock();
         assert_eq!(a.try_lock(), true);
         a.unlock();
@@ -689,14 +691,18 @@ mod test {
     fn test_rwlock() {
         let a = RwLock::new();
         a.read_lock();
-        assert_eq!(a.try_read_lock(), true);
-        assert_eq!(a.try_write_lock(), false);
-        a.unlock();
+        thread::spawn(|&a| {
+            assert_eq!(a.try_write_lock(), false);
+            assert_eq!(a.try_read_lock(), true);
+            a.unlock();
+        }).join().unwrap();
         a.unlock();
 
         a.write_lock();
-        assert_eq!(a.try_read_lock(), false);
-        assert_eq!(a.try_write_lock(), false);
+        thread::spawn(|&a| {
+            assert_eq!(a.try_read_lock(), false);
+            assert_eq!(a.try_write_lock(), false);
+        }).join().unwrap();
         a.unlock();
     }
 

--- a/sysroot/std/sync.alu
+++ b/sysroot/std/sync.alu
@@ -709,17 +709,18 @@ mod test {
     #[cfg(threading)]
     #[test]
     fn test_condvar() {
+        use thread::{spawn, Thread};
+
         let counter = 0;
 
         let flag = Atomic::new(false);
-
         let mutex = Mutex::new();
         let condvar = CondVar::new();
 
-        let t = thread::spawn(|&counter, &condvar, &mutex, &flag| {
+        let t = spawn(|&counter, &condvar, &mutex, &flag| {
             /// Ensure the main thread gets the mutex first;
             while !flag.load(Ordering::SeqCst) {
-                thread::yield();
+                Thread::park();
             }
 
             mutex.lock();
@@ -735,6 +736,7 @@ mod test {
         assert!(!condvar.wait_timeout(&mutex, time::Duration::zero()));
         
         flag.store(true, Ordering::SeqCst);
+        t.thread().unpark();
 
         while counter == 0 {
             condvar.wait(&mutex);

--- a/sysroot/std/sync.alu
+++ b/sysroot/std/sync.alu
@@ -1,0 +1,222 @@
+//! Thread synchronization
+
+use std::builtins::{Primitive, ZeroSized, Integer};
+
+enum Ordering {
+    Relaxed = 0,
+    Consume = 1,
+    Acquire = 2,
+    Release = 3,
+    AcqRel = 4,
+    SeqCst = 5 
+}
+
+/// Values that can be operated on atomically.
+struct Atomic<T: Primitive + !ZeroSized> {
+    inner: T
+}
+
+impl Atomic<T: Primitive + !ZeroSized> {
+    fn new(inner: T) -> Atomic<T> {
+        Atomic { inner: inner }
+    }
+
+    #[force_inline]
+    fn load(self: &Atomic<T>, ordering: Ordering) -> T {
+        intrinsics::codegen_func::<T>("__atomic_load_n", &self.inner, ordering as libc::c_int)
+    }
+
+    #[force_inline]
+    fn store(self: &mut Atomic<T>, value: T, ordering: Ordering) {
+        intrinsics::codegen_func::<void>("__atomic_store_n", &self.inner, value, ordering as libc::c_int)
+    }
+
+    #[force_inline]
+    fn exchange(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
+        intrinsics::codegen_func::<T>("__atomic_exchange_n", &self.inner, value, ordering as libc::c_int)
+    }
+
+    #[force_inline]
+    fn compare_exchange(
+        self: &mut Atomic<T>, 
+        expected: T, 
+        desired: T, 
+        success_ordering: Ordering, 
+        failure_ordering: Ordering
+    ) -> Result<T, T> {
+        if intrinsics::codegen_func::<bool>(
+            "__atomic_compare_exchange_n", 
+            &self.inner, 
+            &expected, 
+            desired, 
+            false,
+            success_ordering as libc::c_int,
+            failure_ordering as libc::c_int
+        ) {
+            Result::ok(expected)
+        } else {
+            Result::err(expected)
+        }
+    }
+
+    #[force_inline]
+    fn compare_exchange_weak(
+        self: &mut Atomic<T>, 
+        expected: T, 
+        desired: T, 
+        success_ordering: Ordering, 
+        failure_ordering: Ordering
+    ) -> Result<T, T> {
+        if intrinsics::codegen_func::<bool>(
+            "__atomic_compare_exchange_n", 
+            &self.inner, 
+            &expected, 
+            desired, 
+            true,
+            success_ordering as libc::c_int,
+            failure_ordering as libc::c_int
+        ) {
+            Result::ok(expected)
+        } else {
+            Result::err(expected)
+        }
+    }
+}
+
+/// Memory barrier
+fn fence(ordering: Ordering) {
+    intrinsics::codegen_func::<void>("__atomic_thread_fence", ordering as libc::c_int)
+}
+
+impl Atomic<T: Integer> {
+    #[force_inline]
+    fn fetch_add(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
+        intrinsics::codegen_func::<T>("__atomic_fetch_add", &self.inner, value, ordering as libc::c_int)
+    }
+
+    #[force_inline]
+    fn fetch_sub(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
+        intrinsics::codegen_func::<T>("__atomic_fetch_sub", &self.inner, value, ordering as libc::c_int)
+    }
+
+    #[force_inline]
+    fn fetch_and(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
+        intrinsics::codegen_func::<T>("__atomic_fetch_and", &self.inner, value, ordering as libc::c_int)
+    }
+
+    #[force_inline]
+    fn fetch_or(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
+        intrinsics::codegen_func::<T>("__atomic_fetch_or", &self.inner, value, ordering as libc::c_int)
+    }
+
+    #[force_inline]
+    fn fetch_xor(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
+        intrinsics::codegen_func::<T>("__atomic_fetch_xor", &self.inner, value, ordering as libc::c_int)
+    }
+
+    #[force_inline]
+    fn fetch_nand(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
+        intrinsics::codegen_func::<T>("__atomic_fetch_nand", &self.inner, value, ordering as libc::c_int)
+    }
+}
+
+#[cfg(all(test, test_std))]
+mod test {
+    #[test]
+    fn test_ordering_values_match() {
+        // This test asserts that the ordering constant values we hardcode above match the
+        // builtin constants in the C compiler.
+
+        macro match($a, $b) {
+            assert_eq!($a as libc::c_int, intrinsics::codegen_const::<libc::c_int>($b));
+        }
+
+        match!(Ordering::Relaxed, "__ATOMIC_RELAXED");
+        match!(Ordering::Consume, "__ATOMIC_CONSUME");
+        match!(Ordering::Acquire, "__ATOMIC_ACQUIRE");
+        match!(Ordering::Release, "__ATOMIC_RELEASE");
+        match!(Ordering::AcqRel, "__ATOMIC_ACQ_REL");
+        match!(Ordering::SeqCst, "__ATOMIC_SEQ_CST");
+    }
+
+    #[test]
+    fn test_load() {
+        let a: Atomic<i32> = Atomic::new(42);
+        assert_eq!(a.load(Ordering::Relaxed), 42);
+    }
+
+    #[test]
+    fn test_store() {
+        let a: Atomic<i32> = Atomic::new(42);
+        a.store(43, Ordering::Relaxed);
+        assert_eq!(a.load(Ordering::Relaxed), 43);
+    }
+
+    #[test]
+    fn test_exchange() {
+        let a: Atomic<i32> = Atomic::new(42);
+        assert_eq!(a.exchange(43, Ordering::Relaxed), 42);
+        assert_eq!(a.load(Ordering::Relaxed), 43);
+    }
+
+    #[test]
+    fn test_compare_exchange() {
+        let a: Atomic<i32> = Atomic::new(42);
+        assert_eq!(a.compare_exchange(42, 43, Ordering::Relaxed, Ordering::Relaxed), Result::ok(42));
+        assert_eq!(a.load(Ordering::Relaxed), 43);
+        assert_eq!(a.compare_exchange(44, 45, Ordering::Relaxed, Ordering::Relaxed), Result::err(43));
+        assert_eq!(a.load(Ordering::Relaxed), 43);
+    }
+
+    #[test]
+    fn test_compare_exchange_weak() {
+        let a: Atomic<i32> = Atomic::new(42);
+        assert_eq!(a.compare_exchange_weak(42, 43, Ordering::Relaxed, Ordering::Relaxed), Result::ok(42));
+        assert_eq!(a.load(Ordering::Relaxed), 43);
+        assert_eq!(a.compare_exchange_weak(44, 45, Ordering::Relaxed, Ordering::Relaxed), Result::err(43));
+        assert_eq!(a.load(Ordering::Relaxed), 43);
+    }
+
+    #[test]
+    fn test_fetch_add() {
+        let a: Atomic<u32> = Atomic::new(42u32);
+        assert_eq!(a.fetch_add(1, Ordering::Relaxed), 42u32);
+        assert_eq!(a.load(Ordering::Relaxed), 43u32);
+    }
+
+    #[test]
+    fn test_fetch_sub() {
+        let a: Atomic<u32> = Atomic::new(42u32);
+        assert_eq!(a.fetch_sub(1, Ordering::Relaxed), 42u32);
+        assert_eq!(a.load(Ordering::Relaxed), 41u32);
+    }
+
+    #[test]
+    fn test_fetch_and() {
+        let a: Atomic<u32> = Atomic::new(42u32);
+        assert_eq!(a.fetch_and(0xFu32, Ordering::Relaxed), 42u32);
+        assert_eq!(a.load(Ordering::Relaxed), 10u32);
+    }
+
+    #[test]
+    fn test_fetch_or() {
+        let a: Atomic<u32> = Atomic::new(42u32);
+        assert_eq!(a.fetch_or(0xFu32, Ordering::Relaxed), 42u32);
+        assert_eq!(a.load(Ordering::Relaxed), 47u32);
+    }
+
+    #[test]
+    fn test_fetch_xor() {
+        let a: Atomic<u32> = Atomic::new(42u32);
+        assert_eq!(a.fetch_xor(0xFu32, Ordering::Relaxed), 42u32);
+        assert_eq!(a.load(Ordering::Relaxed), 37u32);
+    }
+
+    #[test]
+    fn test_fetch_nand() {
+        let a: Atomic<u32> = Atomic::new(42u32);
+        assert_eq!(a.fetch_nand(0xFu32, Ordering::Relaxed), 42u32);
+        assert_eq!(a.load(Ordering::Relaxed), 0xfffffff5u32);
+    }
+}
+

--- a/sysroot/std/sync.alu
+++ b/sysroot/std/sync.alu
@@ -11,7 +11,7 @@ enum Ordering {
     Acquire = 2,
     Release = 3,
     AcqRel = 4,
-    SeqCst = 5 
+    SeqCst = 5
 }
 
 /// Values that can be operated on atomically.
@@ -43,23 +43,23 @@ impl Atomic<T: Primitive + !ZeroSized> {
         intrinsics::codegen_func::<T>("__atomic_exchange_n", &self.inner, value, ordering as libc::c_int)
     }
 
-    /// Atomically compares the value in the atomic variable to `expected` and, if they are equal, 
+    /// Atomically compares the value in the atomic variable to `expected` and, if they are equal,
     /// sets the atomic variable to `desired`.
     ///
     /// This is the strong version, which will not fail spuriously. See also [compare_exchange_weak].
     #[force_inline]
     fn compare_exchange(
-        self: &mut Atomic<T>, 
-        expected: T, 
-        desired: T, 
-        success_ordering: Ordering, 
+        self: &mut Atomic<T>,
+        expected: T,
+        desired: T,
+        success_ordering: Ordering,
         failure_ordering: Ordering
     ) -> Result<T, T> {
         if intrinsics::codegen_func::<bool>(
-            "__atomic_compare_exchange_n", 
-            &self.inner, 
-            &expected, 
-            desired, 
+            "__atomic_compare_exchange_n",
+            &self.inner,
+            &expected,
+            desired,
             false,
             success_ordering as libc::c_int,
             failure_ordering as libc::c_int
@@ -76,17 +76,17 @@ impl Atomic<T: Primitive + !ZeroSized> {
     /// This is the weak version, which can fail spuriously even when the comparison succeeds.
     #[force_inline]
     fn compare_exchange_weak(
-        self: &mut Atomic<T>, 
-        expected: T, 
-        desired: T, 
-        success_ordering: Ordering, 
+        self: &mut Atomic<T>,
+        expected: T,
+        desired: T,
+        success_ordering: Ordering,
         failure_ordering: Ordering
     ) -> Result<T, T> {
         if intrinsics::codegen_func::<bool>(
-            "__atomic_compare_exchange_n", 
-            &self.inner, 
-            &expected, 
-            desired, 
+            "__atomic_compare_exchange_n",
+            &self.inner,
+            &expected,
+            desired,
             true,
             success_ordering as libc::c_int,
             failure_ordering as libc::c_int
@@ -166,7 +166,7 @@ impl Mutex {
         }
     }
 
-    /// Attempts to acquire a mutex, but does not block. 
+    /// Attempts to acquire a mutex, but does not block.
     ///
     /// Returns `true` if the mutex was successfully acquired, `false` otherwise.
     fn try_lock(self: &mut Mutex) -> bool {
@@ -282,7 +282,7 @@ impl CondVar {
 
     /// Waits on a condition variable with a timeout.
     ///
-    /// Returns `true` if the condition variable was signaled, `false` otherwise. However, since the 
+    /// Returns `true` if the condition variable was signaled, `false` otherwise. However, since the
     /// condition variable can wake up spuriously, it is not guaranteed that the condition is actually
     /// satisfied.
     fn wait_timeout(self: &mut CondVar, mutex: &mut Mutex, timeout: time::Duration) -> bool {
@@ -336,7 +336,7 @@ impl ChannelIterator<T> {
     mixin iter::IteratorExt<ChannelIterator<T>, T>;
 }
 
-/// 
+///
 enum ChannelError {
     Closed,
     WouldBlock
@@ -366,27 +366,27 @@ impl ChannelError {
 /// A simple bounded synchronous channel.
 ///
 /// Uses a ring buffer and [Mutex] and [CondVar] to provide mutual exclusion and signalling.
-/// 
+///
 /// # Example
 /// ```
 /// use std::sync::Channel;
 /// use std::thread::spawn;
-/// 
+///
 /// // Space for 10 elements
 /// let chan: Channel<i32> = Channel::new(5);
-/// 
+///
 /// let t = spawn(|&chan| {
 ///     for i in 0..10 {
 ///         chan.send(i).unwrap();
 ///     }
 ///     chan.close();
 /// });
-/// 
+///
 /// /// Prints all the values.
 /// for i in chan {
 ///     println!("{}", i);
 /// }
-/// 
+///
 /// t.join().unwrap();
 /// ```
 struct Channel<T> {
@@ -422,7 +422,7 @@ impl Channel<T> {
     fn send(self: &mut Channel<T>, value: T) -> Result<(), ChannelError> {
         self._wait(Channel::_send_cond::<T>);
         self._do_send(value)
-    } 
+    }
 
     /// Try to send a value to the channel.
     ///
@@ -430,7 +430,7 @@ impl Channel<T> {
     fn try_send(self: &mut Channel<T>, value: T) -> Result<(), ChannelError> {
         self._try_wait(Channel::_send_cond::<T>)?;
         self._do_send(value)
-    } 
+    }
 
     /// Try to send a value to the channel with a timeout.
     ///
@@ -438,7 +438,7 @@ impl Channel<T> {
     fn send_timeout(self: &mut Channel<T>, value: T, timeout: Duration) -> Result<(), ChannelError> {
         self._wait_timeout(Channel::_send_cond::<T>, timeout)?;
         self._do_send(value)
-    }    
+    }
 
     /// Receive a value from the channel.
     ///
@@ -491,23 +491,23 @@ impl Channel<T> {
         if !self.mutex.try_lock() {
             return Result::err(ChannelError::WouldBlock);
         }
-        
+
         if !cond(self) {
             self.mutex.unlock();
             return Result::err(ChannelError::WouldBlock);
         }
-        
+
         Result::ok(())
     }
 
     fn _wait_timeout<F: Callable<(&Channel<T>), bool>>(self: &mut Channel<T>, cond: F, timeout: Duration) -> Result<(), ChannelError> {
         let start = Instant::now();
-        
-        // timedlock is not available on MacOS. The assumption is that the mutex is 
-        // unlikely to be contended for long enough to matter, so the timeout is just 
+
+        // timedlock is not available on MacOS. The assumption is that the mutex is
+        // unlikely to be contended for long enough to matter, so the timeout is just
         // passed to the condvar.
         self.mutex.lock();
-    
+
         while !cond(self) {
             let remaining = timeout.sub(
                 &Instant::now().duration_since(&start)
@@ -526,11 +526,11 @@ impl Channel<T> {
     fn _recv_cond(self: &Channel<T>) -> bool {
         self.reader != self.writer || self.closed
     }
-    
+
     fn _send_cond(self: &Channel<T>) -> bool {
-        (self.reader != (self.writer + 1) % self.buffer.len) || self.closed 
+        (self.reader != (self.writer + 1) % self.buffer.len) || self.closed
     }
-    
+
     fn _do_recv(self: &mut Channel<T>) -> Result<T, ChannelError> {
         // Don't check self.closed, there may still be items to read
         if self.reader == self.writer {
@@ -553,11 +553,11 @@ impl Channel<T> {
 
         self.buffer[self.writer] = value;
         self.writer = (self.writer + 1) % self.buffer.len;
-        
+
         self.mutex.unlock();
         self.cond.notify_one();
         Result::ok(())
-    } 
+    }
 
     /// @ iter::Iterable::iter
     fn iter(self: &mut Channel<T>) -> ChannelIterator<T> {
@@ -672,7 +672,7 @@ mod test {
         assert_eq!(a.fetch_nand(0xFu32, Ordering::Relaxed), 42u32);
         assert_eq!(a.load(Ordering::Relaxed), 0xfffffff5u32);
     }
-    
+
     #[cfg(threading)]
     #[test]
     fn test_mutex() {
@@ -730,18 +730,18 @@ mod test {
             condvar.notify_one();
         });
 
-        mutex.lock(); 
+        mutex.lock();
         defer mutex.unlock();
 
         assert!(!condvar.wait_timeout(&mutex, time::Duration::zero()));
-        
+
         flag.store(true, Ordering::SeqCst);
         t.thread().unpark();
 
         while counter == 0 {
             condvar.wait(&mutex);
         }
-        
+
         assert_eq!(mutex.try_lock(), false);
 
         t.join().unwrap();

--- a/sysroot/std/sync.alu
+++ b/sysroot/std/sync.alu
@@ -178,22 +178,6 @@ impl Mutex {
         }
     }
 
-    /// Attempts to acquire a mutex with a timeout
-    ///
-    /// Returns `true` if the mutex was successfully acquired, `false` otherwise.
-    fn lock_timeout(self: &mut Mutex, timeout: time::Duration) -> bool {
-        let timespec = libc::timespec {
-            tv_sec: util::cast(timeout.secs),
-            tv_nsec: util::cast(timeout.nanos)
-        }
-        let ret = libc::pthread_mutex_timedlock(&self.inner, &timespec);
-        switch ret {
-            0 => true,
-            libc::ETIMEDOUT => false,
-            _ => panic!("pthread_mutex_timedlock failed: {}", Error::from_errno_custom(ret))
-        }
-    }
-
     /// Releases a mutex.
     fn unlock(self: &mut Mutex) {
         let ret = libc::pthread_mutex_unlock(&self.inner);
@@ -240,22 +224,6 @@ impl RwLock {
         }
     }
 
-    /// Acquires a reader-writer lock for reading with a timeout.
-    ///
-    /// Returns `true` if the lock was successfully acquired, `false` otherwise.
-    fn read_lock_timeout(self: &mut RwLock, timeout: time::Duration) -> bool {
-        let timespec = libc::timespec {
-            tv_sec: util::cast(timeout.secs),
-            tv_nsec: util::cast(timeout.nanos)
-        }
-        let ret = libc::pthread_rwlock_timedrdlock(&self.inner, &timespec);
-        switch ret {
-            0 => true,
-            libc::ETIMEDOUT => false,
-            _ => panic!("pthread_rwlock_timedrdlock failed: {}", Error::from_errno_custom(ret))
-        }
-    }
-
     /// Acquires a reader-writer lock for writing.
     fn write_lock(self: &mut RwLock) {
         let ret = libc::pthread_rwlock_wrlock(&self.inner);
@@ -273,22 +241,6 @@ impl RwLock {
             0 => true,
             libc::EBUSY => false,
             _ => panic!("pthread_rwlock_trywrlock failed: {}", Error::from_errno_custom(ret))
-        }
-    }
-
-    /// Acquires a reader-writer lock for writing with a timeout.
-    ///
-    /// Returns `true` if the lock was successfully acquired, `false` otherwise.
-    fn write_lock_timeout(self: &mut RwLock, timeout: time::Duration) -> bool {
-        let timespec = libc::timespec {
-            tv_sec: util::cast(timeout.secs),
-            tv_nsec: util::cast(timeout.nanos)
-        }
-        let ret = libc::pthread_rwlock_timedwrlock(&self.inner, &timespec);
-        switch ret {
-            0 => true,
-            libc::ETIMEDOUT => false,
-            _ => panic!("pthread_rwlock_timedwrlock failed: {}", Error::from_errno_custom(ret))
         }
     }
 
@@ -550,9 +502,11 @@ impl Channel<T> {
 
     fn _wait_timeout<F: Callable<(&Channel<T>), bool>>(self: &mut Channel<T>, cond: F, timeout: Duration) -> Result<(), ChannelError> {
         let start = Instant::now();
-        if !self.mutex.lock_timeout(timeout) {
-            return Result::err(ChannelError::WouldBlock);
-        }
+        
+        // timedlock is not available on MacOS. The assumption is that the mutex is 
+        // unlikely to be contended for long enough to matter, so the timeout is just 
+        // passed to the condvar.
+        self.mutex.lock();
     
         while !cond(self) {
             let remaining = timeout.sub(

--- a/sysroot/std/sync.alu
+++ b/sysroot/std/sync.alu
@@ -1,7 +1,10 @@
-//! Thread synchronization
+//! Thread synchronization primitives
 
 use std::builtins::{Primitive, ZeroSized, Integer};
 
+/// Memory ordering
+///
+/// Follows C11 memory model ([see here](https://en.cppreference.com/w/c/atomic/memory_order)).
 enum Ordering {
     Relaxed = 0,
     Consume = 1,
@@ -17,25 +20,33 @@ struct Atomic<T: Primitive + !ZeroSized> {
 }
 
 impl Atomic<T: Primitive + !ZeroSized> {
+    /// Create a new `Atomic` value with the given initial value.
     fn new(inner: T) -> Atomic<T> {
         Atomic { inner: inner }
     }
 
+    /// Loads a value from the atomic variable.
     #[force_inline]
     fn load(self: &Atomic<T>, ordering: Ordering) -> T {
         intrinsics::codegen_func::<T>("__atomic_load_n", &self.inner, ordering as libc::c_int)
     }
 
+    /// Stores a value into the atomic variable.
     #[force_inline]
     fn store(self: &mut Atomic<T>, value: T, ordering: Ordering) {
         intrinsics::codegen_func::<void>("__atomic_store_n", &self.inner, value, ordering as libc::c_int)
     }
 
+    /// Stores a value into the atomic variable, atomically returning the old value.
     #[force_inline]
     fn exchange(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
         intrinsics::codegen_func::<T>("__atomic_exchange_n", &self.inner, value, ordering as libc::c_int)
     }
 
+    /// Atomically compares the value in the atomic variable to `expected` and, if they are equal, 
+    /// sets the atomic variable to `desired`.
+    ///
+    /// This is the strong version, which will not fail spuriously. See also [compare_exchange_weak].
     #[force_inline]
     fn compare_exchange(
         self: &mut Atomic<T>, 
@@ -59,6 +70,10 @@ impl Atomic<T: Primitive + !ZeroSized> {
         }
     }
 
+    /// Atomically compares the value in the atomic variable to `expected` and, if they are equal,
+    /// sets the atomic variable to `desired`.
+    ///
+    /// This is the weak version, which can fail spuriously even when the comparison succeeds.
     #[force_inline]
     fn compare_exchange_weak(
         self: &mut Atomic<T>, 
@@ -83,45 +98,530 @@ impl Atomic<T: Primitive + !ZeroSized> {
     }
 }
 
-/// Memory barrier
-fn fence(ordering: Ordering) {
-    intrinsics::codegen_func::<void>("__atomic_thread_fence", ordering as libc::c_int)
-}
-
 impl Atomic<T: Integer> {
+    /// Atomically adds `value` to the atomic variable and returns the old value.
     #[force_inline]
     fn fetch_add(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
         intrinsics::codegen_func::<T>("__atomic_fetch_add", &self.inner, value, ordering as libc::c_int)
     }
 
+    /// Atomically subtracts `value` from the atomic variable and returns the old value.
     #[force_inline]
     fn fetch_sub(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
         intrinsics::codegen_func::<T>("__atomic_fetch_sub", &self.inner, value, ordering as libc::c_int)
     }
 
+    /// Atomically performs `*self &= value` and returns the old value.
     #[force_inline]
     fn fetch_and(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
         intrinsics::codegen_func::<T>("__atomic_fetch_and", &self.inner, value, ordering as libc::c_int)
     }
 
+    /// Atomically performs `*self |= value` and returns the old value.
     #[force_inline]
     fn fetch_or(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
         intrinsics::codegen_func::<T>("__atomic_fetch_or", &self.inner, value, ordering as libc::c_int)
     }
 
+    /// Atomically performs `*self ^= value` and returns the old value.
     #[force_inline]
     fn fetch_xor(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
         intrinsics::codegen_func::<T>("__atomic_fetch_xor", &self.inner, value, ordering as libc::c_int)
     }
 
+    /// Atomically performs `*self = ~(*self & value)` and returns the old value.
     #[force_inline]
     fn fetch_nand(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
         intrinsics::codegen_func::<T>("__atomic_fetch_nand", &self.inner, value, ordering as libc::c_int)
     }
 }
 
+/// Memory barrier
+fn fence(ordering: Ordering) {
+    intrinsics::codegen_func::<void>("__atomic_thread_fence", ordering as libc::c_int)
+}
+
+/// A mutual exclusion lock (mutex)
+///
+/// This is a standard pthread mutex.
+struct Mutex {
+    inner: libc::pthread_mutex_t
+}
+
+impl Mutex {
+    use std::io::Error;
+
+    /// Creates a new mutex.
+    fn new() -> Mutex {
+        Mutex {
+            inner: libc::pthread_mutex_initializer()
+        }
+    }
+
+    /// Acquires a mutex, blocking the current thread until it can acquire it.
+    fn lock(self: &mut Mutex) {
+        let ret = libc::pthread_mutex_lock(&self.inner);
+        if ret != 0 {
+            panic!("pthread_mutex_lock failed: {}", Error::from_errno_custom(ret));
+        }
+    }
+
+    /// Attempts to acquire a mutex, but does not block. 
+    ///
+    /// Returns `true` if the mutex was successfully acquired, `false` otherwise.
+    fn try_lock(self: &mut Mutex) -> bool {
+        let ret = libc::pthread_mutex_trylock(&self.inner);
+        switch ret {
+            0 => true,
+            libc::EBUSY => false,
+            _ => panic!("pthread_mutex_trylock failed: {}", Error::from_errno_custom(ret))
+        }
+    }
+
+    /// Attempts to acquire a mutex with a timeout
+    ///
+    /// Returns `true` if the mutex was successfully acquired, `false` otherwise.
+    fn lock_timeout(self: &mut Mutex, timeout: time::Duration) -> bool {
+        let timespec = libc::timespec {
+            tv_sec: util::cast(timeout.secs),
+            tv_nsec: util::cast(timeout.nanos)
+        }
+        let ret = libc::pthread_mutex_timedlock(&self.inner, &timespec);
+        switch ret {
+            0 => true,
+            libc::ETIMEDOUT => false,
+            _ => panic!("pthread_mutex_timedlock failed: {}", Error::from_errno_custom(ret))
+        }
+    }
+
+    /// Releases a mutex.
+    fn unlock(self: &mut Mutex) {
+        let ret = libc::pthread_mutex_unlock(&self.inner);
+        if ret != 0 {
+            panic!("pthread_mutex_unlock failed: {}", Error::from_errno_custom(ret));
+        }
+    }
+}
+
+/// Reader-writer lock
+///
+/// This is a standard pthread rwlock.
+struct RwLock {
+    inner: libc::pthread_rwlock_t
+}
+
+impl RwLock {
+    use std::io::Error;
+
+    /// Creates a new reader-writer lock.
+    fn new() -> RwLock {
+        RwLock {
+            inner: libc::pthread_rwlock_initializer()
+        }
+    }
+
+    /// Acquires a reader-writer lock for reading.
+    fn read_lock(self: &mut RwLock) {
+        let ret = libc::pthread_rwlock_rdlock(&self.inner);
+        if ret != 0 {
+            panic!("pthread_rwlock_rdlock failed: {}", Error::from_errno_custom(ret));
+        }
+    }
+
+    /// Attempts to acquire a reader-writer lock for reading.
+    ///
+    /// Returns `true` if the lock was successfully acquired, `false` otherwise.
+    fn try_read_lock(self: &mut RwLock) -> bool {
+        let ret = libc::pthread_rwlock_tryrdlock(&self.inner);
+        switch ret {
+            0 => true,
+            libc::EBUSY => false,
+            _ => panic!("pthread_rwlock_tryrdlock failed: {}", Error::from_errno_custom(ret))
+        }
+    }
+
+    /// Acquires a reader-writer lock for reading with a timeout.
+    ///
+    /// Returns `true` if the lock was successfully acquired, `false` otherwise.
+    fn read_lock_timeout(self: &mut RwLock, timeout: time::Duration) -> bool {
+        let timespec = libc::timespec {
+            tv_sec: util::cast(timeout.secs),
+            tv_nsec: util::cast(timeout.nanos)
+        }
+        let ret = libc::pthread_rwlock_timedrdlock(&self.inner, &timespec);
+        switch ret {
+            0 => true,
+            libc::ETIMEDOUT => false,
+            _ => panic!("pthread_rwlock_timedrdlock failed: {}", Error::from_errno_custom(ret))
+        }
+    }
+
+    /// Acquires a reader-writer lock for writing.
+    fn write_lock(self: &mut RwLock) {
+        let ret = libc::pthread_rwlock_wrlock(&self.inner);
+        if ret != 0 {
+            panic!("pthread_rwlock_wrlock failed: {}", Error::from_errno_custom(ret));
+        }
+    }
+
+    /// Attempts to acquire a reader-writer lock for writing.
+    ///
+    /// Returns `true` if the lock was successfully acquired, `false` otherwise.
+    fn try_write_lock(self: &mut RwLock) -> bool {
+        let ret = libc::pthread_rwlock_trywrlock(&self.inner);
+        switch ret {
+            0 => true,
+            libc::EBUSY => false,
+            _ => panic!("pthread_rwlock_trywrlock failed: {}", Error::from_errno_custom(ret))
+        }
+    }
+
+    /// Acquires a reader-writer lock for writing with a timeout.
+    ///
+    /// Returns `true` if the lock was successfully acquired, `false` otherwise.
+    fn write_lock_timeout(self: &mut RwLock, timeout: time::Duration) -> bool {
+        let timespec = libc::timespec {
+            tv_sec: util::cast(timeout.secs),
+            tv_nsec: util::cast(timeout.nanos)
+        }
+        let ret = libc::pthread_rwlock_timedwrlock(&self.inner, &timespec);
+        switch ret {
+            0 => true,
+            libc::ETIMEDOUT => false,
+            _ => panic!("pthread_rwlock_timedwrlock failed: {}", Error::from_errno_custom(ret))
+        }
+    }
+
+    /// Releases a reader-writer lock.
+    fn unlock(self: &mut RwLock) {
+        let ret = libc::pthread_rwlock_unlock(&self.inner);
+        if ret != 0 {
+            panic!("pthread_rwlock_unlock failed: {}", Error::from_errno_custom(ret));
+        }
+    }
+}
+
+/// Condition variable
+///
+/// This is a standard pthread condition variable.
+struct CondVar {
+    inner: libc::pthread_cond_t
+}
+
+impl CondVar {
+    use std::io::Error;
+
+    /// Creates a new condition variable.
+    fn new() -> CondVar {
+        CondVar {
+            inner: libc::pthread_cond_initializer()
+        }
+    }
+
+    /// Waits on a condition variable.
+    ///
+    /// May return spuriously.
+    fn wait(self: &mut CondVar, mutex: &mut Mutex) {
+        let ret = libc::pthread_cond_wait(&self.inner, &mutex.inner);
+        if ret != 0 {
+            panic!("pthread_cond_wait failed: {}", Error::from_errno_custom(ret));
+        }
+    }
+
+    /// Waits on a condition variable with a timeout.
+    ///
+    /// Returns `true` if the condition variable was signaled, `false` otherwise. However, since the 
+    /// condition variable can wake up spuriously, it is not guaranteed that the condition is actually
+    /// satisfied.
+    fn wait_timeout(self: &mut CondVar, mutex: &mut Mutex, timeout: time::Duration) -> bool {
+        let timespec = libc::timespec {
+            tv_sec: util::cast(timeout.secs),
+            tv_nsec: util::cast(timeout.nanos)
+        }
+        let ret = libc::pthread_cond_timedwait(&self.inner, &mutex.inner, &timespec);
+        switch ret {
+            0 => true,
+            libc::ETIMEDOUT => false,
+            _ => panic!("pthread_cond_timedwait failed: {}", Error::from_errno_custom(ret))
+        }
+    }
+
+    /// Signals a condition variable, waking up one waiting thread.
+    fn notify_one(self: &mut CondVar) {
+        let ret = libc::pthread_cond_signal(&self.inner);
+        if ret != 0 {
+            panic!("pthread_cond_signal failed: {}", Error::from_errno_custom(ret));
+        }
+    }
+
+    /// Signals a condition variable, waking up all waiting threads.
+    fn notify_all(self: &mut CondVar) {
+        let ret = libc::pthread_cond_broadcast(&self.inner);
+        if ret != 0 {
+            panic!("pthread_cond_broadcast failed: {}", Error::from_errno_custom(ret));
+        }
+    }
+}
+
+/// Iterator over values of [Channel].
+struct ChannelIterator<T> {
+    inner: &mut Channel<T>
+}
+
+impl ChannelIterator<T> {
+    /// @ iter::Iterator::next
+    fn next(self: &mut ChannelIterator<T>) -> Option<T> {
+        let ret = self.inner.recv();
+        if ret.is_ok {
+            Option::some(ret.inner.ok)
+        } else {
+            assert_eq!(ret.inner.err, ChannelError::Closed);
+            Option::none()
+        }
+    }
+
+    mixin iter::Iterator<ChannelIterator<T>, T>;
+    mixin iter::IteratorExt<ChannelIterator<T>, T>;
+}
+
+/// 
+enum ChannelError {
+    Closed,
+    WouldBlock
+}
+
+impl ChannelError {
+    use fmt::{write, Formattable, Formatter, Result};
+    use cmp::Equatable;
+
+    /// @ Equatable::equals
+    fn equals(self: &ChannelError, other: &ChannelError) -> bool {
+        *self as i32 == *other as i32
+    }
+
+    /// @ Formattable::fmt
+    fn fmt<F: Formatter<F>>(self: &ChannelError, f: &mut F) -> Result {
+        switch *self {
+            ChannelError::Closed => write!(f, "channel closed"),
+            ChannelError::WouldBlock => write!(f, "channel would block")
+            _ => unreachable!()
+        }
+    }
+
+    mixin cmp::Equatable<ChannelError>;
+}
+
+/// A simple bounded synchronous channel.
+///
+/// Uses a ring buffer and [Mutex] and [CondVar] to provide mutual exclusion and signalling.
+/// 
+/// # Example
+/// ```
+/// use std::sync::Channel;
+/// use std::thread::spawn;
+/// 
+/// // Space for 10 elements
+/// let chan: Channel<i32> = Channel::new(5);
+/// 
+/// let t = spawn(|&chan| {
+///     for i in 0..10 {
+///         chan.send(i).unwrap();
+///     }
+///     chan.close();
+/// });
+/// 
+/// /// Prints all the values.
+/// for i in chan {
+///     println!("{}", i);
+/// }
+/// 
+/// t.join().unwrap();
+/// ```
+struct Channel<T> {
+    mutex: Mutex,
+    cond: CondVar,
+    buffer: &mut [T],
+    closed: bool,
+    reader: usize,
+    writer: usize
+}
+
+impl Channel<T> {
+    use time::{Instant, Duration};
+    use builtins::Callable;
+
+    /// Creates a new channel with a given capacity
+    fn new(capacity: usize) -> Channel<T> {
+        assert!(capacity >= 1);
+
+        Channel {
+            mutex: Mutex::new(),
+            cond: CondVar::new(),
+            buffer: mem::alloc::<T>(capacity + 1),
+            closed: false,
+            reader: 0,
+            writer: 0,
+        }
+    }
+
+    /// Send a value to the channel.
+    ///
+    /// This function will block if the channel is full.
+    fn send(self: &mut Channel<T>, value: T) -> Result<(), ChannelError> {
+        self._wait(Channel::_send_cond::<T>);
+        self._do_send(value)
+    } 
+
+    /// Try to send a value to the channel.
+    ///
+    /// If the channel is full, this function will return `Result::err(ChannelError::WouldBlock)`.
+    fn try_send(self: &mut Channel<T>, value: T) -> Result<(), ChannelError> {
+        self._try_wait(Channel::_send_cond::<T>)?;
+        self._do_send(value)
+    } 
+
+    /// Try to send a value to the channel with a timeout.
+    ///
+    /// If the channel is full, this function will return `Result::err(ChannelError::WouldBlock)`.
+    fn send_timeout(self: &mut Channel<T>, value: T, timeout: Duration) -> Result<(), ChannelError> {
+        self._wait_timeout(Channel::_send_cond::<T>, timeout)?;
+        self._do_send(value)
+    }    
+
+    /// Receive a value from the channel.
+    ///
+    /// This function will block if the channel is empty.
+    fn recv(self: &mut Channel<T>) -> Result<T, ChannelError> {
+        self._wait(Channel::_recv_cond::<T>);
+        self._do_recv()
+    }
+
+    /// Try to receive a value from the channel.
+    ///
+    /// If the channel is empty, this function will return `Result::err(ChannelError::WouldBlock)`.
+    fn try_recv(self: &mut Channel<T>) -> Result<T, ChannelError>  {
+        self._try_wait(Channel::_recv_cond::<T>)?;
+        self._do_recv()
+    }
+
+    /// Try to receive a value from the channel with a timeout.
+    ///
+    /// If the channel is empty, this function will return `Result::err(ChannelError::WouldBlock)`.
+    fn recv_timeout(self: &mut Channel<T>, timeout: Duration) -> Result<T, ChannelError> {
+        self._wait_timeout(Channel::_recv_cond::<T>, timeout)?;
+        self._do_recv()
+    }
+
+    /// Close the channel.
+    ///
+    /// All subsequent calls to `send` or `recv` (or their variants) will return `Result::err(ChannelError::Closed)`.
+    fn close(self: &mut Channel<T>) {
+        self.mutex.lock();
+        let cond = self.reader == self.writer;
+        self.closed = true;
+        self.mutex.unlock();
+
+        if cond {
+            self.cond.notify_all();
+        } else {
+            self.cond.notify_one();
+        }
+    }
+
+    fn _wait<F: Callable<(&Channel<T>), bool>>(self: &mut Channel<T>, cond: F) {
+        self.mutex.lock();
+        while !cond(self) {
+            self.cond.wait(&self.mutex);
+        }
+    }
+
+    fn _try_wait<F: Callable<(&Channel<T>), bool>>(self: &mut Channel<T>, cond: F) -> Result<(), ChannelError> {
+        if !self.mutex.try_lock() {
+            return Result::err(ChannelError::WouldBlock);
+        }
+        
+        if !cond(self) {
+            self.mutex.unlock();
+            return Result::err(ChannelError::WouldBlock);
+        }
+        
+        Result::ok(())
+    }
+
+    fn _wait_timeout<F: Callable<(&Channel<T>), bool>>(self: &mut Channel<T>, cond: F, timeout: Duration) -> Result<(), ChannelError> {
+        let start = Instant::now();
+        if !self.mutex.lock_timeout(timeout) {
+            return Result::err(ChannelError::WouldBlock);
+        }
+    
+        while !cond(self) {
+            let remaining = timeout.sub(
+                &Instant::now().duration_since(&start)
+            );
+
+            if remaining.negative() {
+                self.mutex.unlock();
+                return Result::err(ChannelError::WouldBlock);
+            }
+            self.cond.wait_timeout(&self.mutex, remaining);
+        }
+
+        Result::ok(())
+    }
+
+    fn _recv_cond(self: &Channel<T>) -> bool {
+        self.reader != self.writer || self.closed
+    }
+    
+    fn _send_cond(self: &Channel<T>) -> bool {
+        (self.reader != (self.writer + 1) % self.buffer.len) || self.closed 
+    }
+    
+    fn _do_recv(self: &mut Channel<T>) -> Result<T, ChannelError> {
+        // Don't check self.closed, there may still be items to read
+        if self.reader == self.writer {
+            self.mutex.unlock();
+            return Result::err(ChannelError::Closed);
+        }
+
+        let value = self.buffer[self.reader];
+        self.reader = (self.reader + 1) % self.buffer.len;
+        self.mutex.unlock();
+        self.cond.notify_one();
+        Result::ok(value)
+    }
+
+    fn _do_send(self: &mut Channel<T>, value: T) -> Result<(), ChannelError> {
+        if self.closed {
+            self.mutex.unlock();
+            return Result::err(ChannelError::Closed);
+        }
+
+        self.buffer[self.writer] = value;
+        self.writer = (self.writer + 1) % self.buffer.len;
+        
+        self.mutex.unlock();
+        self.cond.notify_one();
+        Result::ok(())
+    } 
+
+    /// @ iter::Iterable::iter
+    fn iter(self: &mut Channel<T>) -> ChannelIterator<T> {
+        ChannelIterator {
+            inner: self
+        }
+    }
+
+    /// @ mem::Freeable::free
+    fn free(self: &mut Channel<T>) {
+        mem::free(self.buffer);
+    }
+}
+
 #[cfg(all(test, test_std))]
 mod test {
+    use time::Duration;
+
     #[test]
     fn test_ordering_values_match() {
         // This test asserts that the ordering constant values we hardcode above match the
@@ -217,6 +717,123 @@ mod test {
         let a: Atomic<u32> = Atomic::new(42u32);
         assert_eq!(a.fetch_nand(0xFu32, Ordering::Relaxed), 42u32);
         assert_eq!(a.load(Ordering::Relaxed), 0xfffffff5u32);
+    }
+    
+    #[cfg(threading)]
+    #[test]
+    fn test_mutex() {
+        let a = Mutex::new();
+        a.lock();
+        assert_eq!(a.try_lock(), false);
+        a.unlock();
+        assert_eq!(a.try_lock(), true);
+        a.unlock();
+    }
+
+    #[cfg(threading)]
+    #[test]
+    fn test_rwlock() {
+        let a = RwLock::new();
+        a.read_lock();
+        assert_eq!(a.try_read_lock(), true);
+        assert_eq!(a.try_write_lock(), false);
+        a.unlock();
+        a.unlock();
+
+        a.write_lock();
+        assert_eq!(a.try_read_lock(), false);
+        assert_eq!(a.try_write_lock(), false);
+        a.unlock();
+    }
+
+    #[cfg(threading)]
+    #[test]
+    fn test_condvar() {
+        let counter = 0;
+
+        let flag = Atomic::new(false);
+
+        let mutex = Mutex::new();
+        let condvar = CondVar::new();
+
+        let t = thread::spawn(|&counter, &condvar, &mutex, &flag| {
+            /// Ensure the main thread gets the mutex first;
+            while !flag.load(Ordering::SeqCst) {
+                thread::yield();
+            }
+
+            mutex.lock();
+            defer mutex.unlock();
+
+            counter += 1;
+            condvar.notify_one();
+        });
+
+        mutex.lock(); 
+        defer mutex.unlock();
+
+        assert!(!condvar.wait_timeout(&mutex, time::Duration::zero()));
+        
+        flag.store(true, Ordering::SeqCst);
+
+        while counter == 0 {
+            condvar.wait(&mutex);
+        }
+        
+        assert_eq!(mutex.try_lock(), false);
+
+        t.join().unwrap();
+        assert_eq!(counter, 1);
+    }
+
+    #[cfg(threading)]
+    #[test]
+    fn test_channel() {
+        let chan: Channel<i32> = Channel::new(3);
+        assert_eq!(chan.send(42), Result::ok(()));
+        assert_eq!(chan.recv(), Result::ok(42));
+    }
+
+    #[cfg(threading)]
+    #[test]
+    fn test_channel_closed() {
+        let chan: Channel<i32> = Channel::new(3);
+        assert_eq!(chan.send(42), Result::ok(()));
+        assert_eq!(chan.send(42), Result::ok(()));
+        chan.close();
+
+        assert_eq!(chan.send(42), Result::err(ChannelError::Closed));
+        assert_eq!(chan.recv(), Result::ok(42));
+        assert_eq!(chan.recv(), Result::ok(42));
+        assert_eq!(chan.recv(), Result::err(ChannelError::Closed));
+    }
+
+    #[cfg(threading)]
+    #[test]
+    fn test_channel_try() {
+        let chan: Channel<i32> = Channel::new(3);
+        assert_eq!(chan.try_send(42), Result::ok(()));
+        assert_eq!(chan.try_send(42), Result::ok(()));
+        assert_eq!(chan.try_send(42), Result::ok(()));
+        assert_eq!(chan.try_send(42), Result::err(ChannelError::WouldBlock));
+        assert_eq!(chan.try_recv(), Result::ok(42));
+        assert_eq!(chan.try_recv(), Result::ok(42));
+        assert_eq!(chan.try_recv(), Result::ok(42));
+        assert_eq!(chan.try_recv(), Result::err(ChannelError::WouldBlock));
+    }
+
+    #[cfg(threading)]
+    #[test]
+    fn test_channel_timeout() {
+        let chan: Channel<i32> = Channel::new(3);
+        assert_eq!(chan.send_timeout(42, Duration::zero()), Result::ok(()));
+        assert_eq!(chan.send_timeout(42, Duration::zero()), Result::ok(()));
+        assert_eq!(chan.send_timeout(42, Duration::zero()), Result::ok(()));
+        assert_eq!(chan.send_timeout(42, Duration::zero()), Result::err(ChannelError::WouldBlock));
+        assert_eq!(chan.recv_timeout(Duration::zero()), Result::ok(42));
+        assert_eq!(chan.recv_timeout(Duration::zero()), Result::ok(42));
+        assert_eq!(chan.recv_timeout(Duration::zero()), Result::ok(42));
+        assert_eq!(chan.recv_timeout(Duration::zero()), Result::err(ChannelError::WouldBlock));
     }
 }
 

--- a/sysroot/std/thread.alu
+++ b/sysroot/std/thread.alu
@@ -1,9 +1,10 @@
-//! Threading support
+//! Multi-threading support
+//!
+//! See also the [std::sync] module for synchronization primitives.
 
 use std::builtins::Callable;
-use std::time::sleep;
-use std::time::Duration;
 use std::io::Error;
+use std::sync::{Atomic, Ordering};
 
 enum JoinErrorKind {
     Os,
@@ -15,6 +16,9 @@ union JoinErrorT {
     panic: std::panicking::PanicInfo
 }
 
+/// An error returned from [JoinHandle::join]
+///
+/// It can represent either a panic or an OS error.
 struct JoinError {
     kind: JoinErrorKind,
     inner: JoinErrorT
@@ -54,42 +58,39 @@ impl JoinError {
     }
 }
 
-struct JoinHandleInner<T> {
-    thread: Thread,
-    ret: Result<T, std::panicking::PanicInfo>,
-}
-
-struct JoinHandleInnerFunc<F, T> {
-    inner: JoinHandleInner<T>,
-    callback: F
-}
-
-impl JoinHandleInnerFunc {
-    fn _run<T, F: Callable<(), T>>(arg: &mut void) -> &mut void {
-        let inner = arg as &mut JoinHandleInnerFunc<F, T>;
-        std::panicking::internal::THREAD_PANIC_INFO = &inner.inner.ret.inner.err;
-        inner.inner.ret = Result::ok(inner.callback());
-        libc::pthread_exit(null);
-    }
-}
-
+/// A handle that allows to wait for the thread to finish.
+/// 
+/// Each `JoinHandle` must be either joined or detached before it goes out of scope.
+/// Failure to do so will result in a resource leak.
 struct JoinHandle<T> {
-    inner: &mut JoinHandleInner<T>,
+    _thread_id: libc::pthread_t,
+    _handle: &mut internal::ThreadHandle<T>,
 }
 
 impl JoinHandle<T> {
+    /// Waits for the associated thread to finish.
+    ///
+    /// Returns the return value of the thread function if the thread ran to completion.
+    /// It it panicked or was killed, it returns an error variant of `JoinError`.
+    /// 
+    /// Joining a thread that has already been joined or detached is undefined behavior.
     fn join(self: &mut JoinHandle<T>) -> Result<T, JoinError> {
-        let handle = &self.inner;
+        assert!(self._handle != null);
+        let handle = &self._handle;
 
         let exit_value: &mut void;
-        let ret = libc::pthread_join(handle.thread.id, &exit_value);
+        let ret = libc::pthread_join(self._thread_id, &exit_value);
         if ret != 0 {
             return Result::err(JoinError::from_os(Error::from_errno_custom(ret)));
         }
 
-        defer self.free(); 
-        if self.inner.ret.is_ok {
-            Result::ok(self.inner.ret.inner.ok)
+        defer {
+            libc::free(self._handle as &mut void); 
+            self._handle = null;
+        };
+
+        if handle.ret.is_ok {
+            Result::ok(handle.ret.inner.ok)
         } else {
             Result::err(if exit_value == &handle.ret.inner.err as &mut void {
                 JoinError::from_panic(handle.ret.inner.err)
@@ -100,68 +101,301 @@ impl JoinHandle<T> {
         }
     }
 
-    fn thread(self: &mut JoinHandle<T>) -> Thread {
-        self.inner.thread
-    }
+    /// Detaches the thread, letting it run in background.
+    ///
+    /// After the thread finishes, the resources associated with it will be freed automatically.
+    /// If a detached thread panics, the process will terminate.
+    ///
+    /// Detaching a thread that has already been joined or detached is undefined behavior.
+    fn detach(self: &mut JoinHandle<T>) {
+        assert!(self._handle != null);
+        let handle = &self._handle;
 
-    fn move(self: &mut JoinHandle<T>) -> JoinHandle<T> {
-        let ret = *self;
-        self.inner = null;
-        ret
-    } 
+        // We may be detaching a thread before the entry function populated `pi_addr` with the
+        // address of the thread-local PanicInfo handler. In this case we just override it with
+        // a sentinel value (usize::max_value()). In this case we do not free the handle, since
+        // the thread still needs to be able to read it. Thread will free it after it CAS-es the 
+        // `pi_addr`.
+        let pi_addr = handle.pi_addr.exchange(util::cast(usize::max_value()), Ordering::SeqCst);
+        if pi_addr == null {
+            self._handle = null; // Just clear, don't free.
+        } else {
+            defer {
+                libc::free(self._handle as &mut void);
+                self._handle = null;
+            };
 
-    fn free(self: &mut JoinHandle<T>) {
-        libc::free(self.inner as &mut void)
-    } 
-}
+            // Clear the thread's panic info so that if it panics, the process
+            // is terminated.
+            let panic_info = pi_addr.exchange(null, Ordering::SeqCst);
+            if (panic_info == null) {
+                let exit_value: &mut void;
+                let ret = libc::pthread_join(self._thread_id, &exit_value);
+                if ret != 0 {
+                    panic!("pthread_join failed: ", Error::from_errno_custom(ret));
+                } else if exit_value == &handle.ret.inner.err as &mut void {
+                    panic!("thread panicked at {}:{}:{}",
+                        handle.ret.inner.err.file,
+                        handle.ret.inner.err.line,
+                        handle.ret.inner.err.column
+                    );
+                } else {
+                    // Thread already successfully finished, clean up.
+                    return;
+                }
+            }
+        } 
 
-struct Thread {
-    id: libc::pthread_t
-}
-
-impl Thread {
-    fn current() -> Thread {
-        Thread {
-            id: libc::pthread_self()
-        }
-    }
-
-    fn spawn<T, F: Callable<(), T>>(func: F) -> JoinHandle<T> {
-        #[cfg(not(threading))]
-        compile_fail!("threading is not enabled (use --cfg threading)");
-
-        let handle = std::mem::new::<JoinHandleInnerFunc<F, T>>();
-        handle.callback = func;
-        handle.inner.ret = Result::err(mem::zeroed());
-
-        let ret = libc::pthread_create(
-            &handle.inner.thread.id, 
-            null, 
-            JoinHandleInnerFunc::_run::<T, F>, 
-            handle as &mut void
-        );
+        let ret = libc::pthread_detach(self._thread_id);
         if ret != 0 {
-            panic!("failed to create thread");
-        }
-
-        JoinHandle {
-           inner: handle as &mut JoinHandleInner<T>,
+            panic!("pthread_detach failed: {}", Error::from_errno_custom(ret));
         }
     }
+}
+
+/// Spawn a new thread.
+///
+/// The thread will execute the given function and then terminate. `spawn` returns a [JoinHandle], which
+/// can be used to join the thread and retreive the value that the thread returned.
+///
+/// # Example
+/// ```
+/// use std::thread::{spawn, sleep};
+/// use std::time::Duration;
+/// 
+/// let text = "The quick brown fox jumps over the lazy dog";
+/// 
+/// let t = spawn(|=text| -> usize {
+///     // pretend that calculating the length is expensive
+///     sleep(Duration::from_secs(1)); 
+///     text.len
+/// });
+///
+/// println!("Calculating length of {}", text);
+/// println!("Length is {}", t.join().unwrap());
+/// ```
+///
+/// # Panic handling
+///
+/// If the child thread panics, the process is not terminated automatically. Instead, the 
+/// [JoinHandle::join] function will return a [JoinError] with the panic information.
+/// 
+/// If a thread is [detached](JoinHandle::detach), a panic in the thread will terminate the process.
+fn spawn<T, F: Callable<(), T>>(func: F) -> JoinHandle<T> {
+    #[cfg(not(threading))]
+    compile_fail!("threading is not enabled (use --cfg threading)");
+
+    let handle = std::mem::new::<internal::ThreadHandleFunc<F, T>>();
+    handle.inner.pi_addr = Atomic::new(null as &mut Atomic<&mut std::panicking::PanicInfo>);
+    handle.inner.ret = Result::err(mem::zeroed());
+    handle.callback = func;
+
+    let thread_id: libc::pthread_t;
+    let ret = libc::pthread_create(
+        &thread_id, 
+        null,
+        internal::_run_thread::<T, F>, 
+        handle as &mut void
+    );
+    if ret != 0 {
+        panic!("pthread_create failed: {}", Error::from_errno_custom(ret));
+    }
+
+    JoinHandle {
+        _thread_id: thread_id,
+       _handle: handle as &mut internal::ThreadHandle<T>,
+    }
+}
+
+/// Yields the execution of the current thread.
+///
+/// You probably don't want to use this in a spin-lock.
+fn yield() {
+    libc::sched_yield();
+}
+
+/// Suspends thread execution for the specified duration.
+///
+/// The sleep may sleep for less than the specified time if interrupted by a
+/// signal.
+fn sleep(duration: time::Duration) {
+    if duration < time::Duration::zero() {
+        return;
+    }
+
+    libc::nanosleep(&libc::timespec {
+        tv_sec: util::cast(duration.secs),
+        tv_nsec: util::cast(duration.nanos)
+    }, null);
 }
 
 mod internal {
-    macro pthread_try($expr) {
-        let ret = $expr;
-        if ret != 0 {
-            return std::result::Result::err(
-                std::io::Error::from_errno_custom(ret)
-            )
+    /// A heap-allocated additional data associated with an Alumina thread
+    ///
+    /// `pi_addr` represents the address of the thread-local PanicInfo handler and ret
+    /// is the storage for the thread's return value (or panic info). We need this in 
+    /// order to be able to make the child thread propagate the panic in case we detach
+    /// the thread early.
+    struct ThreadHandle<T> {
+        pi_addr: Atomic<&mut Atomic<&mut std::panicking::PanicInfo>>,
+        ret: Result<T, std::panicking::PanicInfo>,
+    }
+    
+    /// An aliased version of [ThreadHandle] that also contains the function to be called.
+    ///
+    /// If the function is not a closure (or a function pointer), then `F` is zero-sized 
+    /// and this struct has identical layout to [ThreadHandle], otherwise it will contain 
+    /// the captured variables.  This aliasing allows us to type-erase the thread function 
+    /// and not have to carry the function type in [JoinHandle].
+    struct ThreadHandleFunc<F, T> {
+        inner: ThreadHandle<T>,
+        callback: F
+    }
+    
+    /// Wrapper over the user-provided thread function
+    ///
+    /// This is the function that gets passed to `pthread_create` and it is responsible
+    /// for setting up the panic handler and storing the return value of the thread.
+    fn _run_thread<T, F: Callable<(), T>>(arg: &mut void) -> &mut void {
+        let handle_func = arg as &mut ThreadHandleFunc<F, T>;
+        let callback = handle_func.callback;
+        let handle = &handle_func.inner;
+
+        // TODO: is this fence really necessary? I do it so that the callback that we copied is not 
+        // reordered after the `compare_exchange` below.
+        std::sync::fence(Ordering::SeqCst);
+
+        let pi_addr = &panicking::internal::THREAD_PANIC_INFO;
+        pi_addr.store(&handle.ret.inner.err, Ordering::SeqCst);
+
+        // After `compare_exchange` finishes, ThreadHandle is no longer guaranteed to be valid.
+        if handle.pi_addr.compare_exchange(null, pi_addr, Ordering::SeqCst, Ordering::SeqCst).is_ok {
+            let ret = callback();
+            // Detaching the thread will clear THREAD_PANIC_INFO, which means the space
+            // for storing the result may already be freed. In this case we just ignore it.
+            if pi_addr.exchange(null, Ordering::SeqCst) != null {
+                handle.ret = Result::ok(ret);
+            }
+        } else {
+            // Thread was detached before we reached this point, we are responsible for cleaning up
+            // the handle.
+            pi_addr.store(null, Ordering::SeqCst);
+            libc::free(arg);
+            callback();
         }
+
+        null
     }
 }
 
-#[cfg(all(test, test_std))]
-mod tests {
 
+#[cfg(all(threading, test, test_std))]
+mod tests {
+    use time::Duration;
+
+    macro set($flag) {
+        $flag.store(true, Ordering::SeqCst)
+    }
+
+    macro wait_for($flag) {
+        while !$flag.load(Ordering::SeqCst) {
+            yield();
+        } 
+    }
+
+    #[test]
+    fn test_spawn() {
+        let t = spawn(|| -> i32 { 42 });
+        assert_eq!(t.join().unwrap(), 42);
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    extern "C" fn syscall(num: libc::c_long, ...) -> libc::c_long;
+
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    #[test]
+    fn test_spawn_manual_exit() {
+        let t = spawn(|| -> i32 { 
+            /// call just SYS_exit without SYS_exit_group
+            syscall(60, 0 as libc::c_int); 
+            unreachable!() 
+        });
+        
+        t.join().unwrap_err();
+    }
+
+    #[test]
+    fn test_panic() {
+        let t = spawn(|| -> i32 { panic!("panic") });
+        
+        t.join().unwrap_err();
+    }
+
+
+    #[test]
+    fn test_detach() {
+        let t = spawn(|| -> i32 { 42 });
+        t.detach();
+    }
+
+    #[test]
+    fn test_detach_finished() {
+        let t = spawn(|| -> i32 { 42 });
+        
+        while !t._handle.ret.is_ok {
+            yield();
+            sync::fence(Ordering::SeqCst);
+        }
+
+        t.detach();
+    }
+
+    #[test(should_fail)]
+    fn test_detach_panic() {
+        let flag = Atomic::new(false);
+        let t = spawn(|&flag| -> i32 { 
+            wait_for!(flag);
+            panic!("panic") 
+        });
+        t.detach();
+        set!(flag);
+        
+        // We will only sleep if the detached process does not in fact terminate
+        // the process when it panics.
+        sleep(Duration::from_secs(1));
+    }
+
+    #[test(should_fail)]
+    fn test_detach_panic_2() {
+        let flag = Atomic::new(false);
+        let t = spawn(|&flag| -> i32 { 
+            set!(flag);
+            panic!("panic") 
+        });
+        wait_for!(flag);
+        t.detach();
+        
+        // We will only sleep if the detached process does not in fact terminate
+        // the process when it panics.
+        sleep(Duration::from_secs(1));
+    }
+
+    #[test(should_fail)]
+    fn test_detach_panic_3() {
+        let flag1 = Atomic::new(false);
+        let flag2 = Atomic::new(false);
+
+        let t = spawn(|&flag1, &flag2| -> i32 { 
+            set!(flag1);
+            wait_for!(flag2);
+            panic!("panic") 
+        });
+        wait_for!(flag1);
+        t.detach();
+        set!(flag2);
+        
+        // We will only sleep if the detached process does not in fact terminate
+        // the process when it panics.
+        sleep(Duration::from_secs(1));
+    }
 }

--- a/sysroot/std/thread.alu
+++ b/sysroot/std/thread.alu
@@ -1,0 +1,167 @@
+//! Threading support
+
+use std::builtins::Callable;
+use std::time::sleep;
+use std::time::Duration;
+use std::io::Error;
+
+enum JoinErrorKind {
+    Os,
+    Panic
+}
+
+union JoinErrorT {
+    os: std::io::Error,
+    panic: std::panicking::PanicInfo
+}
+
+struct JoinError {
+    kind: JoinErrorKind,
+    inner: JoinErrorT
+}
+
+impl JoinError {
+    use fmt::{Formatter, Result, write};
+
+    fn from_os(os: std::io::Error) -> JoinError {
+        JoinError {
+            kind: JoinErrorKind::Os,
+            inner: JoinErrorT {
+                os: os
+            }
+        }
+    }
+
+    fn from_panic(panic: std::panicking::PanicInfo) -> JoinError {
+        JoinError {
+            kind: JoinErrorKind::Panic,
+            inner: JoinErrorT {
+                panic: panic
+            }
+        }
+    }
+
+    fn fmt<F: Formatter<F>>(self: &JoinError, f: &mut F) -> Result {
+        switch self.kind {
+            JoinErrorKind::Os => self.inner.os.fmt(f),
+            JoinErrorKind::Panic => write!(f, "child thread panicked at {}:{}:{}",
+                self.inner.panic.file,
+                self.inner.panic.line,
+                self.inner.panic.column
+            ),
+            _ => unreachable!()
+        }
+    }
+}
+
+struct JoinHandleInner<T> {
+    thread: Thread,
+    ret: Result<T, std::panicking::PanicInfo>,
+}
+
+struct JoinHandleInnerFunc<F, T> {
+    inner: JoinHandleInner<T>,
+    callback: F
+}
+
+impl JoinHandleInnerFunc {
+    fn _run<T, F: Callable<(), T>>(arg: &mut void) -> &mut void {
+        let inner = arg as &mut JoinHandleInnerFunc<F, T>;
+        std::panicking::internal::THREAD_PANIC_INFO = &inner.inner.ret.inner.err;
+        inner.inner.ret = Result::ok(inner.callback());
+        libc::pthread_exit(null);
+    }
+}
+
+struct JoinHandle<T> {
+    inner: &mut JoinHandleInner<T>,
+}
+
+impl JoinHandle<T> {
+    fn join(self: &mut JoinHandle<T>) -> Result<T, JoinError> {
+        let handle = &self.inner;
+
+        let exit_value: &mut void;
+        let ret = libc::pthread_join(handle.thread.id, &exit_value);
+        if ret != 0 {
+            return Result::err(JoinError::from_os(Error::from_errno_custom(ret)));
+        }
+
+        defer self.free(); 
+        if self.inner.ret.is_ok {
+            Result::ok(self.inner.ret.inner.ok)
+        } else {
+            Result::err(if exit_value == &handle.ret.inner.err as &mut void {
+                JoinError::from_panic(handle.ret.inner.err)
+            } else {
+                /// This can happen if someone manually calls pthread_exit()
+                JoinError::from_os(Error::custom("thread returned without a value"))
+            })
+        }
+    }
+
+    fn thread(self: &mut JoinHandle<T>) -> Thread {
+        self.inner.thread
+    }
+
+    fn move(self: &mut JoinHandle<T>) -> JoinHandle<T> {
+        let ret = *self;
+        self.inner = null;
+        ret
+    } 
+
+    fn free(self: &mut JoinHandle<T>) {
+        libc::free(self.inner as &mut void)
+    } 
+}
+
+struct Thread {
+    id: libc::pthread_t
+}
+
+impl Thread {
+    fn current() -> Thread {
+        Thread {
+            id: libc::pthread_self()
+        }
+    }
+
+    fn spawn<T, F: Callable<(), T>>(func: F) -> JoinHandle<T> {
+        #[cfg(not(threading))]
+        compile_fail!("threading is not enabled (use --cfg threading)");
+
+        let handle = std::mem::new::<JoinHandleInnerFunc<F, T>>();
+        handle.callback = func;
+        handle.inner.ret = Result::err(mem::zeroed());
+
+        let ret = libc::pthread_create(
+            &handle.inner.thread.id, 
+            null, 
+            JoinHandleInnerFunc::_run::<T, F>, 
+            handle as &mut void
+        );
+        if ret != 0 {
+            panic!("failed to create thread");
+        }
+
+        JoinHandle {
+           inner: handle as &mut JoinHandleInner<T>,
+        }
+    }
+}
+
+mod internal {
+    macro pthread_try($expr) {
+        let ret = $expr;
+        if ret != 0 {
+            return std::result::Result::err(
+                std::io::Error::from_errno_custom(ret)
+            )
+        }
+    }
+}
+
+#[cfg(all(test, test_std))]
+mod tests {
+
+}

--- a/sysroot/std/thread.alu
+++ b/sysroot/std/thread.alu
@@ -11,12 +11,21 @@ enum JoinErrorKind {
     Panic
 }
 
+impl JoinErrorKind {
+    /// @ cmp::Equatable::equals
+    fn equals(self: &JoinErrorKind, other: &JoinErrorKind) -> bool {
+        *self as i32 == *other as i32
+    }
+
+    mixin cmp::Equatable<JoinErrorKind>;
+}
+
 union JoinErrorT {
     os: std::io::Error,
     panic: std::panicking::PanicInfo
 }
 
-/// An error returned from [JoinHandle::join]
+/// An error returned from [JoinHandle::join].
 ///
 /// It can represent either a panic or an OS error.
 struct JoinError {
@@ -45,6 +54,7 @@ impl JoinError {
         }
     }
 
+    /// @ fmt::Formattable::fmt
     fn fmt<F: Formatter<F>>(self: &JoinError, f: &mut F) -> Result {
         switch self.kind {
             JoinErrorKind::Os => self.inner.os.fmt(f),
@@ -63,11 +73,15 @@ impl JoinError {
 /// Each `JoinHandle` must be either joined or detached before it goes out of scope.
 /// Failure to do so will result in a resource leak.
 struct JoinHandle<T> {
-    _thread_id: libc::pthread_t,
-    _handle: &mut internal::ThreadHandle<T>,
+    _handle: &mut internal::ThreadHandle<T>
 }
 
 impl JoinHandle<T> {
+    /// Returns the [Thread] object associated with this join handle.
+    fn thread(self: &JoinHandle<T>) -> Thread {
+        Thread { inner: self._handle.thread_info }
+    }
+
     /// Waits for the associated thread to finish.
     ///
     /// Returns the return value of the thread function if the thread ran to completion.
@@ -78,21 +92,20 @@ impl JoinHandle<T> {
         assert!(self._handle != null);
         let handle = &self._handle;
 
-        let exit_value: &mut void;
-        let ret = libc::pthread_join(self._thread_id, &exit_value);
+        let ret = libc::pthread_join(handle.thread_info.id, null);
         if ret != 0 {
             return Result::err(JoinError::from_os(Error::from_errno_custom(ret)));
         }
 
         defer {
-            libc::free(self._handle as &mut void); 
+            handle.free();
             self._handle = null;
         };
 
         if handle.ret.is_ok {
             Result::ok(handle.ret.inner.ok)
         } else {
-            Result::err(if exit_value == &handle.ret.inner.err as &mut void {
+            Result::err(if handle.panicked {
                 JoinError::from_panic(handle.ret.inner.err)
             } else {
                 /// This can happen if someone manually calls pthread_exit()
@@ -110,43 +123,23 @@ impl JoinHandle<T> {
     fn detach(self: &mut JoinHandle<T>) {
         assert!(self._handle != null);
         let handle = &self._handle;
+        let thread_id = handle.thread_info.id;
 
-        // We may be detaching a thread before the entry function populated `pi_addr` with the
-        // address of the thread-local PanicInfo handler. In this case we just override it with
-        // a sentinel value (usize::max_value()). In this case we do not free the handle, since
-        // the thread still needs to be able to read it. Thread will free it after it CAS-es the 
-        // `pi_addr`.
-        let pi_addr = handle.pi_addr.exchange(util::cast(usize::max_value()), Ordering::SeqCst);
-        if pi_addr == null {
-            self._handle = null; // Just clear, don't free.
-        } else {
-            defer {
-                libc::free(self._handle as &mut void);
-                self._handle = null;
-            };
-
-            // Clear the thread's panic info so that if it panics, the process
-            // is terminated.
-            let panic_info = pi_addr.exchange(null, Ordering::SeqCst);
-            if (panic_info == null) {
-                let exit_value: &mut void;
-                let ret = libc::pthread_join(self._thread_id, &exit_value);
-                if ret != 0 {
-                    panic!("pthread_join failed: ", Error::from_errno_custom(ret));
-                } else if exit_value == &handle.ret.inner.err as &mut void {
-                    panic!("thread panicked at {}:{}:{}",
-                        handle.ret.inner.err.file,
-                        handle.ret.inner.err.line,
-                        handle.ret.inner.err.column
-                    );
-                } else {
-                    // Thread already successfully finished, clean up.
-                    return;
-                }
+        if handle.pop() {
+            defer handle.free();
+            if handle.panicked {
+                panic!("thread panicked at {}:{}:{}",
+                    handle.ret.inner.err.file,
+                    handle.ret.inner.err.line,
+                    handle.ret.inner.err.column
+                );
+            } else {
+                // Thread already successfully finished, clean up.
+                return;
             }
-        } 
+        }
 
-        let ret = libc::pthread_detach(self._thread_id);
+        let ret = libc::pthread_detach(thread_id);
         if ret != 0 {
             panic!("pthread_detach failed: {}", Error::from_errno_custom(ret));
         }
@@ -186,32 +179,112 @@ fn spawn<T, F: Callable<(), T>>(func: F) -> JoinHandle<T> {
     compile_fail!("threading is not enabled (use --cfg threading)");
 
     let handle = std::mem::new::<internal::ThreadHandleFunc<F, T>>();
-    handle.inner.pi_addr = Atomic::new(null as &mut Atomic<&mut std::panicking::PanicInfo>);
-    handle.inner.ret = Result::err(mem::zeroed());
+    handle.inner = internal::ThreadHandle::new();
     handle.callback = func;
 
-    let thread_id: libc::pthread_t;
     let ret = libc::pthread_create(
-        &thread_id, 
+        &handle.inner.thread_info.id, 
         null,
         internal::_run_thread::<T, F>, 
         handle as &mut void
     );
     if ret != 0 {
+        handle.inner.free();
         panic!("pthread_create failed: {}", Error::from_errno_custom(ret));
     }
 
     JoinHandle {
-        _thread_id: thread_id,
        _handle: handle as &mut internal::ThreadHandle<T>,
     }
 }
 
-/// Yields the execution of the current thread.
-///
-/// You probably don't want to use this in a spin-lock.
-fn yield() {
-    libc::sched_yield();
+/// A structure representing an Alumina thread.
+struct Thread {
+    inner: &mut internal::ThreadInfo 
+}
+
+impl Thread {
+    /// Returns the current thread
+    /// 
+    /// If the current thread is a foreign thread (e.g. not spawned using [spawn] 
+    /// or a main thread of a program with a non-Alumina entrypoint), this function 
+    /// will panic.
+    fn current() -> Thread {
+        #[cfg(not(threading))]
+        compile_fail!("threading is not enabled (use --cfg threading)");
+
+        if internal::THREAD_INFO == null {
+            // This can happen if done in an unmanaged thread (e.g. a callback 
+            // from a thread created by an external library).
+            panic!("thread info was not initialized");
+        }
+        
+        Thread {
+            inner: internal::THREAD_INFO
+        }
+    }
+
+    /// Returns the native thread id of a thread.
+    fn id(self: &Thread) -> libc::pthread_t {
+        self.inner.id
+    }
+
+    /// Suspends the current thread until another thread calls [Thread::unpark]. 
+    /// 
+    /// If the thread was unparked before the park function is called, this function 
+    /// will return immediately. It may also return spuriously, so care must be taken 
+    /// if it is used as a synchronization primitive.
+    ///
+    /// The purpose of this function is to efficiently wait on a condition and can be 
+    /// more lightweight than a [sync::CondVar] on some platforms. 
+    ///
+    /// This is the same mechanism as [Rust's thread parking](https://doc.rust-lang.org/std/thread/fn.park.html).
+    /// # Example
+    /// ```
+    /// use std::sync::{Atomic, Ordering};
+    /// use std::thread::{Thread, spawn, sleep};
+    ///
+    /// let main_thread = Thread::current();
+    /// let flag: Atomic<bool> = Atomic::new(false);
+    /// let parked = spawn(|&flag| { 
+    ///     while !flag.load(Ordering::SeqCst) {
+    ///         Thread::park();
+    ///     }
+    ///     println!("Hello from `parked`")
+    /// });
+    ///
+    /// sleep(Duration::from_secs(1));
+    /// println!("Hello from `parked`")
+    ///
+    /// flag.store(true, Ordering::SeqCst);
+    /// parked.thread().unpark();
+    ///
+    /// parked.join().unwrap();
+    /// ```
+    fn park() {
+        current().inner.parker.park();
+    }
+
+    /// Resumes the execution of a thread that was previously parked.
+    ///
+    /// See also [Thread::park].
+    fn unpark(self: &Thread) {
+        self.inner.parker.unpark();
+    }
+
+    /// Yields the execution of the current thread.
+    ///
+    /// You probably don't want to use this in a spin-lock.
+    fn yield() {
+        libc::sched_yield();
+    }
+
+    /// @ cmp::Equatable::equals
+    fn equals(self: &Thread, other: &Thread) -> bool {
+        self.id() == other.id()
+    }
+
+    mixin cmp::Equatable<Thread>;
 }
 
 /// Suspends thread execution for the specified duration.
@@ -230,15 +303,51 @@ fn sleep(duration: time::Duration) {
 }
 
 mod internal {
-    /// A heap-allocated additional data associated with an Alumina thread
-    ///
-    /// `pi_addr` represents the address of the thread-local PanicInfo handler and ret
-    /// is the storage for the thread's return value (or panic info). We need this in 
-    /// order to be able to make the child thread propagate the panic in case we detach
-    /// the thread early.
+    #[thread_local] static THREAD_INFO: &mut ThreadInfo; 
+
+    struct ThreadInfo {
+        id: libc::pthread_t,
+        parker: parker::Parker
+    }
+
+    impl ThreadInfo {
+        fn new() -> &mut ThreadInfo {
+            let ret = std::mem::new::<internal::ThreadInfo>();
+            ret.parker = parker::Parker::new();
+            ret
+        } 
+
+        fn free(self: &mut ThreadInfo) {
+            libc::free(self as &mut void);
+        }
+    } 
+
+    /// Ref-counted additional data associated with an Alumina thread
     struct ThreadHandle<T> {
-        pi_addr: Atomic<&mut Atomic<&mut std::panicking::PanicInfo>>,
+        ref_count: Atomic<usize>,
+        thread_info: &mut ThreadInfo,
+        panicked: bool,
         ret: Result<T, std::panicking::PanicInfo>,
+    }
+
+    impl ThreadHandle<T> {
+        fn new() -> ThreadHandle<T> {
+            ThreadHandle {
+                ref_count: Atomic::new(2usize),
+                panicked: false,
+                thread_info: ThreadInfo::new(),
+                ret: Result::err(mem::zeroed())
+            }
+        }
+
+        fn pop(self: &mut ThreadHandle<T>) -> bool {
+            self.ref_count.fetch_sub(1, Ordering::SeqCst) == 1
+        }
+
+        fn free(self: &mut ThreadHandle<T>) {
+            libc::free(self.thread_info as &mut void);
+            libc::free(self as &mut void);
+        }
     }
     
     /// An aliased version of [ThreadHandle] that also contains the function to be called.
@@ -258,33 +367,30 @@ mod internal {
     /// for setting up the panic handler and storing the return value of the thread.
     fn _run_thread<T, F: Callable<(), T>>(arg: &mut void) -> &mut void {
         let handle_func = arg as &mut ThreadHandleFunc<F, T>;
-        let callback = handle_func.callback;
         let handle = &handle_func.inner;
+        
+        THREAD_INFO = handle.thread_info;
+        std::panicking::internal::set_panic_hook(handle as &mut void, _panic_hook::<T>);
 
-        // TODO: is this fence really necessary? I do it so that the callback that we copied is not 
-        // reordered after the `compare_exchange` below.
-        std::sync::fence(Ordering::SeqCst);
-
-        let pi_addr = &panicking::internal::THREAD_PANIC_INFO;
-        pi_addr.store(&handle.ret.inner.err, Ordering::SeqCst);
-
-        // After `compare_exchange` finishes, ThreadHandle is no longer guaranteed to be valid.
-        if handle.pi_addr.compare_exchange(null, pi_addr, Ordering::SeqCst, Ordering::SeqCst).is_ok {
-            let ret = callback();
-            // Detaching the thread will clear THREAD_PANIC_INFO, which means the space
-            // for storing the result may already be freed. In this case we just ignore it.
-            if pi_addr.exchange(null, Ordering::SeqCst) != null {
-                handle.ret = Result::ok(ret);
-            }
-        } else {
-            // Thread was detached before we reached this point, we are responsible for cleaning up
-            // the handle.
-            pi_addr.store(null, Ordering::SeqCst);
-            libc::free(arg);
-            callback();
+        handle.ret = Result::ok(handle_func.callback());
+        if handle.pop() {
+            handle.free();
         }
-
+            
         null
+    }
+
+    fn _panic_hook<T>(arg: &mut void, info: &panicking::PanicInfo) {
+        let handle = arg as &mut ThreadHandle<T>;
+        handle.panicked = true;
+        handle.ret = Result::err(*info);
+
+        if handle.pop() {
+            // We have been detached, we need to propagate the panic
+            handle.free();
+        } else {
+            libc::pthread_exit(null)
+        }
     }
 }
 
@@ -293,16 +399,6 @@ mod internal {
 mod tests {
     use time::Duration;
 
-    macro set($flag) {
-        $flag.store(true, Ordering::SeqCst)
-    }
-
-    macro wait_for($flag) {
-        while !$flag.load(Ordering::SeqCst) {
-            yield();
-        } 
-    }
-
     #[test]
     fn test_spawn() {
         let t = spawn(|| -> i32 { 42 });
@@ -310,25 +406,22 @@ mod tests {
     }
 
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-    extern "C" fn syscall(num: libc::c_long, ...) -> libc::c_long;
-
-    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     #[test]
     fn test_spawn_manual_exit() {
         let t = spawn(|| -> i32 { 
             /// call just SYS_exit without SYS_exit_group
-            syscall(60, 0 as libc::c_int); 
+            libc::syscall(60, 0 as libc::c_int); 
             unreachable!() 
         });
-        
-        t.join().unwrap_err();
+
+        assert_eq!(t.join().unwrap_err().kind, JoinErrorKind::Os);
     }
 
     #[test]
     fn test_panic() {
         let t = spawn(|| -> i32 { panic!("panic") });
         
-        t.join().unwrap_err();
+        assert_eq!(t.join().unwrap_err().kind, JoinErrorKind::Panic);
     }
 
 
@@ -340,11 +433,21 @@ mod tests {
 
     #[test]
     fn test_detach_finished() {
-        let t = spawn(|| -> i32 { 42 });
+        let main_thread = Thread::current();
+        let t = spawn(|=main_thread| -> i32 { 
+            defer main_thread.unpark();
+            42 
+        });
         
-        while !t._handle.ret.is_ok {
-            yield();
+        Thread::park();
+        loop {
+            // Spin a few cycles until the thread sets the return value
             sync::fence(Ordering::SeqCst);
+            if t._handle.ret.is_ok {
+                break;
+            } else {
+                Thread::yield();
+            }
         }
 
         t.detach();
@@ -352,13 +455,12 @@ mod tests {
 
     #[test(should_fail)]
     fn test_detach_panic() {
-        let flag = Atomic::new(false);
-        let t = spawn(|&flag| -> i32 { 
-            wait_for!(flag);
+        let t = spawn(|| -> i32 { 
+            Thread::park();
             panic!("panic") 
         });
         t.detach();
-        set!(flag);
+        t.thread().unpark();
         
         // We will only sleep if the detached process does not in fact terminate
         // the process when it panics.
@@ -367,12 +469,12 @@ mod tests {
 
     #[test(should_fail)]
     fn test_detach_panic_2() {
-        let flag = Atomic::new(false);
-        let t = spawn(|&flag| -> i32 { 
-            set!(flag);
+        let main_thread = Thread::current();
+        let t = spawn(|=main_thread| -> i32 { 
+            main_thread.unpark();
             panic!("panic") 
         });
-        wait_for!(flag);
+        Thread::park();
         t.detach();
         
         // We will only sleep if the detached process does not in fact terminate
@@ -382,20 +484,45 @@ mod tests {
 
     #[test(should_fail)]
     fn test_detach_panic_3() {
-        let flag1 = Atomic::new(false);
-        let flag2 = Atomic::new(false);
-
-        let t = spawn(|&flag1, &flag2| -> i32 { 
-            set!(flag1);
-            wait_for!(flag2);
+        let main_thread = Thread::current();
+        let t = spawn(|=main_thread| -> i32 { 
+            main_thread.unpark();
+            Thread::park();
             panic!("panic") 
         });
-        wait_for!(flag1);
+        Thread::park();
         t.detach();
-        set!(flag2);
+        t.thread().unpark();
         
         // We will only sleep if the detached process does not in fact terminate
         // the process when it panics.
         sleep(Duration::from_secs(1));
+    }
+
+    #[test]
+    fn test_current() {
+        let f = spawn(|| -> libc::pthread_t {
+            Thread::current().id()
+        });
+
+        let t1 = f.thread().id();
+        let t2 = f.join().unwrap();
+
+        assert_eq!(t1, t2);
+    }
+
+    #[test(should_fail)]
+    fn test_current_foreign_thread() {
+        let id: libc::pthread_t;
+        libc::pthread_create(
+            &id, 
+            null,
+            |arg: &mut void| -> &mut void {
+                Thread::current(); // panics
+                null
+            }, 
+            null
+        );
+        libc::pthread_join(id, null);
     }
 }

--- a/sysroot/std/thread.alu
+++ b/sysroot/std/thread.alu
@@ -69,7 +69,7 @@ impl JoinError {
 }
 
 /// A handle that allows to wait for the thread to finish.
-/// 
+///
 /// Each `JoinHandle` must be either joined or detached before it goes out of scope.
 /// Failure to do so will result in a resource leak.
 struct JoinHandle<T> {
@@ -86,7 +86,7 @@ impl JoinHandle<T> {
     ///
     /// Returns the return value of the thread function if the thread ran to completion.
     /// It it panicked or was killed, it returns an error variant of `JoinError`.
-    /// 
+    ///
     /// Joining a thread that has already been joined or detached is undefined behavior.
     fn join(self: &mut JoinHandle<T>) -> Result<T, JoinError> {
         assert!(self._handle != null);
@@ -155,12 +155,12 @@ impl JoinHandle<T> {
 /// ```
 /// use std::thread::{spawn, sleep};
 /// use std::time::Duration;
-/// 
+///
 /// let text = "The quick brown fox jumps over the lazy dog";
-/// 
+///
 /// let t = spawn(|=text| -> usize {
 ///     // pretend that calculating the length is expensive
-///     sleep(Duration::from_secs(1)); 
+///     sleep(Duration::from_secs(1));
 ///     text.len
 /// });
 ///
@@ -170,9 +170,9 @@ impl JoinHandle<T> {
 ///
 /// # Panic handling
 ///
-/// If the child thread panics, the process is not terminated automatically. Instead, the 
+/// If the child thread panics, the process is not terminated automatically. Instead, the
 /// [JoinHandle::join] function will return a [JoinError] with the panic information.
-/// 
+///
 /// If a thread is [detached](JoinHandle::detach), a panic in the thread will terminate the process.
 fn spawn<T, F: Callable<(), T>>(func: F) -> JoinHandle<T> {
     #[cfg(not(threading))]
@@ -183,9 +183,9 @@ fn spawn<T, F: Callable<(), T>>(func: F) -> JoinHandle<T> {
     handle.callback = func;
 
     let ret = libc::pthread_create(
-        &handle.inner.thread_info.id, 
+        &handle.inner.thread_info.id,
         null,
-        internal::_run_thread::<T, F>, 
+        internal::_run_thread::<T, F>,
         handle as &mut void
     );
     if ret != 0 {
@@ -200,25 +200,25 @@ fn spawn<T, F: Callable<(), T>>(func: F) -> JoinHandle<T> {
 
 /// A structure representing an Alumina thread.
 struct Thread {
-    inner: &mut internal::ThreadInfo 
+    inner: &mut internal::ThreadInfo
 }
 
 impl Thread {
     /// Returns the current thread
-    /// 
-    /// If the current thread is a foreign thread (e.g. not spawned using [spawn] 
-    /// or a main thread of a program with a non-Alumina entrypoint), this function 
+    ///
+    /// If the current thread is a foreign thread (e.g. not spawned using [spawn]
+    /// or a main thread of a program with a non-Alumina entrypoint), this function
     /// will panic.
     fn current() -> Thread {
         #[cfg(not(threading))]
         compile_fail!("threading is not enabled (use --cfg threading)");
 
         if internal::THREAD_INFO == null {
-            // This can happen if done in an unmanaged thread (e.g. a callback 
+            // This can happen if done in an unmanaged thread (e.g. a callback
             // from a thread created by an external library).
             panic!("thread info was not initialized");
         }
-        
+
         Thread {
             inner: internal::THREAD_INFO
         }
@@ -229,14 +229,14 @@ impl Thread {
         self.inner.id
     }
 
-    /// Suspends the current thread until another thread calls [Thread::unpark]. 
-    /// 
-    /// If the thread was unparked before the park function is called, this function 
-    /// will return immediately. It may also return spuriously, so care must be taken 
+    /// Suspends the current thread until another thread calls [Thread::unpark].
+    ///
+    /// If the thread was unparked before the park function is called, this function
+    /// will return immediately. It may also return spuriously, so care must be taken
     /// if it is used as a synchronization primitive.
     ///
-    /// The purpose of this function is to efficiently wait on a condition and can be 
-    /// more lightweight than a [sync::CondVar] on some platforms. 
+    /// The purpose of this function is to efficiently wait on a condition and can be
+    /// more lightweight than a [sync::CondVar] on some platforms.
     ///
     /// This is the same mechanism as [Rust's thread parking](https://doc.rust-lang.org/std/thread/fn.park.html).
     /// # Example
@@ -246,7 +246,7 @@ impl Thread {
     ///
     /// let main_thread = Thread::current();
     /// let flag: Atomic<bool> = Atomic::new(false);
-    /// let parked = spawn(|&flag| { 
+    /// let parked = spawn(|&flag| {
     ///     while !flag.load(Ordering::SeqCst) {
     ///         Thread::park();
     ///     }
@@ -303,7 +303,7 @@ fn sleep(duration: time::Duration) {
 }
 
 mod internal {
-    #[thread_local] static THREAD_INFO: &mut ThreadInfo; 
+    #[thread_local] static THREAD_INFO: &mut ThreadInfo;
 
     struct ThreadInfo {
         id: libc::pthread_t,
@@ -315,12 +315,12 @@ mod internal {
             let ret = std::mem::new::<internal::ThreadInfo>();
             ret.parker = parker::Parker::new();
             ret
-        } 
+        }
 
         fn free(self: &mut ThreadInfo) {
             libc::free(self as &mut void);
         }
-    } 
+    }
 
     /// Ref-counted additional data associated with an Alumina thread
     struct ThreadHandle<T> {
@@ -349,18 +349,18 @@ mod internal {
             libc::free(self as &mut void);
         }
     }
-    
+
     /// An aliased version of [ThreadHandle] that also contains the function to be called.
     ///
-    /// If the function is not a closure (or a function pointer), then `F` is zero-sized 
-    /// and this struct has identical layout to [ThreadHandle], otherwise it will contain 
-    /// the captured variables.  This aliasing allows us to type-erase the thread function 
+    /// If the function is not a closure (or a function pointer), then `F` is zero-sized
+    /// and this struct has identical layout to [ThreadHandle], otherwise it will contain
+    /// the captured variables.  This aliasing allows us to type-erase the thread function
     /// and not have to carry the function type in [JoinHandle].
     struct ThreadHandleFunc<F, T> {
         inner: ThreadHandle<T>,
         callback: F
     }
-    
+
     /// Wrapper over the user-provided thread function
     ///
     /// This is the function that gets passed to `pthread_create` and it is responsible
@@ -368,7 +368,7 @@ mod internal {
     fn _run_thread<T, F: Callable<(), T>>(arg: &mut void) -> &mut void {
         let handle_func = arg as &mut ThreadHandleFunc<F, T>;
         let handle = &handle_func.inner;
-        
+
         THREAD_INFO = handle.thread_info;
         std::panicking::internal::set_panic_hook(handle as &mut void, _panic_hook::<T>);
 
@@ -376,7 +376,7 @@ mod internal {
         if handle.pop() {
             handle.free();
         }
-            
+
         null
     }
 
@@ -408,10 +408,10 @@ mod tests {
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     #[test]
     fn test_spawn_manual_exit() {
-        let t = spawn(|| -> i32 { 
+        let t = spawn(|| -> i32 {
             /// call just SYS_exit without SYS_exit_group
-            libc::syscall(60, 0 as libc::c_int); 
-            unreachable!() 
+            libc::syscall(60, 0 as libc::c_int);
+            unreachable!()
         });
 
         assert_eq!(t.join().unwrap_err().kind, JoinErrorKind::Os);
@@ -420,7 +420,7 @@ mod tests {
     #[test]
     fn test_panic() {
         let t = spawn(|| -> i32 { panic!("panic") });
-        
+
         assert_eq!(t.join().unwrap_err().kind, JoinErrorKind::Panic);
     }
 
@@ -434,11 +434,11 @@ mod tests {
     #[test]
     fn test_detach_finished() {
         let main_thread = Thread::current();
-        let t = spawn(|=main_thread| -> i32 { 
+        let t = spawn(|=main_thread| -> i32 {
             defer main_thread.unpark();
-            42 
+            42
         });
-        
+
         Thread::park();
         loop {
             // Spin a few cycles until the thread sets the return value
@@ -455,13 +455,13 @@ mod tests {
 
     #[test(should_fail)]
     fn test_detach_panic() {
-        let t = spawn(|| -> i32 { 
+        let t = spawn(|| -> i32 {
             Thread::park();
-            panic!("panic") 
+            panic!("panic")
         });
         t.detach();
         t.thread().unpark();
-        
+
         // We will only sleep if the detached process does not in fact terminate
         // the process when it panics.
         sleep(Duration::from_secs(1));
@@ -470,13 +470,13 @@ mod tests {
     #[test(should_fail)]
     fn test_detach_panic_2() {
         let main_thread = Thread::current();
-        let t = spawn(|=main_thread| -> i32 { 
+        let t = spawn(|=main_thread| -> i32 {
             main_thread.unpark();
-            panic!("panic") 
+            panic!("panic")
         });
         Thread::park();
         t.detach();
-        
+
         // We will only sleep if the detached process does not in fact terminate
         // the process when it panics.
         sleep(Duration::from_secs(1));
@@ -485,15 +485,15 @@ mod tests {
     #[test(should_fail)]
     fn test_detach_panic_3() {
         let main_thread = Thread::current();
-        let t = spawn(|=main_thread| -> i32 { 
+        let t = spawn(|=main_thread| -> i32 {
             main_thread.unpark();
             Thread::park();
-            panic!("panic") 
+            panic!("panic")
         });
         Thread::park();
         t.detach();
         t.thread().unpark();
-        
+
         // We will only sleep if the detached process does not in fact terminate
         // the process when it panics.
         sleep(Duration::from_secs(1));
@@ -515,12 +515,12 @@ mod tests {
     fn test_current_foreign_thread() {
         let id: libc::pthread_t;
         libc::pthread_create(
-            &id, 
+            &id,
             null,
             |arg: &mut void| -> &mut void {
                 Thread::current(); // panics
                 null
-            }, 
+            },
             null
         );
         libc::pthread_join(id, null);

--- a/sysroot/std/thread/parker.alu
+++ b/sysroot/std/thread/parker.alu
@@ -1,0 +1,28 @@
+//! Thread "parking". Adapted from Rust's `Parker` implementation.
+//!
+//! See [Futex implementation](https://github.com/rust-lang/rust/blob/master/library/std/src/sys_common/thread_parker/futex.rs) and
+//! [generic implementation using pthread](https://github.com/rust-lang/rust/blob/master/library/std/src/sys_common/thread_parker/generic.rs).
+
+#[cfg(not(any(target_os = "linux", target_os = "android"))]
+use pthread::Parker;
+#[cfg(any(target_os = "linux", target_os = "android")]
+use futex::Parker;
+
+#[cfg(all(threading, test, test_std))] 
+mod tests {
+    use time::Duration;
+
+    #[test] 
+    fn test_park() {
+        let parker = Parker::new();
+        parker.unpark();
+        parker.park();
+    }
+
+    #[test] 
+    fn test_park_timeout() {
+        let parker = Parker::new();
+        parker.unpark(); 
+        parker.park_timeout(Duration::from_secs(5));
+    }
+}

--- a/sysroot/std/thread/parker.alu
+++ b/sysroot/std/thread/parker.alu
@@ -8,21 +8,21 @@ use pthread::Parker;
 #[cfg(any(target_os = "linux", target_os = "android")]
 use futex::Parker;
 
-#[cfg(all(threading, test, test_std))] 
+#[cfg(all(threading, test, test_std))]
 mod tests {
     use time::Duration;
 
-    #[test] 
+    #[test]
     fn test_park() {
         let parker = Parker::new();
         parker.unpark();
         parker.park();
     }
 
-    #[test] 
+    #[test]
     fn test_park_timeout() {
         let parker = Parker::new();
-        parker.unpark(); 
+        parker.unpark();
         parker.park_timeout(Duration::from_secs(5));
     }
 }

--- a/sysroot/std/thread/parker/futex.alu
+++ b/sysroot/std/thread/parker/futex.alu
@@ -1,0 +1,96 @@
+use sync::{AtomicI32, Ordering};
+use time::Duration;
+
+const PARKED: i32 = -1;
+const EMPTY: i32 = 0;
+const NOTIFIED: i32 = 1;
+
+struct Parker {
+    state: Atomic<i32>,
+}
+
+fn futex_wait(futex: &mut Atomic<i32>, expected: i32, timeout: Option<Duration>) {
+    let maybe_timespec = timeout.map(|d: Duration| -> libc::timespec {
+        libc::timespec {
+            tv_sec: util::cast(d.secs),
+            tv_nsec: util::cast(d.nanos)
+        }
+    });
+
+    libc::syscall(
+        libc::SYS_futex,
+        &futex.inner,
+        libc::FUTEX_WAIT | libc::FUTEX_PRIVATE_FLAG,
+        expected,
+        maybe_timespec.as_ptr()
+    );
+}
+
+fn futex_wake(futex: &mut Atomic<i32>) {
+    libc::syscall(
+        libc::SYS_futex,
+        &futex.inner,
+        libc::FUTEX_WAKE | libc::FUTEX_PRIVATE_FLAG,
+        1i32
+    );
+}
+
+impl Parker {
+    fn new() -> Parker {
+        Parker { state: Atomic::new(EMPTY) }
+    }
+
+    // Assumes this is only called by the thread that owns the Parker,
+    // which means that `self.state != PARKED`.
+    fn park(self: &mut Parker) {
+        // Change NOTIFIED=>EMPTY or EMPTY=>PARKED, and directly return in the
+        // first case.
+        if self.state.fetch_sub(1, Ordering::Acquire) == NOTIFIED {
+            return;
+        }
+        loop {
+            // Wait for something to happen, assuming it's still set to PARKED.
+            futex_wait(&self.state, PARKED, Option::none());
+            // Change NOTIFIED=>EMPTY and return in that case.
+            if self.state.compare_exchange(NOTIFIED, EMPTY, Ordering::Acquire, Ordering::Acquire).is_ok {
+                return;
+            } else {
+                // Spurious wake up. We loop to try again.
+            }
+        }
+    }
+
+    // Assumes this is only called by the thread that owns the Parker,
+    // which means that `self.state != PARKED`.
+    fn park_timeout(self: &mut Parker, timeout: Duration) {
+        // Change NOTIFIED=>EMPTY or EMPTY=>PARKED, and directly return in the
+        // first case.
+        if self.state.fetch_sub(1, Ordering::Acquire) == NOTIFIED {
+            return;
+        }
+        // Wait for something to happen, assuming it's still set to PARKED.
+        futex_wait(&self.state, PARKED, Option::some(timeout));
+        // This is not just a store, because we need to establish a
+        // release-acquire ordering with unpark().
+        if self.state.exchange(EMPTY, Ordering::Acquire) == NOTIFIED {
+            // Woke up because of unpark().
+        } else {
+            // Timeout or spurious wake up.
+            // We return either way, because we can't easily tell if it was the
+            // timeout or not.
+        }
+    }
+
+    #[inline]
+    fn unpark(self: &mut Parker) {
+        // Change PARKED=>NOTIFIED, EMPTY=>NOTIFIED, or NOTIFIED=>NOTIFIED, and
+        // wake the thread in the first case.
+        //
+        // Note that even NOTIFIED=>NOTIFIED results in a write. This is on
+        // purpose, to make sure every unpark() has a release-acquire ordering
+        // with park().
+        if self.state.exchange(NOTIFIED, Ordering::Release) == PARKED {
+            futex_wake(&self.state);
+        }
+    }
+}

--- a/sysroot/std/thread/parker/futex.alu
+++ b/sysroot/std/thread/parker/futex.alu
@@ -1,3 +1,5 @@
+#![cfg(any(target_os = "linux", target_os = "android")]
+
 use sync::{AtomicI32, Ordering};
 use time::Duration;
 

--- a/sysroot/std/thread/parker/pthread.alu
+++ b/sysroot/std/thread/parker/pthread.alu
@@ -29,7 +29,7 @@ impl Parker {
         self.lock.lock();
         defer self.lock.unlock();
 
-        let ret = self.state.compare_exchange(EMPTY, PARKED, Ordering::SeqCst, Ordering::SeqCst);  
+        let ret = self.state.compare_exchange(EMPTY, PARKED, Ordering::SeqCst, Ordering::SeqCst);
         if !ret.is_ok {
             if ret.inner.err == NOTIFIED {
                 let old = self.state.exchange(EMPTY, Ordering::SeqCst);
@@ -58,7 +58,7 @@ impl Parker {
         self.lock.lock();
         defer self.lock.unlock();
 
-        let ret = self.state.compare_exchange(EMPTY, PARKED, Ordering::SeqCst, Ordering::SeqCst);  
+        let ret = self.state.compare_exchange(EMPTY, PARKED, Ordering::SeqCst, Ordering::SeqCst);
         if !ret.is_ok {
             if ret.inner.err == NOTIFIED {
                 let old = self.state.exchange(EMPTY, Ordering::SeqCst);

--- a/sysroot/std/thread/parker/pthread.alu
+++ b/sysroot/std/thread/parker/pthread.alu
@@ -1,0 +1,113 @@
+use sync::{Atomic, Ordering, CondVar, Mutex};
+use time::Duration;
+
+const EMPTY: usize = 0;
+const PARKED: usize = 1;
+const NOTIFIED: usize = 2;
+
+struct Parker {
+    state: Atomic<usize>,
+    lock: Mutex,
+    cvar: CondVar,
+}
+
+impl Parker {
+    fn new() -> Parker {
+        Parker { state: Atomic::new(EMPTY), lock: Mutex::new(), cvar: CondVar::new() }
+    }
+
+    // This implementation doesn't require `unsafe`, but other implementations
+    // may assume this is only called by the thread that owns the Parker.
+    fn park(self: &mut Parker) {
+        // If we were previously notified then we consume this notification and
+        // return quickly.
+        if self.state.compare_exchange(NOTIFIED, EMPTY, Ordering::SeqCst, Ordering::SeqCst).is_ok {
+            return;
+        }
+
+        // Otherwise we need to coordinate going to sleep
+        self.lock.lock();
+        defer self.lock.unlock();
+
+        let ret = self.state.compare_exchange(EMPTY, PARKED, Ordering::SeqCst, Ordering::SeqCst);  
+        if !ret.is_ok {
+            if ret.inner.err == NOTIFIED {
+                let old = self.state.exchange(EMPTY, Ordering::SeqCst);
+                assert_eq!(old, NOTIFIED);
+                return;
+            } else {
+                panic!("inconsistent park state")
+            }
+        }
+
+        loop {
+            self.cvar.wait(&self.lock);
+            if self.state.compare_exchange(NOTIFIED, EMPTY, Ordering::SeqCst, Ordering::SeqCst).is_ok {
+                return;
+            }
+        }
+    }
+
+    fn park_timeout(self: &mut Parker, dur: Duration) {
+        // Like `park` above we have a fast path for an already-notified thread, and
+        // afterwards we start coordinating for a sleep.
+        // return quickly.
+        if self.state.compare_exchange(NOTIFIED, EMPTY, Ordering::SeqCst, Ordering::SeqCst).is_ok {
+            return;
+        }
+        self.lock.lock();
+        defer self.lock.unlock();
+
+        let ret = self.state.compare_exchange(EMPTY, PARKED, Ordering::SeqCst, Ordering::SeqCst);  
+        if !ret.is_ok {
+            if ret.inner.err == NOTIFIED {
+                let old = self.state.exchange(EMPTY, Ordering::SeqCst);
+                assert_eq!(old, NOTIFIED);
+                return;
+            } else {
+                panic!("inconsistent park state")
+            }
+        }
+
+        // Wait with a timeout, and if we spuriously wake up or otherwise wake up
+        // from a notification we just want to unconditionally set the state back to
+        // empty, either consuming a notification or un-flagging ourselves as
+        // parked.
+        self.cvar.wait_timeout(&self.lock, dur);
+        switch self.state.exchange(EMPTY, Ordering::SeqCst) {
+            NOTIFIED => {} // got a notification, hurray!
+            PARKED => {}   // no notification, alas
+            _ => panic!("inconsistent park_timeout state"),
+        }
+    }
+
+    fn unpark(self: &mut Parker) {
+        // To ensure the unparked thread will observe any writes we made
+        // before this call, we must perform a release operation that `park`
+        // can synchronize with. To do that we must write `NOTIFIED` even if
+        // `state` is already `NOTIFIED`. That is why this must be a swap
+        // rather than a compare-and-swap that returns if it reads `NOTIFIED`
+        // on failure.
+        switch self.state.exchange(NOTIFIED, Ordering::SeqCst) {
+            EMPTY => return,    // no one was waiting
+            NOTIFIED => return, // already unparked
+            PARKED => {}        // gotta go wake someone up
+            _ => panic!("inconsistent state in unpark"),
+        }
+
+        // There is a period between when the parked thread sets `state` to
+        // `PARKED` (or last checked `state` in the case of a spurious wake
+        // up) and when it actually waits on `cvar`. If we were to notify
+        // during this period it would be ignored and then when the parked
+        // thread went to sleep it would never wake up. Fortunately, it has
+        // `lock` locked at this stage so we can acquire `lock` to wait until
+        // it is ready to receive the notification.
+        //
+        // Releasing `lock` before the call to `notify_one` means that when the
+        // parked thread wakes it doesn't get woken only to have to wait for us
+        // to release `lock`.
+        self.lock.lock();
+        self.lock.unlock();
+        self.cvar.notify_one()
+    }
+}

--- a/sysroot/std/time.alu
+++ b/sysroot/std/time.alu
@@ -45,12 +45,12 @@ impl Instant {
                 nanos += NANOS_PER_SEC as i32;
             }
             Duration::new(secs, nanos as u32)
-        } 
+        }
 
 
         #[cfg(target_os = "macos")] {
             let diff = self.inner - earlier.inner;
-            let total_nanos = ((diff as i128) * (internal::TIMEBASE.numer as i128) / 
+            let total_nanos = ((diff as i128) * (internal::TIMEBASE.numer as i128) /
                 (internal::TIMEBASE.denom as i128)) as i64;
             let (secs, nanos) = math::div_floor(total_nanos, NANOS_PER_SEC as i64);
             Duration::new(secs, nanos as u32)
@@ -78,7 +78,7 @@ impl Instant {
 
         #[cfg(target_os = "macos")] {
             let total_nanos = (rhs.nanos as u128) + (rhs.secs as u128) * (NANOS_PER_SEC as u128);
-            let nanos = (total_nanos * (internal::TIMEBASE.denom as u128) / 
+            let nanos = (total_nanos * (internal::TIMEBASE.denom as u128) /
                 (internal::TIMEBASE.numer as u128)) as u64;
 
             Instant {
@@ -108,15 +108,15 @@ impl Instant {
 
         #[cfg(target_os = "macos")] {
             let total_nanos = (rhs.nanos as u128) + (rhs.secs as u128) * (NANOS_PER_SEC as u128);
-            let nanos = (total_nanos * (internal::TIMEBASE.denom as u128) / 
+            let nanos = (total_nanos * (internal::TIMEBASE.denom as u128) /
                 (internal::TIMEBASE.numer as u128)) as u64;
-            
+
             Instant {
                 inner: lhs.inner - nanos
             }
         }
     }
-    
+
     /// @ std::cmp::Equatable::equals
     fn equals(lhs: &Instant, rhs: &Instant) -> bool {
         #[cfg(not(target_os = "macos"))] {
@@ -137,7 +137,7 @@ impl Instant {
             lhs.inner.compare(&rhs.inner)
         }
     }
-    
+
     mixin cmp::Comparable<Instant>;
     mixin cmp::Equatable<Instant>;
 }
@@ -159,7 +159,7 @@ impl Instant {
             let v: mach_timebase_info_t;
             mach_timebase_info(&v);
             v
-        };   
+        };
     }
 }
 
@@ -174,9 +174,9 @@ struct Duration {
 
 impl Duration {
     fn new(secs: i64, nanos: u32) -> Duration {
-        Duration { 
-            secs: (nanos / NANOS_PER_SEC) as i64 + secs, 
-            nanos: nanos % NANOS_PER_SEC 
+        Duration {
+            secs: (nanos / NANOS_PER_SEC) as i64 + secs,
+            nanos: nanos % NANOS_PER_SEC
         }
     }
 
@@ -241,7 +241,7 @@ impl Duration {
         if nanos >= NANOS_PER_SEC {
             secs += 1;
             nanos -= NANOS_PER_SEC
-        } 
+        }
 
         Duration {
             secs: secs,
@@ -293,7 +293,7 @@ impl Duration {
         } else {
             *self
         };
-        
+
         let secs = abs.secs % 60;
         let mins = (abs.secs / 60) % 60;
         let hours = abs.secs / 3600;
@@ -317,7 +317,7 @@ mod tests {
     #[test]
     fn test_monotonish() {
         use thread::sleep;
-        
+
         let start = Instant::now();
         Duration::from_nanos(1000).sleep();
         let end = Instant::now();
@@ -392,16 +392,16 @@ mod tests {
             assert_eq!(
                 format_in!(buf, "{}", $dur).unwrap(),
                 $expected
-            );    
+            );
         }
-        
+
         chk!(Duration::zero(), "00:00:00");
         chk!(Duration::from_secs(1), "00:00:01");
         chk!(Duration::from_secs(60), "00:01:00");
         chk!(Duration::from_secs(60*60), "01:00:00");
         chk!(Duration::from_secs(86399), "23:59:59");
         chk!(Duration::from_nanos(1), "00:00:00.000000001");
-        chk!(Duration::from_nanos(999999999), "00:00:00.999999999"); 
+        chk!(Duration::from_nanos(999999999), "00:00:00.999999999");
 
         chk!(Duration::from_secs(-1), "-00:00:01");
         chk!(Duration::from_secs(-60), "-00:01:00");

--- a/sysroot/std/time.alu
+++ b/sysroot/std/time.alu
@@ -309,21 +309,6 @@ impl Duration {
     mixin cmp::Equatable<Duration>;
 }
 
-/// Suspends thread execution for the specified duration.
-///
-/// The sleep may sleep for less than the specified time if interrupted by a
-/// signal.
-fn sleep(duration: &Duration) {
-    if *duration < Duration::zero() {
-        return;
-    }
-
-    libc::nanosleep(&libc::timespec {
-        tv_sec: util::cast(duration.secs),
-        tv_nsec: util::cast(duration.nanos)
-    }, null);
-}
-
 
 #[cfg(all(test, test_std))]
 mod tests {
@@ -331,6 +316,8 @@ mod tests {
 
     #[test]
     fn test_monotonish() {
+        use thread::sleep;
+        
         let start = Instant::now();
         Duration::from_nanos(1000).sleep();
         let end = Instant::now();

--- a/sysroot/test.alu
+++ b/sysroot/test.alu
@@ -1,14 +1,14 @@
 //! Unit testing mini-framework.
 //!
 //! When `--cfg test` is provided as an argument to the compiler, this module will override
-//! the `main` entrypoint with the test runner which will run all the test cases defined in 
+//! the `main` entrypoint with the test runner which will run all the test cases defined in
 //! the code that is being compiled.
 //!
-//! Nothing prevents you from writing your own framework, just compile with 
+//! Nothing prevents you from writing your own framework, just compile with
 //! `--cfg custom_test_framework` and use the test support glue in [std::runtime] to get the test
 //! cases.
 
-#[cfg(all(test, not(custom_test_framework))] 
+#[cfg(all(test, not(custom_test_framework))]
 {
     use std::io::{StringWriter, copy, Error};
     use std::process::{Command, Stdio, Forked};
@@ -54,7 +54,7 @@
         return false;
     }
 
-    /// Run a single test case in a forked process and collect output. 
+    /// Run a single test case in a forked process and collect output.
     fn run(test: &TestCaseMeta) -> TestResult {
         let should_fail = test.should_fail();
         let start_time = Instant::now();
@@ -64,7 +64,7 @@
             .stderr(Stdio::Piped)
             .spawn()
             .unwrap();
-    
+
         if !child.is_some {
             test.test();
             if should_fail {
@@ -104,9 +104,9 @@
             }
         }
     }
-    
+
     enum State {
-        Normal, 
+        Normal,
         Prefix,
         Filter
     }
@@ -176,8 +176,8 @@
 
         test_cases
             .as_slice_mut()
-            .sort_by(|m: &TestCaseMeta| -> (&[u8], &[u8]) { 
-                (m.path, m.name) 
+            .sort_by(|m: &TestCaseMeta| -> (&[u8], &[u8]) {
+                (m.path, m.name)
             });
 
         let filtered_count = TEST_CASES.len - test_cases.len();
@@ -189,7 +189,7 @@
     fn main(args: &[&[u8]]) -> i32 {
         let args = parse_args(args);
         let start_time = Instant::now();
-        
+
         let results: Vector<TestResult> = Vector::new();
         defer results.free_all();
 
@@ -251,34 +251,34 @@
                     }
                 }
             }
-            eprintln!("test result: \x1b[0;31mFAILED\x1b[0m. {} passed; {} failed; {} ignored; finished in {}", 
-                num_passed, 
-                num_failed, 
+            eprintln!("test result: \x1b[0;31mFAILED\x1b[0m. {} passed; {} failed; {} ignored; finished in {}",
+                num_passed,
+                num_failed,
                 num_ignored,
                 elapsed
             );
             1
         } else {
             eprintln!("");
-            eprintln!("test result: \x1b[0;32mok\x1b[0m. {} passed; {} failed; {} ignored; finished in {}", 
-                num_passed, 
-                num_failed, 
-                num_ignored, 
+            eprintln!("test result: \x1b[0;32mok\x1b[0m. {} passed; {} failed; {} ignored; finished in {}",
+                num_passed,
+                num_failed,
+                num_ignored,
                 elapsed
             );
             0
         }
     }
-    
+
     /// Quis testabitur ipsos testes
     #[cfg(test_std)] {
         #[test]
         fn regular_test() {
         }
-        
+
         #[test(ignore)]
         fn ignored_test() {}
-        
+
         #[test(should_fail)]
         fn should_fail_test() {
             panic!("oops")

--- a/tools/alumina-doc/common.alu
+++ b/tools/alumina-doc/common.alu
@@ -16,7 +16,7 @@ impl Path {
     use std::fmt::{Formatter, write, writeln, Error};
     use std::cmp::{Comparable, Equatable, Ordering};
     use std::hash::{Hashable, Hasher};
-    
+
     fn new(segments: Vector<&[u8]>) -> Path {
         Path { segments: segments }
     }
@@ -151,13 +151,13 @@ impl ItemKind {
         switch *self {
             ItemKind::Module,
             ItemKind::Protocol,
-            ItemKind::Enum, 
+            ItemKind::Enum,
             ItemKind::Union,
-            ItemKind::Struct, 
+            ItemKind::Struct,
             ItemKind::Macro => true,
             _ => false,
         }
-    }   
+    }
 
     fn is_indexed(self: &ItemKind) -> bool {
         switch *self {
@@ -165,7 +165,7 @@ impl ItemKind {
             ItemKind::Field => false,
             _ => true,
         }
-    }   
+    }
 
 
     fn should_show_in_sidebar(self: &ItemKind) -> bool {
@@ -173,7 +173,7 @@ impl ItemKind {
             ItemKind::Mixin => false,
             _ => true,
         }
-    }   
+    }
 
     fn show_siblings(self: &ItemKind) -> bool {
         switch *self {
@@ -184,7 +184,7 @@ impl ItemKind {
             ItemKind::Enum => false,
             _ => true,
         }
-    }  
+    }
 
     fn show_source_link(self: &ItemKind) -> bool {
         switch *self {
@@ -193,16 +193,16 @@ impl ItemKind {
             ItemKind::Variant => false,
             _ => true,
         }
-    }  
+    }
 
     fn show_signature(self: &ItemKind) -> bool {
         switch *self {
             ItemKind::Module => false,
             _ => true,
         }
-    }  
-    
-    
+    }
+
+
     fn equals(self: &ItemKind, other: &ItemKind) -> bool {
         (*self as i32) == (*other as i32)
     }
@@ -231,7 +231,7 @@ impl Item {
         self.defined_in.free();
         self.doc_comment.free();
     }
-    
+
     /// Show re-exports only if the original item was defined in a submodule.
     ///
     /// Since Alumina does not have item visibility, this is a heuristic to determine
@@ -241,13 +241,13 @@ impl Item {
         let def = self.defined_in.as_slice();
 
         if loc == def {
-            return true; 
+            return true;
         } else if loc.len >= 2 && loc[0] == "std" && loc[1] == "prelude"  {
             // Special case for prelude
             return true;
         } else if  loc.len >= def.len {
             return false;
-        } 
+        }
 
         let suffix_len = 0usize;
         loop {
@@ -316,7 +316,7 @@ impl ItemBag {
             k.free();
             v.free()
         }
-        
+
         self.items.free();
         self.lookup.free();
         self.arena.free();
@@ -353,7 +353,7 @@ impl ItemBag {
             .as_slice_mut()
             .sort_by(|it: &&Item| -> (&[&[u8]], i32, usize, &[u8]) {
                 use std::mem::slice::empty;
-     
+
                 let item_loc = it.node.start_byte();
                 let start = it.path.as_slice();
 
@@ -417,7 +417,7 @@ impl ItemBag {
             for s in i.path.as_slice()[dst.segments.len()..] {
                 src_path.push(s);
             }
-            
+
             if !self.lookup.get(src_path).is_some {
                 self.add_item(Item {
                     kind: i.kind,
@@ -431,7 +431,7 @@ impl ItemBag {
                     node: i.node,
                 });
             }
-            
+
             src_path.free();
         }
     }
@@ -442,7 +442,7 @@ impl ItemBag {
             for (src, dst) in self.aliases {
                 let scope = src.clone();
                 let suffix = Path::from_str(scope.pop());
-                
+
                 let resolved = self.resolve(&scope, &suffix, true);
                 if resolved.is_some {
                     let item = resolved.inner;
@@ -481,10 +481,10 @@ impl ParseContext {
     fn from_file(parser: &mut Parser, filename: std::fs::Path) -> Result<ParseContext> {
         let source = std::fs::File::read_to_string(filename).map_err(Error::from_io)?;
         defer source.free();
-    
+
         let tree = parser.parse(source.as_slice());
         defer tree.free();
-        
+
         Result::ok(ParseContext {
             _source: source.move(),
             tree: tree.move(),
@@ -531,7 +531,7 @@ impl LinkContext {
     fn link_for_item(self: &LinkContext, item: &Item, defined_in: bool) -> Option<StringBuf> {
         use std::fmt::format;
         use std::string::join_fmt;
-        
+
         let path = if defined_in {
             item.defined_in.clone()
         } else {
@@ -556,13 +556,13 @@ impl LinkContext {
                 format!("/{}.html#item.{}", "/".join_fmt(&path.segments.iter()), name).unwrap()
             }
         };
-        
+
         Option::some(val)
     }
 
     fn resolve_link(self: &LinkContext, path: &Path) -> Option<StringBuf> {
         use std::option::try;
-        
+
         let item = self.item_bag.resolve(self.path, path, true)?;
         self.link_for_item(item, true)
     }

--- a/tools/alumina-doc/main.alu
+++ b/tools/alumina-doc/main.alu
@@ -434,18 +434,6 @@ impl Processor {
 
         visitor.visit(parse_context.root_node());
 
-        self.items.add_item(Item {
-            kind: ItemKind::Module,
-            has_cfg: false,
-            defined_in: path.clone(),
-            path: path.move(),
-            cfg_index: 0,
-            node: parse_context.root_node(),
-            parse_context: parse_context,
-            group_node: Option::none(),
-            doc_comment: visitor.file_doc_comment.move(),
-        });
-
         Result::ok(())
     }
 

--- a/tools/alumina-doc/main.alu
+++ b/tools/alumina-doc/main.alu
@@ -38,8 +38,8 @@ impl PageWriter<T: std::io::Writable<T>> {
         if item.path.segments.empty() {
             wln!(self, "<h1>{}</h1>", item.kind);
             return Result::ok(());
-        } 
-        
+        }
+
         if with_kind {
             w!(self, "<div class=\"main-title\"><h1>{} ", item.kind);
         } else {
@@ -76,7 +76,7 @@ impl PageWriter<T: std::io::Writable<T>> {
 
     fn write_signature(self: &PageWriter<T>, item: &Item, top_level: bool) -> Result<()> {
         let link_context = LinkContext::new(self.item_bag, &item.defined_in);
-        
+
         if !top_level {
             let name = item.path.last().unwrap();
             if item.cfg_index == 0 {
@@ -87,21 +87,21 @@ impl PageWriter<T: std::io::Writable<T>> {
         } else {
             wln!(self, "<div class=\"signature\">");
         }
-        
+
         wln!(self, "{}", if top_level { "<h3>" } else { "<h4>" });
         if item.has_cfg {
             wln!(self, "<span class=\"badge\">#[cfg]</span>");
         }
         let printer = CodePrinter::new(item.parse_context, &link_context, self.writer);
         printer.visit(item.node);
-        
+
         child_by!(item.node, FieldKind::TypeArguments)
             .map(|=self, &printer, node: Node| -> Result<()> {
                 let cursor = node.walk();
                 defer cursor.free();
-                
+
                 printer.protocol_bounds = true;
-                
+
                 for (idx, child) in children_by!(node, FieldKind::Argument, &cursor).enumerate() {
                     if !child_by!(child, FieldKind::Bound).is_some {
                         continue;
@@ -110,11 +110,11 @@ impl PageWriter<T: std::io::Writable<T>> {
                     printer.visit(child);
                     wln!(self, "</div>");
                 }
-                
+
                 Result::ok(())
             })
             .transpose()?;
-        
+
         wln!(self, "{}", if top_level { "</h3>" } else { "</h4>" });
         if item.kind.show_source_link() {
             let file = item.parse_context.filename.as_path().strip_prefix(std::fs::Path::new("./")).unwrap();
@@ -122,16 +122,16 @@ impl PageWriter<T: std::io::Writable<T>> {
             let end = item.node.end_point();
             wln!(self, "<div class=\"source-link\">");
             wln!(
-                self, 
+                self,
                 "<a href=\"https://github.com/tibordp/alumina/blob/master/{}#L{}-L{}\"/>source</a>",
-                file, 
+                file,
                 start.row + 1,
                 end.row + 1
             );
             wln!(self, "</div>");
         }
         wln!(self, "</div>");
-        
+
         Result::ok(())
     }
 
@@ -150,16 +150,16 @@ impl PageWriter<T: std::io::Writable<T>> {
         } else {
             wln!(self, "<div class=\"signature impl-header not-first\"><h3>");
         }
-        
+
         let printer = CodePrinter::new(item.parse_context, &link_context, self.writer);
         printer.visit(node);
         child_by!(node, FieldKind::TypeArguments)
             .map(|=self, &printer, node: Node| -> Result<()> {
                 let cursor = node.walk();
                 defer cursor.free();
-                
+
                 printer.protocol_bounds = true;
-                
+
                 for (idx, child) in children_by!(node, FieldKind::Argument, &cursor).enumerate() {
                     if !child_by!(child, FieldKind::Bound).is_some {
                         continue;
@@ -167,26 +167,26 @@ impl PageWriter<T: std::io::Writable<T>> {
                     wln!(self, "<div class=\"protocol-bound\">");
                     printer.visit(child);
                     wln!(self, "</div>");
-                } 
-                
+                }
+
                 Result::ok(())
             })
             .transpose()?;
-        
+
         wln!(self, "</h3></div>");
 
         Result::ok(())
     }
-    
+
     fn write_page(
-        self: &PageWriter<T>, 
-        nav_item: &Item, 
-        top_level: &Item, 
-        nav_items: &Vector<&Item>, 
+        self: &PageWriter<T>,
+        nav_item: &Item,
+        top_level: &Item,
+        nav_items: &Vector<&Item>,
         main_items: &Vector<&Item>
     ) -> Result<()> {
         let link_context = LinkContext::new(self.item_bag, &top_level.defined_in);
-        
+
         wln!(self, "<!DOCTYPE html>");
         wln!(self, "<html lang=\"en\">");
         wln!(self, "<head>");
@@ -196,7 +196,7 @@ impl PageWriter<T: std::io::Writable<T>> {
         } else {
             wln!(self, "<title>{} - Alumina Docs</title>", top_level.path);
         }
-        
+
         wln!(self, "<link rel=\"stylesheet\" href=\"/static/styles.css\">");
         wln!(self, "<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">");
         wln!(self, "<link rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>");
@@ -207,14 +207,14 @@ impl PageWriter<T: std::io::Writable<T>> {
         wln!(self, "<link rel=\"manifest\" href=\"/static/manifest.json\" />");
         wln!(self, "<link rel=\"mask-icon\" href=\"/static/safari-pinned-tab.svg\" color=\"#5bbad5\" />");
         wln!(self, "<link rel=\"shortcut icon\" href=\"/static/favicon.ico\" />");
-        
+
         if self.processor.base_domain.is_some && top_level.path != top_level.defined_in {
             let link = link_context.resolve_link(&top_level.defined_in).unwrap();
             defer link.free();
             wln!(
-                self, 
-                "<link rel=\"canonical\" href=\"{}{}\" />", 
-                self.processor.base_domain.inner, 
+                self,
+                "<link rel=\"canonical\" href=\"{}{}\" />",
+                self.processor.base_domain.inner,
                 link
             );
         }
@@ -227,9 +227,9 @@ impl PageWriter<T: std::io::Writable<T>> {
         wln!(self, "<link href=\"https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;500&family=Source+Code+Pro:wght@400;600&family=Source+Serif+4:opsz,wght@8..60,400;8..60,700&display=swap\" rel=\"stylesheet\">");
         wln!(self, "</head>");
         wln!(self, "<body>");
-        
+
         // Left sidebar
-        
+
         wln!(self, "<nav>");
         wln!(self, "<a href=\"/\">");
         wln!(self, "<img width=\"100px\" height=\"100px\" class=\"logo\" src=\"/static/logo.svg\" alt=\"Alumina Docs\">");
@@ -238,14 +238,14 @@ impl PageWriter<T: std::io::Writable<T>> {
         if nav_item.path.last().is_some {
             self.write_breadcrumbs(nav_item, false)?;
         }
-        
+
         for grp in nav_items
             .iter()
             .filter(|i: &Item| -> bool { i.kind.should_show_in_sidebar() })
             .group_by(|i: &Item| -> ItemKind { i.kind }) {
             wln!(self, "<h2>{}s</h2>", grp.key);
             wln!(self, "<ul>");
-            
+
             for item in grp {
                 let link_context = LinkContext::new(self.item_bag, &item.defined_in);
                 let link = link_context.link_for_item(item, false).unwrap();
@@ -257,9 +257,9 @@ impl PageWriter<T: std::io::Writable<T>> {
             wln!(self, "</ul>");
         }
         wln!(self, "</nav>");
-        
+
         // Main section
-        
+
         wln!(self, "<div class=\"main-container\">");
         wln!(self, "<div id=\"search-container\">");
         wln!(self, "<a class=\"mobile-only\" href=\"/\">");
@@ -267,38 +267,38 @@ impl PageWriter<T: std::io::Writable<T>> {
         wln!(self, "</a>");
         wln!(self, "<input id=\"search-input\" class=\"search-input\" autocomplete=\"off\" spellcheck=\"false\" placeholder=\"Search the documentation...\" type=\"search\"></input>");
         wln!(self, "</div>");
-        wln!(self, "<div id=\"search-results\"></div>");    
+        wln!(self, "<div id=\"search-results\"></div>");
         wln!(self, "<main id=\"main-content\">");
-        
+
         if top_level.path.segments.len() > 0 {
             self.write_breadcrumbs(top_level, true)?;
         }
-        
+
         if top_level.kind.show_signature() {
             self.write_signature(top_level, true)?;
         }
-        
+
         write_docstring(self.writer, top_level.doc_comment.as_slice(), false, &link_context)
-        .map_err(Error::from::<std::fmt::Error>)?;    
-        
+        .map_err(Error::from::<std::fmt::Error>)?;
+
         if top_level.kind.has_own_page() {
             for grp in main_items.iter().group_by(|i: &Item| -> ItemKind { i.kind }) {
                 wln!(self, "<h2 id=\"{}\">{}s</h2>", grp.key, grp.key);
-                
+
                 let first = true;
 
                 for impl_grp in grp.group_by(|i: &Item| -> Option<Node> { i.group_node }) {
 
                     self.write_impl_header(top_level, impl_grp.key, first)?;
                     first = false;
-                    
+
                     if grp.key.has_own_page() {
                         wln!(self, "<div class=\"item-short-table\">");
                         for item in impl_grp {
                             let link_context = LinkContext::new(self.item_bag, &item.defined_in);
                             let name = item.path.last().unwrap();
                             let link = link_context.link_for_item(item, false).unwrap();
-                            
+
                             if item.cfg_index == 0 {
                                 wln!(self, "<div class=\"row\" id=\"item.{}\">", name);
                             } else {
@@ -312,28 +312,28 @@ impl PageWriter<T: std::io::Writable<T>> {
                             wln!(self, "</div>");
                             w!(self, "<div class=\"cell-doc\">");
                             write_docstring(self.writer, item.doc_comment.as_slice(), true, &link_context)
-                            .map_err(Error::from::<std::fmt::Error>)?;  
+                            .map_err(Error::from::<std::fmt::Error>)?;
                             wln!(self, "</div>");
                             wln!(self, "</div>");
-                            
+
                             link.free();
                         }
                         wln!(self, "</div>");
-                        
+
                     } else {
                         wln!(self, "<ul>");
                         for item in impl_grp {
                             let link_context = LinkContext::new(self.item_bag, &item.defined_in);
-                            wln!(self, "<li>");                  
+                            wln!(self, "<li>");
                             self.write_signature(item, false)?;
-                            
+
                             wln!(self, "<div class=\"item-doc\">");
                             write_docstring(self.writer, item.doc_comment.as_slice(), false, &link_context)
-                                .map_err(Error::from::<std::fmt::Error>)?;  
+                                .map_err(Error::from::<std::fmt::Error>)?;
                             wln!(self, "</div>");
                             wln!(self, "</li>");
                         }
-                        
+
                         wln!(self, "</ul>");
                     }
                 }
@@ -363,7 +363,7 @@ fn clean_doc_comment(link_context: &LinkContext, doc_comment: &[u8]) -> StringBu
 
         return clean_doc_comment(
             &link_context,
-            item.doc_comment.as_slice(), 
+            item.doc_comment.as_slice(),
         );
     }
 
@@ -378,7 +378,7 @@ fn clean_doc_comment(link_context: &LinkContext, doc_comment: &[u8]) -> StringBu
     x(&result, result.as_slice().replace("\\", "\\\\")).free();
     x(&result, result.as_slice().replace("\n", "\\n")).free();
     x(&result, result.as_slice().replace("\"", "\\\"")).free();
-    result 
+    result
 }
 
 
@@ -393,7 +393,7 @@ struct Processor {
 
 impl Processor {
     fn new() -> Processor {
-        let parser = Parser::new(); 
+        let parser = Parser::new();
         parser.set_language(tree_sitter_alumina()).unwrap();
 
         Processor {
@@ -413,11 +413,11 @@ impl Processor {
         self.items.free();
         self.parse_contexts.free_all();
     }
-    
+
     fn move(self: &mut Processor) -> Processor {
-        Processor { 
-            parser: self.parser.move(), 
-            items: self.items.move(), 
+        Processor {
+            parser: self.parser.move(),
+            items: self.items.move(),
             arena: self.arena.move(),
         }
     }
@@ -425,7 +425,7 @@ impl Processor {
     fn process_file(self: &mut Processor, module_path: &[u8], filename: std::fs::Path) -> Result<()> {
         let parse_context = self.arena.alloc(ParseContext::from_file(&self.parser, filename)?);
         self.parse_contexts.push(parse_context);
-            
+
         let path = Path::from_str(module_path);
         defer path.free();
 
@@ -440,8 +440,8 @@ impl Processor {
     fn write_page(self: &Processor, top_level: &Item) -> Result<()> {
         let filename = std::fs::PathBuf::from_str("./build/docs");
         defer filename.free();
-    
-    
+
+
         if top_level.path.segments.empty() {
             filename.push(std::fs::Path::new("index.html"));
         } else {
@@ -452,106 +452,106 @@ impl Processor {
                     } else {
                         format!("{}.{}.html", s, top_level.cfg_index).unwrap()
                     };
-    
+
                     filename.push(std::fs::Path::new(formatted.as_slice()));
                     formatted.free();
                 } else {
-                    filename.push(std::fs::Path::new(s));    
+                    filename.push(std::fs::Path::new(s));
                 }
             }
         }
-    
+
         let filename = filename.as_path();
-    
+
         std::fs::DirBuilder::new().recursive(true).create(filename.parent().unwrap())
             .map_err(Error::from_io)?;
-    
+
         let file = std::fs::File::create(filename).map_err(Error::from_io)?;
         defer file.close();
-    
+
         let writer = std::io::BufferedWriter::new(&file, 1024);
         defer {
             writer.flush();
             writer.free();
         };
-        
+
         let main_items = self.items
-            .filtered(|&top_level, v: &Item| -> bool { 
-                v.is_public() && v.path.len() == top_level.path.len() + 1 
+            .filtered(|&top_level, v: &Item| -> bool {
+                v.is_public() && v.path.len() == top_level.path.len() + 1
                     && v.path.starts_with(&top_level.path)
             });
         defer main_items.free();
-    
+
         let (nav_item, nav_items) = if !top_level.kind.show_siblings() {
             (top_level, &main_items)
         } else {
             let nav_items = self.items
-                .filtered(|&top_level, v: &Item| -> bool { 
-                    v.is_public() && v.path.len() == top_level.path.len() && 
-                        v.path.as_slice()[..v.path.len() - 1] == 
+                .filtered(|&top_level, v: &Item| -> bool {
+                    v.is_public() && v.path.len() == top_level.path.len() &&
+                        v.path.as_slice()[..v.path.len() - 1] ==
                             top_level.path.as_slice()[..v.path.len() - 1]
                 });
-            
+
             defer nav_items.free();
-            
+
             let parent_path = top_level.path.clone();
             defer parent_path.free();
             parent_path.pop();
-    
+
             let parent = self.items.get(&parent_path).unwrap();
             (parent, &nav_items)
         };
-    
+
         let page_writer = PageWriter { processor: self,  writer: &writer, item_bag: &self.items };
         page_writer.write_page(nav_item, top_level, nav_items, &main_items)
-    } 
-    
-    fn write_pages(self: &Processor) -> Result<()> { 
+    }
+
+    fn write_pages(self: &Processor) -> Result<()> {
         use std::string::join_fmt;
         use std::fmt::format;
-    
+
         for top_level in self.items.all().filter(|v: &Item| -> bool {  v.is_public() && v.kind.has_own_page() }) {
             self.write_page(top_level)?;
         }
-    
+
         Result::ok(())
-    } 
-    
-    fn write_index(self: &Processor) -> Result<()> { 
+    }
+
+    fn write_index(self: &Processor) -> Result<()> {
         use std::fmt::{write, writeln};
         use std::string::replace_fmt;
-    
+
         let filename = std::fs::Path::new("./build/docs/search_index.js");
         std::fs::DirBuilder::new().recursive(true).create(filename.parent().unwrap())
             .map_err(Error::from_io)?;
-    
+
         let file = std::fs::File::create(filename).map_err(Error::from_io)?;
         defer file.close();
-    
+
         let writer = std::io::BufferedWriter::new(&file, 1024);
         defer {
             writer.flush();
             writer.free();
         };
-    
+
         write!(&writer, "const index = [");
         for item in self.items.all().filter(|v: &Item| -> bool {  v.is_public() && v.kind.is_indexed() }) {
             let link_context = LinkContext::new(&self.items, &item.path);
             let link = link_context.link_for_item(item, false).unwrap();
             let doc = clean_doc_comment(&link_context, item.doc_comment.as_slice());
-    
-            write!(&writer, "[\"{}\",\"{}\",\"{}\"],", 
-                item.path, 
-                doc.as_slice(), 
+
+            write!(&writer, "[\"{}\",\"{}\",\"{}\"],",
+                item.path,
+                doc.as_slice(),
                 link
             ).map_err(Error::from::<std::fmt::Error>)?;
-            
+
             link.free();
             doc.free();
         }
         writeln!(&writer, "];");
         writeln!(&writer, "if (typeof window.loadSearchIndex !== \"undefined\") {{ window.loadSearchIndex(index); }}");
-    
+
         Result::ok(())
     }
 }
@@ -592,7 +592,7 @@ fn main_inner(args: &[&[u8]]) -> Result<()> {
 
     processor.write_pages()?;
     processor.write_index()?;
-        
+
     Result::ok(())
 }
 

--- a/tools/alumina-doc/markdown.alu
+++ b/tools/alumina-doc/markdown.alu
@@ -34,15 +34,15 @@ impl InlineMarkdownState {
     fn reset(self: &mut InlineMarkdownState) -> ::Result<(), Error> {
         if self.kind != State::Normal {
             return Result::err(Error::new())
-        } 
+        }
         self.free();
         *self = InlineMarkdownState::default();
         Result::ok(())
     }
 
     fn move(self: &mut InlineMarkdownState) -> InlineMarkdownState {
-        InlineMarkdownState { 
-            kind: self.kind, 
+        InlineMarkdownState {
+            kind: self.kind,
             link_text: self.link_text.move(),
             link_url: self.link_url.move()
         }
@@ -55,10 +55,10 @@ impl InlineMarkdownState {
 }
 
 /// A very tiny subset of Markdown is supported, just inline code, bold, italic and links
-/// without nesting. 
+/// without nesting.
 struct InlineMarkdown {
     inner: &[u8],
-    state: &mut InlineMarkdownState,    
+    state: &mut InlineMarkdownState,
     link_context: &LinkContext,
 }
 
@@ -93,13 +93,13 @@ impl InlineMarkdown {
             link.as_slice()
         }
 
-        write!(f, 
-            "<a class=\"{}\" href=\"{}\">{}</a>", 
+        write!(f,
+            "<a class=\"{}\" href=\"{}\">{}</a>",
             class,
             link,
             HtmlEscaped::str(text)
         )?;
-        
+
         self.state.link_url.clear();
         self.state.link_text.clear();
 
@@ -213,9 +213,9 @@ impl HtmlEscaped {
 
 /// A mini-markdown subset parser
 fn write_docstring<T: std::io::Writable<T>>(
-    writer: &mut T, 
-    doc_comment: &[u8], 
-    tagline_only: bool, 
+    writer: &mut T,
+    doc_comment: &[u8],
+    tagline_only: bool,
     link_context: &LinkContext
 ) -> Result {
     if doc_comment.len == 0 {
@@ -234,7 +234,7 @@ fn write_docstring<T: std::io::Writable<T>>(
             writer,
             item.doc_comment.as_slice(),
             tagline_only,
-            &link_context    
+            &link_context
         );
     }
 

--- a/tools/alumina-doc/visitors.alu
+++ b/tools/alumina-doc/visitors.alu
@@ -211,12 +211,19 @@ impl TopLevelVisitor {
         });
     }
 
+    fn visit_top_level_attributes(self: &mut TopLevelVisitor, node: Node) -> Result<()> {
+        self.visit_children(node)
+    }
+
     fn visit_attributes(self: &mut TopLevelVisitor, node: Node) -> Result<()> {
         self.visit_children(node)
     }
 
+    fn visit_top_level_attribute_item(self: &mut TopLevelVisitor, node: Node) -> Result<()> {
+        self.visit_attribute_item(node)
+    }
+
     fn visit_attribute_item(self: &mut TopLevelVisitor, node: Node) -> Result<()> {
-        
         if get_name!(self, child_by!(node, FieldKind::Inner).unwrap()) == "cfg" {
             self.has_cfg = true;
         }
@@ -225,7 +232,22 @@ impl TopLevelVisitor {
     }
 
     fn visit_source_file(self: &mut TopLevelVisitor, node: Node) -> Result<()> {
-        self.visit_children(node)
+        check_cfg!(self, node);
+
+        self.visit_children_by_field(node, FieldKind::Body)?;
+        self.items.add_item(Item {
+            kind: ItemKind::Module,
+            path: self.path.clone(),
+            defined_in: self.path.clone(),
+            node: node,
+            cfg_index: 0,
+            parse_context: self.parse_context,
+            doc_comment: self.file_doc_comment.move(),
+            group_node: Option::none(),
+            has_cfg: self.has_cfg,
+        });
+
+        Result::ok(())
     }
 
     fn visit_top_level_block(self: &mut TopLevelVisitor, node: Node) -> Result<()> {

--- a/tools/alumina-doc/visitors.alu
+++ b/tools/alumina-doc/visitors.alu
@@ -31,7 +31,7 @@ impl UseClauseVisitor {
             items: items
         }
     }
-  
+
     fn visit_use_wildcard(self: &mut UseClauseVisitor, node: Node) -> Result<()> {
         let suffix = Path::from_str(
             child_by!(node, FieldKind::Path)
@@ -57,7 +57,7 @@ impl UseClauseVisitor {
 
         let new_prefix = self.path.join_with(&suffix);
         let old_prefix = std::mem::replace(&self.path, new_prefix);
-        defer old_prefix.free();       
+        defer old_prefix.free();
 
         self.visit(child_by!(node, FieldKind::List).unwrap())?;
         std::mem::replace(&self.path, old_prefix.move()).free();
@@ -93,8 +93,8 @@ impl UseClauseVisitor {
 
         let name = child_by!(node, FieldKind::Name)
             .unwrap()
-            .text(self.parse_context.source());       
-        
+            .text(self.parse_context.source());
+
         self.items.add_alias(
             self.original_path.extend_with(name),
             path.extend_with(name)
@@ -109,10 +109,10 @@ impl UseClauseVisitor {
                 .text(self.parse_context.source())
         );
         defer path.free();
-        
+
         let name = child_by!(node, FieldKind::Alias)
             .unwrap()
-            .text(self.parse_context.source());        
+            .text(self.parse_context.source());
 
         self.items.add_alias(
             self.original_path.extend_with(name),
@@ -136,7 +136,7 @@ impl UseClauseVisitor {
     mixin NodeVisitorExt<UseClauseVisitor, Result<()>>;
     mixin NodeVisitor<UseClauseVisitor, Result<()>>;
 }
-    
+
 
 macro check_cfg($self, $node) {
     let has_cfg = $self.has_cfg;
@@ -146,7 +146,7 @@ macro check_cfg($self, $node) {
         $self.visit(child.inner)?;
     }
 
-    defer { $self.has_cfg = has_cfg; } 
+    defer { $self.has_cfg = has_cfg; }
 }
 
 struct TopLevelVisitor {
@@ -177,7 +177,7 @@ impl TopLevelVisitor {
         self.doc_comment.free();
         self.file_doc_comment.free();
     }
-    
+
     fn move(self: &mut TopLevelVisitor) -> TopLevelVisitor {
         TopLevelVisitor {
             parse_context: self.parse_context,
@@ -188,7 +188,7 @@ impl TopLevelVisitor {
             container: self.container
         }
     }
-    
+
     fn add_item(self: &mut TopLevelVisitor, kind: ItemKind, name: &[u8], node: Node) {
         let path = self.path.extend_with(name);
         defer path.free();
@@ -197,7 +197,7 @@ impl TopLevelVisitor {
             .get(&path)
             .map(|i: &Item| -> usize { i.cfg_index + 1 })
             .unwrap_or(0);
-        
+
         self.items.add_item(Item {
             kind: kind,
             path: path.clone(),
@@ -265,7 +265,7 @@ impl TopLevelVisitor {
 
         self.add_item(kind, get_name!(self, node), node);
         Result::ok(())
-    } 
+    }
 
     fn visit_enum_definition(self: &mut TopLevelVisitor, node: Node) -> Result<()> {
         check_cfg!(self, node);
@@ -277,28 +277,28 @@ impl TopLevelVisitor {
 
         self.visit_children_by_field(node, FieldKind::Body)?;
         Result::ok(())
-    } 
+    }
 
     fn visit_const_declaration(self: &mut TopLevelVisitor, node: Node) -> Result<()> {
         check_cfg!(self, node);
 
         self.add_item(ItemKind::Const, get_name!(self, node), node);
         Result::ok(())
-    } 
+    }
 
     fn visit_enum_item(self: &mut TopLevelVisitor, node: Node) -> Result<()> {
         check_cfg!(self, node);
 
         self.add_item(ItemKind::Variant, get_name!(self, node), node);
         Result::ok(())
-    } 
+    }
 
     fn visit_type_definition(self: &mut TopLevelVisitor, node: Node) -> Result<()> {
         check_cfg!(self, node);
 
         self.add_item(ItemKind::TypeDef, get_name!(self, node), node);
         Result::ok(())
-    } 
+    }
 
     fn visit_macro_definition(self: &mut TopLevelVisitor, node: Node) -> Result<()> {
         check_cfg!(self, node);
@@ -333,7 +333,7 @@ impl TopLevelVisitor {
         };
 
         self.add_item(kind, name, node);
-        
+
         self.path.push(name);
         defer self.path.pop();
 
@@ -362,19 +362,19 @@ impl TopLevelVisitor {
     fn visit_impl_block(self: &mut TopLevelVisitor, node: Node) -> Result<()> {
         check_cfg!(self, node);
         let name = child_by!(node, FieldKind::Name).unwrap().text(self.parse_context.source());
-                
+
         self.path.push(name);
         defer self.path.pop();
 
         let container = self.container;
-        
+
         self.container = Option::some(node);
         self.visit_children_by_field(node, FieldKind::Body)?;
         self.container = container;
 
         Result::ok(())
     }
-    
+
     fn visit_protocol_definition(self: &mut TopLevelVisitor, node: Node) -> Result<()> {
         check_cfg!(self, node);
         let name = child_by!(node, FieldKind::Name).unwrap().text(self.parse_context.source());
@@ -384,7 +384,7 @@ impl TopLevelVisitor {
         defer self.path.pop();
 
         let container = self.container;
-        
+
         self.container = Option::some(node);
         self.visit_children_by_field(node, FieldKind::Body)?;
         self.container = container;
@@ -411,8 +411,8 @@ impl TopLevelVisitor {
         self.file_doc_comment.extend_from_slice("\n");
         Result::ok(())
     }
-    
-    
+
+
     mixin NodeVisitorExt<TopLevelVisitor, Result<()>>;
     mixin NodeVisitor<TopLevelVisitor, Result<()>>;
 }
@@ -431,7 +431,7 @@ struct CodePrinter<W: Writable<W>> {
     parse_context: &ParseContext,
     link_context: &LinkContext,
     writer: &mut W,
-    
+
     protocol_bounds: bool
 }
 
@@ -447,18 +447,18 @@ impl CodePrinter<W: Writable<W>> {
 
     fn visit_function_definition(self: &mut CodePrinter<W>, node: Node) -> Result<()> {
         child_by!(node, FieldKind::Abi)
-            .map(|=self, child: Node| -> Result<()> { 
+            .map(|=self, child: Node| -> Result<()> {
                 w!(
-                    self.writer, 
-                    "<span class=\"keyword\">extern</span> <span class=\"literal-string\">{}</span> ", 
+                    self.writer,
+                    "<span class=\"keyword\">extern</span> <span class=\"literal-string\">{}</span> ",
                     child.text(self.parse_context.source())
                 );
-                Result::ok(()) 
+                Result::ok(())
             })
             .transpose()?;
-        
+
         w!(self.writer, "<span class=\"keyword\">fn</span> <span class=\"identifier-function\">{}</span>", get_name!(self, node));
-        
+
         child_by!(node, FieldKind::TypeArguments)
             .map(|=self, child: Node| -> Result<()> { self.visit(child) })
             .transpose()?;
@@ -466,20 +466,20 @@ impl CodePrinter<W: Writable<W>> {
         self.visit(child_by!(node, FieldKind::Parameters).unwrap())?;
 
         child_by!(node, FieldKind::ReturnType)
-            .map(|=self, child: Node| -> Result<()> { 
+            .map(|=self, child: Node| -> Result<()> {
                 w!(self.writer, " -> ");
                 self.visit(child)?
                 Result::ok(())
             })
             .transpose()?;
-            
+
         Result::ok(())
     }
-    
+
     fn visit_generic_argument_list(self: &mut CodePrinter<W>, node: Node) -> Result<()> {
         let cursor = node.walk();
         defer cursor.free();
-        
+
         w!(self.writer, "&lt;");
         for (idx, child) in children_by!(node, FieldKind::Argument, &cursor).enumerate() {
             if idx != 0 {
@@ -495,7 +495,7 @@ impl CodePrinter<W: Writable<W>> {
     fn visit_parameter_list(self: &mut CodePrinter<W>, node: Node) -> Result<()> {
         let cursor = node.walk();
         defer cursor.free();
-        
+
         w!(self.writer, "(");
         for (idx, child) in children_by!(node, FieldKind::Parameter, &cursor).enumerate() {
             if idx != 0 {
@@ -552,12 +552,12 @@ impl CodePrinter<W: Writable<W>> {
     fn visit_macro_parameter(self: &mut CodePrinter<W>, node: Node) -> Result<()> {
         let name = child_by!(node, FieldKind::Name).unwrap()
             .text(self.parse_context.source());
-        
+
         w!(self.writer, "{}", name);
         if child_by!(node, FieldKind::EtCetera).is_some {
             w!(self.writer, "...");
         }
-            
+
         Result::ok(())
     }
 
@@ -595,7 +595,7 @@ impl CodePrinter<W: Writable<W>> {
     fn visit_struct_field(self: &mut CodePrinter<W>, node: Node) -> Result<()> {
         let name = child_by!(node, FieldKind::Name).unwrap()
             .text(self.parse_context.source());
-        
+
         w!(self.writer, "{}: ", name);
         self.visit(child_by!(node, FieldKind::Type).unwrap())?;
 
@@ -615,7 +615,7 @@ impl CodePrinter<W: Writable<W>> {
     fn visit_tuple_type(self: &mut CodePrinter<W>, node: Node) -> Result<()> {
         let cursor = node.walk();
         defer cursor.free();
-        
+
         w!(self.writer, "(");
         for (idx, child) in children_by!(node, FieldKind::Element, &cursor).enumerate() {
             if idx != 0 {
@@ -631,7 +631,7 @@ impl CodePrinter<W: Writable<W>> {
     fn visit_parameter_type_list(self: &mut CodePrinter<W>, node: Node) -> Result<()> {
         let cursor = node.walk();
         defer cursor.free();
-        
+
         w!(self.writer, "(");
         for (idx, child) in children_by!(node, FieldKind::Parameter, &cursor).enumerate() {
             if idx != 0 {
@@ -655,7 +655,7 @@ impl CodePrinter<W: Writable<W>> {
     fn visit_type_arguments(self: &mut CodePrinter<W>, node: Node) -> Result<()> {
         let cursor = node.walk();
         defer cursor.free();
-        
+
         w!(self.writer, "&lt;");
         for (idx, child) in children_by!(node, FieldKind::Type, &cursor).enumerate() {
             if idx != 0 {
@@ -692,9 +692,9 @@ impl CodePrinter<W: Writable<W>> {
     fn visit_function_pointer(self: &mut CodePrinter<W>, node: Node) -> Result<()> {
         w!(self.writer, "fn");
         self.visit(child_by!(node, FieldKind::Parameters).unwrap())?;
-        
+
         child_by!(node, FieldKind::ReturnType)
-            .map(|=self, child: Node| -> Result<()> { 
+            .map(|=self, child: Node| -> Result<()> {
                 w!(self.writer, " -> ");
                 self.visit(child)?
                 Result::ok(())
@@ -705,7 +705,7 @@ impl CodePrinter<W: Writable<W>> {
     }
 
     fn visit_never_type(self: &mut CodePrinter<W>, node: Node) -> Result<()> {
-        w!(self.writer, "!");        
+        w!(self.writer, "!");
         Result::ok(())
     }
 
@@ -723,28 +723,28 @@ impl CodePrinter<W: Writable<W>> {
     fn visit_struct_definition(self: &mut CodePrinter<W>, node: Node) -> Result<()> {
         let kind_text = child_by!(node, FieldKind::Kind)
             .unwrap()
-            .text(self.parse_context.source());      
+            .text(self.parse_context.source());
 
         w!(self.writer, "<span class=\"keyword\">{}</span> <span class=\"identifier-type\">{}</span>", kind_text, get_name!(self, node));
-        
+
         child_by!(node, FieldKind::TypeArguments)
             .map(|=self, node: Node| -> Result<()> { self.visit(node) })
             .transpose()?
 
         w!(self.writer, " {{ ... }}");
-    
+
         Result::ok(())
     }
 
     fn visit_impl_block(self: &mut CodePrinter<W>, node: Node) -> Result<()> {
         w!(self.writer, "<span class=\"keyword\">impl</span> <span class=\"identifier-type\">{}</span>", get_name!(self, node));
-        
+
         child_by!(node, FieldKind::TypeArguments)
             .map(|=self, node: Node| -> Result<()> { self.visit(node) })
             .transpose()?
 
         w!(self.writer, " {{ ... }}");
-    
+
         Result::ok(())
     }
 
@@ -772,7 +772,7 @@ impl CodePrinter<W: Writable<W>> {
 
     fn visit_type_definition(self: &mut CodePrinter<W>, node: Node) -> Result<()> {
         w!(self.writer, "<span class=\"keyword\">type</span> <span class=\"identifier-type\">{}</span>", get_name!(self, node));
-        
+
         child_by!(node, FieldKind::TypeArguments)
             .map(|=self, child: Node| -> Result<()> { self.visit(child) })
             .transpose()?;
@@ -780,14 +780,14 @@ impl CodePrinter<W: Writable<W>> {
         w!(self.writer, " = ");
 
         self.visit(child_by!(node, FieldKind::Inner).unwrap())?;
-            
+
         Result::ok(())
     }
 
     fn visit_const_declaration(self: &mut CodePrinter<W>, node: Node) -> Result<()> {
         w!(self.writer, "<span class=\"keyword\">const</span> <span class=\"identifier-constant\">{}</span>", get_name!(self, node));
         child_by!(node, FieldKind::Type)
-            .map(|=self, child: Node| -> Result<()> { 
+            .map(|=self, child: Node| -> Result<()> {
                 w!(self.writer, ": ");
                 self.visit(child)?
                 Result::ok(())
@@ -799,17 +799,17 @@ impl CodePrinter<W: Writable<W>> {
 
     fn visit_static_declaration(self: &mut CodePrinter<W>, node: Node) -> Result<()> {
         w!(self.writer, "<span class=\"keyword\">static</span> <span class=\"identifier-constant\">{}</span>", get_name!(self, node));
-        
+
         child_by!(node, FieldKind::Type)
-            .map(|=self, child: Node| -> Result<()> { 
+            .map(|=self, child: Node| -> Result<()> {
                 w!(self.writer, ": ");
                 self.visit(child)?
                 Result::ok(())
             })
             .transpose()?;
-        
+
         child_by!(node, FieldKind::Init)
-            .map(|=self, child: Node| -> Result<()> { 
+            .map(|=self, child: Node| -> Result<()> {
                 w!(self.writer, " = ...");
                 Result::ok(())
             })
@@ -820,14 +820,14 @@ impl CodePrinter<W: Writable<W>> {
 
     fn visit_mixin(self: &mut CodePrinter<W>, node: Node) -> Result<()> {
         w!(self.writer, "<span class=\"keyword\">mixin</span>");
-        
+
         child_by!(node, FieldKind::TypeArguments)
             .map(|=self, child: Node| -> Result<()> { self.visit(child) })
             .transpose()?;
 
         w!(self.writer, " ");
         self.visit(child_by!(node, FieldKind::Protocol).unwrap())?;
-            
+
         Result::ok(())
     }
 

--- a/tools/alumina-doc/visitors.alu
+++ b/tools/alumina-doc/visitors.alu
@@ -492,7 +492,7 @@ impl CodePrinter<W: Writable<W>> {
 
     fn visit_protocol_bound(self: &mut CodePrinter<W>, node: Node) -> Result<()> {
         if child_by!(node, FieldKind::Negated).is_some {
-            w!(self.writer, ":");
+            w!(self.writer, "!");
         }
         self.visit(child_by!(node, FieldKind::Type).unwrap())
     }

--- a/tools/snapshot-tests/snapshot.py
+++ b/tools/snapshot-tests/snapshot.py
@@ -67,6 +67,8 @@ def test_examples(source_file, snapshot):
             "../../sysroot",
             "--cfg",
             "no_backtrace",
+            "--cfg",
+            "threading",
             "--output",
             os.path.join(BUILD_DIR, f"{output}.c"),
             f"example={example}",
@@ -95,6 +97,8 @@ def test_examples(source_file, snapshot):
                 os.path.join(BUILD_DIR, f"{output}.out"),
                 "./monkeypatch.c",
                 os.path.join(BUILD_DIR, f"{output}.c"),
+                "-lm",
+                "-lpthread"
             ],
             stderr=subprocess.PIPE,
         )

--- a/tools/snapshot-tests/snapshots/snap_snapshot.py
+++ b/tools/snapshot-tests/snapshots/snap_snapshot.py
@@ -237,6 +237,16 @@ snapshots['test_examples[tests.alu] run_stderr'] = b''
 
 snapshots['test_examples[tests.alu] run_stdout'] = b''
 
+snapshots['test_examples[threading.alu] compile_ret'] = 0
+
+snapshots['test_examples[threading.alu] compile_stderr'] = None
+
+snapshots['test_examples[threading.alu] run_ret'] = 0
+
+snapshots['test_examples[threading.alu] run_stderr'] = b''
+
+snapshots['test_examples[threading.alu] run_stdout'] = b'Sent 0\nSent 1\nSent 2\nSent 3\nSent 4\nReceived 0\nSent 5\nReceived 1\nSent 6\nReceived 2\nSent 7\nReceived 3\nSent 8\nReceived 4\nSent 9\nReceived 5\nReceived 6\nReceived 7\nReceived 8\nReceived 9\n'
+
 snapshots['test_examples[when_expression.alu] compile_ret'] = 0
 
 snapshots['test_examples[when_expression.alu] compile_stderr'] = None

--- a/tools/tree-sitter-codegen/main.alu
+++ b/tools/tree-sitter-codegen/main.alu
@@ -1,4 +1,4 @@
-//! This tool generates strongly-typed Tree-Sitter node types for the self-hosting compiler 
+//! This tool generates strongly-typed Tree-Sitter node types for the self-hosting compiler
 //! (to avoid matching by string) and visitor protocols.
 
 use std::collections::{Vector, HashMap, HashSet};
@@ -25,14 +25,14 @@ impl SanitizedIdentifier {
             inner: identifier,
             pascal_case: true
         }
-    }    
+    }
 
     fn fmt<F: Formatter<F>>(self: &SanitizedIdentifier, f: &mut F) -> Result<(), std::fmt::Error> {
         let first_char = true;
 
         for ch in self.inner {
-            if (ch >= 'a' && ch <= 'z') || 
-                (ch >= 'A' && ch <= 'Z') || 
+            if (ch >= 'a' && ch <= 'z') ||
+                (ch >= 'A' && ch <= 'Z') ||
                 (ch >= '0' && ch <= '9') || ch == '_' {
                     // Convert to PascalCase
                     if self.pascal_case {
@@ -40,7 +40,7 @@ impl SanitizedIdentifier {
                             if first_char {
                                 ch += 'A' - 'a';
                                 first_char = false;
-                            } 
+                            }
                         } else {
                             first_char = true;
                         }
@@ -51,7 +51,7 @@ impl SanitizedIdentifier {
                         f.write_char(ch)?;
                     }
                     continue;
-            } 
+            }
             let replacement = switch ch {
                 '~' => "TILDE",
                 '`' => "BQUOTE",
@@ -136,7 +136,7 @@ fn main(args: &[&[u8]]) {
         if symbol == 0 || language.symbol_type(symbol) != TSSymbolType::Regular {
             println!("    NodeKind::Invalid,");
             continue;
-        } 
+        }
 
         let name = language.symbol_name(symbol);
         println!("    NodeKind::{},", SanitizedIdentifier::pascal(name));
@@ -158,7 +158,7 @@ fn main(args: &[&[u8]]) {
     for name in unique_symbol_names {
         println!("            NodeKind::{} => self.visit_{}(node),",
             SanitizedIdentifier::pascal(name),
-            SanitizedIdentifier::default(name)    
+            SanitizedIdentifier::default(name)
         );
     }
     println!("            _ => self.visit_unknown(node),");


### PR DESCRIPTION
Another in the series of ~Rust ripoffs~ Rust-inspired additions, this time threading.

This makes some opinionated decisions on the runtime environment when threads are present, so `threading` attribute is added to globally disable threading functionality in the standard library. Omitting this also makes `#[thread_local]` attribute a no-op, so it is not safe to link non-multithreaded Alumina code with multi-threaded code in general.