### PR TITLE
feat: Coerce the branches of an if expression to the type of the provided hint

### DIFF
--- a/src/alumina-boot/src/ir/mono.rs
+++ b/src/alumina-boot/src/ir/mono.rs
@@ -3180,14 +3180,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
     ) -> Result<ir::ExprP<'ir>, AluminaError> {
         let cond = self.lower_expr(cond_, Some(self.types.builtin(BuiltinType::Bool)))?;
         let then = self.lower_expr(then, type_hint)?;
-        let els = self.lower_expr(
-            els_,
-            if then.diverges() {
-                type_hint.or(Some(then.ty))
-            } else {
-                Some(then.ty)
-            },
-        )?;
+        let els = self.lower_expr(els_, type_hint.or(Some(then.ty)))?;
 
         if cond.diverges() {
             return Ok(cond);

--- a/src/alumina-boot/src/ir/mono.rs
+++ b/src/alumina-boot/src/ir/mono.rs
@@ -3200,16 +3200,27 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         let then_typ = self.try_qualify_type(then.ty)?;
         let els_typ = self.try_qualify_type(els.ty)?;
 
-        let then = self.try_coerce(then_typ, then)?;
-        let els = self.try_coerce(els_typ, els)?;
+        let mut then = self.try_coerce(then_typ, then)?;
+        let mut els = self.try_coerce(els_typ, els)?;
 
         let gcd = ir::Ty::gcd(then.ty, els.ty);
         if !gcd.assignable_from(then.ty) || !gcd.assignable_from(els.ty) {
-            return Err(CodeErrorKind::MismatchedBranchTypes(
-                self.mono_ctx.type_name(then.ty).unwrap(),
-                self.mono_ctx.type_name(els.ty).unwrap(),
-            ))
-            .with_span(els_.span);
+            if let Some(hint) = type_hint {
+                // If the user supplied a type hint to the if expression, we can try coercing to it
+                // this is mostly for &T and &U -> &dyn Proto coercion where T and U are distinct types
+                // but satisfy the same protocol
+
+                if let (Ok(a), Ok(b)) = (self.try_coerce(hint, then), self.try_coerce(hint, els)) {
+                    then = a;
+                    els = b;
+                }
+            } else {
+                return Err(CodeErrorKind::MismatchedBranchTypes(
+                    self.mono_ctx.type_name(then.ty).unwrap(),
+                    self.mono_ctx.type_name(els.ty).unwrap(),
+                ))
+                .with_span(els_.span);
+            }
         }
 
         if let Ok(Value::Bool(v)) = const_eval(cond) {

--- a/sysroot/std/typing.alu
+++ b/sysroot/std/typing.alu
@@ -251,28 +251,40 @@ mod tests {
         // ...
     }
 
+    protocol Foo<Self> {
+        fn foo(self: &Self) -> i32;
+    }
+
+    protocol Bar<Self> {
+        fn bar(self: &Self) -> i32;
+    }
+
+    struct Quux {}
+
+    impl Quux {
+        fn foo(self: &Quux) -> i32 {
+            42
+        }
+
+        fn bar(self: &Quux) -> i32 {
+            1337
+        }
+    }
+
+    struct Frob {}
+
+    impl Frob {
+        fn foo(self: &Frob) -> i32 {
+            1337
+        }
+
+        fn bar(self: &Frob) -> i32 {
+            42
+        }
+    }
+
     #[test]
     fn test_dyn_multi_protocol() {
-        protocol Foo<Self> {
-            fn foo(self: &Self) -> i32;
-        }
-
-        protocol Bar<Self> {
-            fn bar(self: &Self) -> i32;
-        }
-
-        struct Quux {}
-
-        impl Quux {
-            fn foo(self: &Quux) -> i32 {
-                42
-            }
-
-            fn bar(self: &Quux) -> i32 {
-                1337
-            }
-        }
-
         let a = Quux {};
         let b: &dyn (Foo<Self> + Bar<Self>) = &a;
         let c: &dyn (Bar<Self> + Foo<Self>) = &a;
@@ -294,5 +306,18 @@ mod tests {
         let b: &mut dyn Empty<Self> = &a;
 
         assert_eq!(b as &mut void, &a as &mut void);
+    }
+
+    #[test]
+    fn test_dyn_if_coercion() {
+        for cond in [true, false] {
+            let p: &dyn Foo<Self> = if cond {
+                &Quux {}
+            } else {
+                &Frob {}
+            };
+
+            assert_eq!(p.foo(), if cond { 42 } else { 1337 });
+        }
     }
 }

--- a/sysroot/std/typing.alu
+++ b/sysroot/std/typing.alu
@@ -320,4 +320,20 @@ mod tests {
             assert_eq!(p.foo(), if cond { 42 } else { 1337 });
         }
     }
+
+    #[test]
+    fn test_dyn_if_coercion_switch() {
+        for i in 0..5 {
+            let p: &dyn Foo<Self> = switch i {
+                0 => &Quux {},
+                1 => &Frob {},
+                2 => &Quux {},
+                3 => &Frob {},
+                4 => &Quux {},
+                _ => unreachable!(),
+            };
+
+            assert_eq!(p.foo(), if i % 2 == 0 { 42 } else { 1337 });
+        }
+    }
 }


### PR DESCRIPTION
The types of the two branches in an if expression currently have to be the same type with the exception of pointer mutability and divergence (if one branch diverges it's fine).

However, it can be useful to take higher-level coercions into account as well. This cannot be automatic, since there are an infinite number of types it could be coerced to, but if a type hint is present, it can be done.

This is mostly to support constructs where the two branches create a pointer to a specific type which is then coerced into a `dyn` pointer.