### PR TITLE
fix: Fix the shadowing mechanics for local items

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ ALUMINAC = $(BUILD_DIR)/aluminac
 ALUMINAC_TESTS = $(BUILD_DIR)/aluminac-tests
 CODEGEN = $(BUILD_DIR)/aluminac-generate
 STDLIB_TESTS = $(BUILD_DIR)/stdlib-tests
+LANG_TESTS = $(BUILD_DIR)/lang-tests
 DOCTEST = $(BUILD_DIR)/doctest
 
 # If grammar changes, we need to rebuild the world
@@ -74,6 +75,17 @@ $(STDLIB_TESTS).c: $(ALUMINA_BOOT) $(SYSROOT_FILES)
 	$(ALUMINA_BOOT) $(ALUMINA_FLAGS) --cfg test --cfg test_std --output $@
 
 $(STDLIB_TESTS): $(STDLIB_TESTS).c
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+## ---------------------------- Lang tests -----------------------------
+
+LANG_TEST_FILES = $(shell find src/tests -type f -name '*.alu')
+
+$(LANG_TESTS).c: $(ALUMINA_BOOT) $(SYSROOT_FILES) $(LANG_TEST_FILES)
+	$(ALUMINA_BOOT) $(ALUMINA_FLAGS) --cfg test --output $@ \
+		$(foreach src,$(LANG_TEST_FILES),$(subst /,::,$(basename $(subst src/tests/,lang_tests/,$(src))))=$(src)) \
+
+$(LANG_TESTS): $(LANG_TESTS).c
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 ## ------------------ Self-hosted compiler (aluminac) ------------------

--- a/Makefile
+++ b/Makefile
@@ -213,10 +213,13 @@ alumina-boot: $(ALUMINA_BOOT)
 aluminac: $(ALUMINAC)
 	ln -sf $(ALUMINAC) $@
 
-.PHONY: test-std test-examples  test-alumina-boot test-aluminac test
+.PHONY: test-std test-examples  test-alumina-boot test-aluminac test-lang test
 
 test-std: alumina-boot $(STDLIB_TESTS)
 	$(STDLIB_TESTS) $(TEST_FLAGS)
+
+test-lang: alumina-boot $(LANG_TESTS)
+	$(LANG_TESTS) $(TEST_FLAGS)
 
 test-alumina-boot:
 	cargo test $(CARGO_FLAGS) --all-targets
@@ -224,7 +227,7 @@ test-alumina-boot:
 test-aluminac: $(ALUMINAC_TESTS)
 	$(ALUMINAC_TESTS) $(TEST_FLAGS)
 
-test: test-alumina-boot test-std
+test: test-alumina-boot test-std test-lang
 
 .DEFAULT_GOAL := all
 all: alumina-boot aluminac

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Alumina is an imperative, general-purpose, statically typed, compiled system pro
 Non-exhaustive list of distinguishing features:
 
 - Module system and 2-pass compilation (no header files and forward declarations needed)
-- Generics, protocols and mixins (duck-typed, similar to C++ templates but without overloading/SFINAE)
+- Generics (duck-typed, similar to C++ templates but without SFINAE), protocols and mixins
   - Specialization is possible with [`when` expressions](./examples/when_expression.alu)
   - Opt-in dynamic polymorphism with dynamic dispatch ([`dyn` pointers](./examples/dyn.alu))
 - [Unified call syntax](https://en.wikipedia.org/wiki/Uniform_Function_Call_Syntax) for functions in scope
@@ -18,8 +18,8 @@ Non-exhaustive list of distinguishing features:
   - tuples,
   - first-class 0-sized types (unit/void, function types, 0-sized arrays, structs with no fields, ...),
   - never type
-- Hygenic expression macros
-- Go-style [defer expressions](./examples/defer_and_move.alu)
+- Hygienic expression macros
+- [Defer expressions](./examples/defer_and_move.alu)
 
 Alumina is heavily inspired by Rust, especially in terms of syntax and standard library API. Unlike Rust, however, Alumina is not memory-safe and it requires manual memory management.
 
@@ -243,5 +243,5 @@ Standard library contributions are especially welcome! Ideas for contribution:
 
 Needless to say, a great way to contribute to the project is to just use Alumina for your own programs and libraries. Submit a PR and add your project to the list:
 
-- [timestamped](http://github.com/tibordp/timestamped) - A utility to record and replay the ouptut of a program with timestamps.
+- [timestamped](http://github.com/tibordp/timestamped) - A utility to record and replay the output of a program with timestamps.
 

--- a/src/alumina-boot/src/ast/maker.rs
+++ b/src/alumina-boot/src/ast/maker.rs
@@ -685,7 +685,7 @@ impl<'ast> AstItemMaker<'ast> {
         Ok(())
     }
 
-    fn make_item_group<'src>(
+    pub fn make_item_group<'src>(
         &mut self,
         scope: Scope<'ast, 'src>,
         name: Option<&'ast str>,

--- a/src/alumina-boot/src/codegen/functions.rs
+++ b/src/alumina-boot/src/codegen/functions.rs
@@ -521,7 +521,10 @@ impl<'ir, 'gen> FunctionWriter<'ir, 'gen> {
         } else {
             self.ctx.register_name(
                 id,
-                CName::Mangled(item.name.unwrap_or("anonymous"), self.ctx.make_id()),
+                match item.name {
+                    Some(name) => CName::Mangled(name, self.ctx.make_id()),
+                    None => CName::Id(self.ctx.make_id()),
+                }
             );
             write_function_signature(
                 self.ctx,

--- a/src/alumina-boot/src/codegen/functions.rs
+++ b/src/alumina-boot/src/codegen/functions.rs
@@ -524,7 +524,7 @@ impl<'ir, 'gen> FunctionWriter<'ir, 'gen> {
                 match item.name {
                     Some(name) => CName::Mangled(name, self.ctx.make_id()),
                     None => CName::Id(self.ctx.make_id()),
-                }
+                },
             );
             write_function_signature(
                 self.ctx,

--- a/src/alumina-boot/src/common.rs
+++ b/src/alumina-boot/src/common.rs
@@ -48,6 +48,8 @@ pub enum CodeErrorKind {
     CycleDetected,
     #[error("duplicate name `{}`", .0)]
     DuplicateName(String),
+    #[error("duplicate name `{}` ({} cannot shadow a {})", .0, .1, .2)]
+    CannotShadow(String, String, String),
     #[error("generic associated types are not supported, soz")]
     NoAssociatedTypes,
     #[error("invalid literal")]

--- a/src/tests/lang.alu
+++ b/src/tests/lang.alu
@@ -1,0 +1,37 @@
+//! Tests for various language features and constructs.
+
+#[test]
+fn test_linear_scope_shadowing_fn() {
+    fn foo() -> i32 {
+        1
+    }
+    assert_eq!(foo(), 1);
+
+    fn foo() -> i32 {
+        2
+    }
+    assert_eq!(foo(), 2);
+}
+
+#[test]
+fn test_linear_scope_shadowing_impl() {
+    struct Foo {}
+    impl Foo {
+        fn foo(self: &Foo) -> i32 {
+            1
+        }
+    }
+
+    assert_eq!(Foo{}.foo(), 1);
+
+    struct Foo {}
+    impl Foo {
+        fn foo(self: &Foo) -> i32 {
+            2
+        }
+    }
+
+    impl Bar {}
+
+    assert_eq!(Foo{}.foo(), 2);
+}

--- a/src/tests/lang.alu
+++ b/src/tests/lang.alu
@@ -31,7 +31,29 @@ fn test_linear_scope_shadowing_impl() {
         }
     }
 
-    impl Bar {}
-
     assert_eq!(Foo{}.foo(), 2);
+}
+
+#[test]
+fn test_linear_scope_shadowing_mixed() {
+    let foo = 1;
+    assert_eq!(foo, 1);
+
+    fn foo() -> i32 {
+        1
+    }
+    assert_eq!(foo(), 1);
+
+    struct foo {}
+    impl foo { fn foo() -> i32 { 2 } }
+
+    assert_eq!(foo::foo(), 2);
+
+    const foo: i32 = 3;
+    assert_eq!(foo, 3);
+
+    fn bar() -> i32 { 4 }
+
+    use bar as foo;
+    assert_eq!(foo(), 4);
 }


### PR DESCRIPTION
Local items had weird mechanics with shadowing as AstItemMaker ran at the end of the block which mean if a local item referenced another, which was later shadowed, it would use the wrong one, example

```rust
fn main() {
    fn foo() -> i32 { 1 }
    fn bar() -> i32 { foo() }
    fn foo() -> i32 { 2 }
    
    println!("{}", bar()); // 2
}
```

This PR fixes it so the above code would print 1 as expected, but it also changes the mechanics for `impl` blocks. In linear scopes they have to immediately follow the type they pertain to.

Cyclical references between local items are now also disallowed.