### PR TITLE
feat: Add BinaryHeap and binary_search to std

### DIFF
--- a/sysroot/std/cmp.alu
+++ b/sysroot/std/cmp.alu
@@ -146,10 +146,10 @@ impl Reversed<T: Comparable<T>> {
 ///
 /// ## Example
 /// ```
-/// use std::cmp::{sort_by, reversed};
+/// use std::cmp::{sort_by_key, reversed};
 ///
 /// let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
-/// slice.sort_by(reversed::<i32>);
+/// slice.sort_by_key(reversed::<i32>);
 ///
 /// assert_eq!(slice, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 /// ```
@@ -225,25 +225,40 @@ fn min<T: Comparable<T>>(a: T, b: T) -> T {
     }
 }
 
-/// Sorts a slice using a key extraction function.
+/// Sorts a slice using a custom comparison function.
 ///
 /// ## Example
 /// ```
-/// use std::cmp::sort_by;
+/// use std::cmp::{Ordering, sort_by};
 ///
 /// let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
-/// slice.sort_by(|v: &i32| -> i32 { -*v });
+/// slice.sort_by(|a: &i32, b: &i32| -> Ordering { b.compare(a) });
 ///
 /// assert_eq!(slice, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 /// ```
-fn sort_by<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &mut [T], key: F) {
+fn sort_by<T, F: Fn(&T, &T) -> Ordering>(arr: &mut [T], f: F) {
     if arr.len() <= 1 {
         return;
     }
 
-    let p = internal::partition_by(arr, key);
-    sort_by(arr[..p], key);
-    sort_by(arr[p+1..], key);
+    let p = internal::partition_by(arr, f);
+    sort_by(arr[..p], f);
+    sort_by(arr[p+1..], f);
+}
+
+/// Sorts a slice using a key extraction function.
+///
+/// ## Example
+/// ```
+/// use std::cmp::sort_by_key;
+///
+/// let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
+/// slice.sort_by_key(|v: &i32| -> i32 { -*v });
+///
+/// assert_eq!(slice, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+/// ```
+fn sort_by_key<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &mut [T], key: F) {
+    arr.sort_by(|=key, a: &T, b: &T| -> Ordering { key(a).compare(&key(b)) });
 }
 
 /// Sorts a slice.
@@ -260,7 +275,81 @@ fn sort_by<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &mut [T], key: F) {
 /// assert_eq!(slice, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 /// ```
 fn sort<T: Comparable<T>>(arr: &mut [T]) {
-    sort_by(arr, |k: &T| -> T { *k });
+    arr.sort_by(|a: &T, b: &T| -> Ordering { a.compare(b) });
+}
+
+
+/// Performs a binary search on a sorted slice.
+///
+/// If the element is found, returns `Result::ok(index)`, otherwise returns the index where the
+/// element should be inserted as `Result::err(index)`.
+///
+/// ## Example
+/// ```
+/// use std::cmp::binary_search;
+///
+/// let slice = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].as_slice();
+/// assert_eq!(slice.binary_search(&5), Result::ok(4usize));
+/// assert_eq!(slice.binary_search(&11), Result::err(10usize));
+/// ```
+fn binary_search<T: Comparable<T>>(arr: &[T], needle: &T) -> Result<usize, usize> {
+    arr.binary_search_by(|=needle, k: &T| -> Ordering { k.compare(needle) })
+}
+
+/// Performs a binary search on a sorted slice using a custom comparison function.
+///
+/// If the element is found, returns `Result::ok(index)`, otherwise returns the index where the
+/// element should be inserted as `Result::err(index)`.
+///
+/// ## Example
+/// ```
+/// use std::cmp::{Ordering, binary_search_by};
+///
+/// let slice = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].as_slice();
+/// assert_eq!(slice.binary_search_by(|k: &i32| -> Ordering { k.compare(&5) }), Result::ok(4usize));
+/// assert_eq!(slice.binary_search_by(|k: &i32| -> Ordering { k.compare(&11) }), Result::err(10usize));
+/// ```
+fn binary_search_by<T, F: Fn(&T) -> Ordering>(arr: &[T], f: F) -> Result<usize, usize> {
+    let size = arr.len();
+    let left = 0usize;
+    let right = size;
+
+    while left < right {
+        let mid = left + size / 2;
+        let cmp = f(&arr[mid]);
+
+        switch cmp {
+            Ordering::Less => left = mid + 1,
+            Ordering::Greater => right = mid,
+            _ => return Result::ok(mid)
+        }
+
+        size = right - left;
+    }
+
+    Result::err(left)
+}
+
+/// Performs a binary search on a sorted slice using a key extraction function.
+///
+/// If the element is found, returns `Result::ok(index)`, otherwise returns the index where the
+/// element should be inserted as `Result::err(index)`.
+///
+/// ## Example
+/// ```
+/// use std::cmp::binary_search_by_key;
+///
+/// let slice = [
+///     (0, 0), (1, 2), (2, 4),
+///     (3, 6), (4, 8), (5, 10),
+///     (6, 12), (7, 14), (8, 16)
+/// ].as_slice();
+///
+/// assert_eq!(slice.binary_search_by_key(&5, |v: &(i32, i32)| -> i32 { v.0 }), Result::ok(5usize));
+/// assert_eq!(slice.binary_search_by_key(&11, |v: &(i32, i32)| -> i32 { v.0 }), Result::err(9usize));
+/// ```
+fn binary_search_by_key<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &[T], needle: &K, key: F) -> Result<usize, usize> {
+    arr.binary_search_by(|=needle, =key, k: &T| -> Ordering { key(k).compare(needle) })
 }
 
 
@@ -301,14 +390,14 @@ mod internal {
         lhs.greater_than_or_equal(rhs)
     }
 
-    fn partition_by<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &mut [T], key: F) -> usize {
-        use std::mem::swap;
+    fn partition_by<T, F: Fn(&T, &T) -> Ordering>(arr: &mut [T], f: F) -> usize {
+        use mem::swap;
 
         let pivot = arr[arr.len() - 1];
         let i = 0usize;
         let j = 0usize;
         while j < arr.len() - 1 {
-            if key(&arr[j]) <= key(&pivot) {
+            if f(&arr[j], &pivot) != Ordering::Greater {
                 swap(&arr[i], &arr[j]);
                 i += 1;
             }
@@ -330,10 +419,47 @@ mod tests {
     }
 
     #[test]
-    fn test_sort_by() {
+    fn test_sort_by_key() {
         let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
-        sort_by(slice, |x: &i32| -> i32 { -*x });
+        sort_by_key(slice, |x: &i32| -> i32 { -*x });
 
         assert_eq!(slice, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+    }
+
+    #[test]
+    fn test_sort_by() {
+        let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
+        sort_by(slice, |x: &i32, y: &i32| -> Ordering { x.compare(y) });
+
+        assert_eq!(slice, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    }
+
+    #[test]
+    fn test_binary_search() {
+        let slice = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].as_slice();
+        assert_eq!(slice.binary_search(&5), Result::ok(4usize));
+        assert_eq!(slice.binary_search(&11), Result::err(10usize));
+    }
+
+    #[test]
+    fn test_binary_search_by() {
+        let slice = [
+            (0, 0), (1, 2), (2, 4),
+            (3, 6), (4, 8), (5, 10),
+            (6, 12), (7, 14), (8, 16)
+        ].as_slice();
+        assert_eq!(slice.binary_search_by(|v: &(i32, i32)| -> Ordering { v.0.compare(&5) }), Result::ok(5usize));
+        assert_eq!(slice.binary_search_by(|v: &(i32, i32)| -> Ordering { v.0.compare(&11) }), Result::err(9usize));
+    }
+
+    #[test]
+    fn test_binary_search_by_key() {
+        let slice = [
+            (0, 0), (1, 2), (2, 4),
+            (3, 6), (4, 8), (5, 10),
+            (6, 12), (7, 14), (8, 16)
+        ].as_slice();
+        assert_eq!(slice.binary_search_by_key(&5, |v: &(i32, i32)| -> i32 { v.0 }), Result::ok(5usize));
+        assert_eq!(slice.binary_search_by_key(&11, |v: &(i32, i32)| -> i32 { v.0 }), Result::err(9usize));
     }
 }

--- a/sysroot/std/collections.alu
+++ b/sysroot/std/collections.alu
@@ -4,6 +4,7 @@ use vector::Vector;
 use hashmap::HashMap;
 use hashset::HashSet;
 use deque::Deque;
+use heap::BinaryHeap;
 
 /// Helper for collections that own heap-allocated objects. This is used to
 /// be able to do `defer col.free_all()` without much boilerplate.

--- a/sysroot/std/collections/hashmap.alu
+++ b/sysroot/std/collections/hashmap.alu
@@ -1,7 +1,7 @@
-use std::hash::{Hashable, Hasher, DefaultHash, hash_of};
-use std::option::{Option, try};
-use std::cmp::Equatable;
-use std::iter::Iterator;
+use hash::{Hashable, Hasher, DefaultHash, hash_of};
+use option::{Option, try};
+use cmp::Equatable;
+use iter::Iterator;
 
 const INITIAL_SIZE: usize = 32;
 
@@ -19,10 +19,10 @@ const INITIAL_SIZE: usize = 32;
 /// map.insert(2, 4);
 /// map.insert(3, 5);
 ///
-/// assert!(map.get(1) == Option::some(2));
-/// assert!(map.get(2) == Option::some(4));
-/// assert!(map.get(3) == Option::some(5));
-/// assert!(map.get(4) == Option::none());
+/// assert!(map.get(&1) == Option::some(2));
+/// assert!(map.get(&2) == Option::some(4));
+/// assert!(map.get(&3) == Option::some(5));
+/// assert!(map.get(&4) == Option::none());
 /// ```
 struct HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
     _buckets: &mut [HashItem<(K, V)>],
@@ -30,7 +30,7 @@ struct HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> 
 }
 
 impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
-    use std::mem::slice;
+    use mem::slice;
 
     /// Creates an empty hash map
     ///
@@ -72,14 +72,14 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
     /// map.reserve(100);
     ///
     /// map.insert(1, 2);
-    /// let ptr = map.get_ref(1).unwrap();
+    /// let ptr = map.get_ref(&1).unwrap();
     ///
     /// for i in 1..100 {
     ///     map.insert(i, i * 2);
     /// }
     ///
     /// /// The first element is still at the same position.
-    /// assert_eq!(ptr, map.get_ref(1).unwrap());
+    /// assert_eq!(ptr, map.get_ref(&1).unwrap());
     /// ```
     fn reserve(self: &mut HashMap<K, V, H>, additional: usize) -> bool {
         // We keep the load factor below 0.75.
@@ -129,17 +129,17 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
     }
 
     /// Retreives the value by given key.
-    fn get(self: &HashMap<K, V, H>, key: K) -> Option<V> {
+    fn get(self: &HashMap<K, V, H>, key: &K) -> Option<V> {
         Option::some(self._get_slot(key)?.item.1)
     }
 
     /// Retreives a pointer to the value by given key.
-    fn get_ref(self: &HashMap<K, V, H>, key: K) -> Option<&V> {
+    fn get_ref(self: &HashMap<K, V, H>, key: &K) -> Option<&V> {
         Option::some(&self._get_slot(key)?.item.1 as &V)
     }
 
     /// Retreives a mutable pointer to the value by given key.
-    fn get_mut(self: &mut HashMap<K, V, H>, key: K) -> Option<&mut V> {
+    fn get_mut(self: &mut HashMap<K, V, H>, key: &K) -> Option<&mut V> {
         Option::some(&self._get_slot(key)?.item.1)
     }
 
@@ -147,7 +147,7 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
     ///
     /// If the element with the given key was present in the map, the corresponding value is
     /// returned. Otherwise, `Option::none()` is returned.
-    fn remove(self: &mut HashMap<K, V, H>, key: K) -> Option<V> {
+    fn remove(self: &mut HashMap<K, V, H>, key: &K) -> Option<V> {
         let item = self._get_slot(key)?;
         self._length -= 1;
         item.state = State::Deleted;
@@ -249,12 +249,14 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
         }
     }
 
-    fn _get_slot(self: &HashMap<K, V, H>, key: K) -> Option<&mut HashItem<(K, V)>> {
+    fn _get_slot(self: &HashMap<K, V, H>, key: &K) -> Option<&mut HashItem<(K, V)>> {
         if self._length == 0 {
             return Option::none();
         }
 
-        let initial_index = (hash_of::<K, H>(key) as usize) % self._buckets.len();
+        let hasher = H::new();
+        key.hash(&hasher);
+        let initial_index = (hasher.finish() as usize) % self._buckets.len();
         let index = initial_index;
 
         loop {
@@ -263,7 +265,7 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
                     return Option::none();
                 }
                 State::Occupied => {
-                    if self._buckets[index].item.0 == key {
+                    if self._buckets[index].item.0.equals(key) {
                         return Option::some(&self._buckets[index]);
                     }
                 }
@@ -295,10 +297,10 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
     ///
     /// map.retain(|k: &i32, v: &i32| -> bool { *k == *v });
     ///
-    /// assert_eq!(map.get(1), Option::some(1));
-    /// assert_eq!(map.get(2), Option::none());
-    /// assert_eq!(map.get(3), Option::none());
-    /// assert_eq!(map.get(4), Option::some(4));
+    /// assert_eq!(map.get(&1), Option::some(1));
+    /// assert_eq!(map.get(&2), Option::none());
+    /// assert_eq!(map.get(&3), Option::none());
+    /// assert_eq!(map.get(&4), Option::some(4));
     /// ```
     fn retain<F: Fn(&K, &V) -> bool>(self: &mut HashMap<K, V, H>, func: F) {
         let deleted = 0usize;
@@ -353,7 +355,7 @@ impl HashMap<
     /// defer map.free();
     ///
     /// assert!(map.len() == 3);
-    /// assert!(map.get(1) == Option::some(2));
+    /// assert!(map.get(&1) == Option::some(2));
     /// ```
     fn from_iter(iter: &mut I) -> HashMap<K, V, H> {
         let map = HashMap::new::<K, V, H>();
@@ -570,10 +572,10 @@ mod tests {
         map.insert(2, 4);
         map.insert(3, 5);
 
-        assert!(map.get(1) == Option::some(2));
-        assert!(map.get(2) == Option::some(4));
-        assert!(map.get(3) == Option::some(5));
-        assert!(map.get(4) == Option::none());
+        assert!(map.get(&1) == Option::some(2));
+        assert!(map.get(&2) == Option::some(4));
+        assert!(map.get(&3) == Option::some(5));
+        assert!(map.get(&4) == Option::none());
     }
 
     #[test]
@@ -585,9 +587,9 @@ mod tests {
         map.insert(2, 4);
         map.insert(3, 5);
 
-        *map.get_mut(1).unwrap() = 3;
+        *map.get_mut(&1).unwrap() = 3;
 
-        assert!(map.get(1) == Option::some(3));
+        assert!(map.get(&1) == Option::some(3));
     }
 
     #[test]
@@ -599,10 +601,10 @@ mod tests {
         map.insert(2, 4);
         map.insert(3, 5);
 
-        assert!(map.remove(1) == Option::some(2));
-        assert!(map.remove(2) == Option::some(4));
-        assert!(map.remove(3) == Option::some(5));
-        assert!(map.remove(4) == Option::none());
+        assert!(map.remove(&1) == Option::some(2));
+        assert!(map.remove(&2) == Option::some(4));
+        assert!(map.remove(&3) == Option::some(5));
+        assert!(map.remove(&4) == Option::none());
     }
 
     #[test]
@@ -728,8 +730,8 @@ mod tests {
         assert_eq!(*v.1, 5);
         *v.1 = 200;
 
-        assert_eq!(map.get(1).unwrap(), 100);
-        assert_eq!(map.get(3).unwrap(), 200);
+        assert_eq!(map.get(&1).unwrap(), 100);
+        assert_eq!(map.get(&3).unwrap(), 200);
     }
 
     #[test]

--- a/sysroot/std/collections/hashset.alu
+++ b/sysroot/std/collections/hashset.alu
@@ -1,7 +1,7 @@
-use std::hash::{Hashable, Hasher, DefaultHash};
-use std::option::{Option, try};
-use std::iter::{Iterator, Iterable};
-use std::cmp::Equatable;
+use hash::{Hashable, Hasher, DefaultHash};
+use option::{Option, try};
+use iter::{Iterator, Iterable};
+use cmp::Equatable;
 
 /// A hash-based set collection.
 ///
@@ -18,9 +18,9 @@ use std::cmp::Equatable;
 /// map.insert(2);
 /// map.insert(3);
 ///
-/// assert!(map.contains(1));
-/// assert!(map.contains(2));
-/// assert!(map.contains(3));
+/// assert!(map.contains(&1));
+/// assert!(map.contains(&2));
+/// assert!(map.contains(&3));
 /// ```
 struct HashSet<K: Hashable<K, H> + Equatable<K>, H: Hasher<H> = DefaultHash> {
     _inner: hashmap::HashMap<K, (), H>
@@ -89,13 +89,13 @@ impl HashSet<K: Hashable<K, H> + Equatable<K>, H: Hasher<H> = DefaultHash> {
     ///
     /// Returns `true` if the value was present in the set, `false` otherwise.
     #[inline]
-    fn remove(self: &mut HashSet<K, H>, item: K) -> bool {
+    fn remove(self: &mut HashSet<K, H>, item: &K) -> bool {
         self._inner.remove(item).is_some()
     }
 
     /// Retreives `true` if the set contains the given value, `false` otherwise.
     #[inline]
-    fn contains(self: &HashSet<K, H>, item: K) -> bool {
+    fn contains(self: &HashSet<K, H>, item: &K) -> bool {
         self._inner.get(item).is_some()
     }
 
@@ -151,9 +151,9 @@ impl HashSet<K: Hashable<K, H> + Equatable<K>, H: Hasher<H> = DefaultHash> {
     ///
     /// set.retain(|x: &i32| -> bool { *x % 2 == 0 });
     ///
-    /// assert!(!set.contains(1));
-    /// assert!(set.contains(2));
-    /// assert!(!set.contains(3));
+    /// assert!(!set.contains(&1));
+    /// assert!(set.contains(&2));
+    /// assert!(!set.contains(&3));
     /// ```
     fn retain<F: Fn(&K) -> bool>(self: &mut HashSet<K, H>, func: F) {
         self._inner.retain(|&func, k: &K, v: &()| -> bool { func(k) });
@@ -191,9 +191,9 @@ impl HashSet<K: Hashable<K, H> + Equatable<K>, I: Iterator<I, K>, H: Hasher<H> =
     /// defer set.free();
     ///
     /// assert_eq!(set.len(), 3);
-    /// assert!(set.contains(1));
-    /// assert!(set.contains(2));
-    /// assert!(set.contains(3));
+    /// assert!(set.contains(&1));
+    /// assert!(set.contains(&2));
+    /// assert!(set.contains(&3));
     /// ```
     fn from_iter(iter: &mut I) -> HashSet<K, H> {
         let set = HashSet::new::<K, H>();
@@ -309,8 +309,8 @@ mod tests {
         defer set.free();
 
         assert!(set.insert(1));
-        assert!(set.remove(1));
-        assert!(!set.remove(1));
+        assert!(set.remove(&1));
+        assert!(!set.remove(&1));
         assert!(set.is_empty());
     }
 
@@ -319,9 +319,9 @@ mod tests {
         let set = HashSet::new::<i32>();
         defer set.free();
 
-        assert!(!set.contains(1));
+        assert!(!set.contains(&1));
         assert!(set.insert(1));
-        assert!(set.contains(1));
+        assert!(set.contains(&1));
     }
 
     #[test]
@@ -343,7 +343,7 @@ mod tests {
         assert!(set.is_empty());
         assert!(set.insert(1));
         assert!(!set.is_empty());
-        assert!(set.remove(1));
+        assert!(set.remove(&1));
         assert!(set.is_empty());
     }
 
@@ -419,9 +419,9 @@ mod tests {
         defer set2.free();
 
         assert_eq!(set2.len(), 3);
-        assert!(set2.contains(1));
-        assert!(set2.contains(2));
-        assert!(set2.contains(3));
+        assert!(set2.contains(&1));
+        assert!(set2.contains(&2));
+        assert!(set2.contains(&3));
         assert!(set.is_empty());
     }
 
@@ -431,9 +431,9 @@ mod tests {
         defer set.free();
 
         assert_eq!(set.len(), 3);
-        assert!(set.contains(1));
-        assert!(set.contains(2));
-        assert!(set.contains(3));
+        assert!(set.contains(&1));
+        assert!(set.contains(&2));
+        assert!(set.contains(&3));
     }
 
     #[test]
@@ -443,8 +443,8 @@ mod tests {
 
         set.extend(&[1, 2, 3].iter());
         assert_eq!(set.len(), 3);
-        assert!(set.contains(1));
-        assert!(set.contains(2));
-        assert!(set.contains(3));
+        assert!(set.contains(&1));
+        assert!(set.contains(&2));
+        assert!(set.contains(&3));
     }
 }

--- a/sysroot/std/collections/heap.alu
+++ b/sysroot/std/collections/heap.alu
@@ -1,0 +1,653 @@
+//! Binary heap collection and utilities.
+//!
+//! This module provides an allocating binary heap collection type, [BinaryHeap] as well as
+//! methods for in-place binary heaps over raw slices ([heapify], [sift_up], [sift_down], ...).
+
+use cmp::Comparable;
+
+/// A binary max-heap (priority queue).
+///
+/// # Example
+/// ```
+/// use std::collections::BinaryHeap;
+///
+/// let heap: BinaryHeap<i32> = BinaryHeap::new();
+/// defer heap.free();
+///
+/// heap.push(2);
+/// heap.push(9);
+/// heap.push(5);
+///
+/// assert_eq!(heap.pop(), Option::some(9));
+/// assert_eq!(heap.pop(), Option::some(5));
+/// assert_eq!(heap.pop(), Option::some(2));
+/// assert_eq!(heap.pop(), Option::none());
+/// ```
+///
+/// Min-heap functionality can be achieved by using a `BinaryHeap` over a type
+/// that implements [cmp::Comparable] in reverse order.
+///
+/// ```
+/// use std::collections::BinaryHeap;
+/// use std::cmp::{Comparable, Ordering};
+///
+/// struct ReversedI32 { val: i32 }
+///
+/// impl ReversedI32 {
+///     fn compare(self: &ReversedI32, other: &ReversedI32) -> Ordering {
+///         other.val.compare(&self.val)
+///     }
+///
+///     mixin Comparable<ReversedI32>;
+/// }
+///
+/// let heap: BinaryHeap<ReversedI32> = BinaryHeap::new();
+/// defer heap.free();
+///
+/// heap.push(ReversedI32 { val: 2 });
+/// heap.push(ReversedI32 { val: 9 });
+/// heap.push(ReversedI32 { val: 5 });
+///
+/// assert_eq!(heap.pop(), Option::some(ReversedI32 { val: 2 }));
+/// assert_eq!(heap.pop(), Option::some(ReversedI32 { val: 5 }));
+/// assert_eq!(heap.pop(), Option::some(ReversedI32 { val: 9 }));
+/// assert_eq!(heap.pop(), Option::none());
+/// ```
+struct BinaryHeap<T: Comparable<T>> {
+    _data: Vector<T>
+}
+
+impl BinaryHeap<T: Comparable<T>> {
+    use iter::Iterator;
+
+    /// Creates an empty binary heap.
+    ///
+    /// This will not allocate until the first element is inserted.
+    fn new() -> BinaryHeap<T> {
+        BinaryHeap { _data: Vector::new() }
+    }
+
+    /// Create a heap that can hold up to `capacity` elements without reallocating.
+    fn with_capacity(capacity: usize) -> BinaryHeap<T> {
+        BinaryHeap { _data: Vector::with_capacity(capacity) }
+    }
+
+    /// Creates a heap from an existing vector.
+    ///
+    /// The vector will be heapified in-place.
+    fn from_vector(vector: Vector<T>) -> BinaryHeap<T> {
+        let heap = BinaryHeap { _data: vector };
+        heapify(heap._data.as_slice_mut());
+
+        heap
+    }
+
+    /// Creates a heap from an existing vector.
+    ///
+    /// The vector is assumed to be heapified. If it is not, the behavior is
+    /// undefined.
+    fn from_vector_raw(vector: Vector<T>) -> BinaryHeap<T> {
+        BinaryHeap { _data: vector }
+    }
+
+    /// Creates a heap from a slice of elements.
+    ///
+    /// The elements are copied into the heap and heapified.
+    fn from_slice(slice: &[T]) -> BinaryHeap<T> {
+        from_vector(Vector::from_slice(slice))
+    }
+
+    /// Creates a heap from an iterator.
+    fn from_iter<I: Iterator<I, T>>(iter: &mut I) -> BinaryHeap<T> {
+        let heap = BinaryHeap::new::<T>();
+        heap.extend(iter);
+        heap
+    }
+
+    /// Reserves capacity for at least `additional` more elements
+    /// to be inserted without reallocating.
+    fn reserve(self: &mut BinaryHeap<T>, additional: usize) {
+        self._data.reserve(additional);
+    }
+
+    /// Returns the maximum number of elements the heap can hold
+    /// without reallocating.
+    fn capacity(self: &BinaryHeap<T>) -> usize {
+        self._data.capacity()
+    }
+
+    /// Returns `true` if the heap contains no elements.
+    fn is_empty(self: &BinaryHeap<T>) -> bool {
+        self._data.is_empty()
+    }
+
+    /// Returns the number of elements in the heap.
+    fn len(self: &BinaryHeap<T>) -> usize {
+        self._data.len()
+    }
+
+    /// Extends the heap from an iterator.
+    fn extend<I: Iterator<I, T>>(self: &mut BinaryHeap<T>, iter: &mut I) {
+        self.reserve(iter.size_hint().unwrap_or(0));
+
+        loop {
+            let item = iter.next();
+            if item.is_some() {
+                self.push(item.unwrap());
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Extends the heap from a slice of elements.
+    fn extend_from_slice(self: &mut BinaryHeap<T>, slice: &[T]) {
+        let old_len = self.len();
+        self._data.extend_from_slice(slice);
+        heapify_tail(self._data.as_slice_mut(), old_len);
+    }
+
+    /// Inserts an element into the heap.
+    fn push(self: &mut BinaryHeap<T>, value: T) {
+        let old_len = self._data.len();
+        self._data.push(value);
+
+        sift_up(self._data.as_slice_mut(), 0, old_len);
+    }
+
+    /// Returns the largest element in the heap without removing it.
+    ///
+    /// Returns `Option::none()` if the heap is empty.
+    fn peek(self: &BinaryHeap<T>) -> Option<T> {
+        self._data.get(0)
+    }
+
+    /// Removes the maximum element in the heap, returning it.
+    ///
+    /// Returns `Option::none()` if the heap is empty.
+    fn pop(self: &mut BinaryHeap<T>) -> Option<T> {
+        self._data.pop().map(|=self, item: T| -> T {
+            if !self.is_empty() {
+                mem::swap(&item, &self._data._data[0]);
+                sift_down_to_bottom(self._data.as_slice_mut(), 0);
+            }
+
+            item
+        })
+    }
+
+    /// Shrink the size of the underlying buffer to the minimum size
+    /// needed to hold the current elements.
+    fn shrink_to_fit(self: &mut BinaryHeap<T>) {
+        self._data.shrink_to_fit();
+    }
+
+    /// Removes the elements not mathing the given predicate.
+    ///
+    /// Does not remove excess capacity, call [shrink_to_fit] afterwards, if this
+    /// is desired.
+    fn retain<F: Fn(&T) -> bool>(self: &mut BinaryHeap<T>, f: F) {
+        let first_removed = self.len();
+
+        let i = 0usize;
+        self._data.retain(|=f, &first_removed, &i, e: &T| -> bool {
+            let keep = f(e);
+            if !keep && i < first_removed {
+                first_removed = i;
+            }
+            i += 1;
+            keep
+        });
+
+        heapify_tail(self._data.as_slice_mut(), first_removed);
+    }
+
+    /// Returns an iterator over the elements in the heap.
+    ///
+    /// The iterator will return the elements in arbitrary order (satisfying the
+    /// heap property).
+    fn iter(self: &BinaryHeap<T>) -> mem::SliceIterator<&T> {
+        self._data.iter()
+    }
+
+    /// Returns a iterator over the pointers to elements in the heap.
+    ///
+    /// The iterator will return the elements in arbitrary order (satisfying the
+    /// heap property).
+    fn iter_ref(self: &BinaryHeap<T>) -> mem::SliceRefIterator<&T> {
+        self._data.iter_ref()
+    }
+
+    /// View the vector as a slice of elements in arbitrary order (satisfying the
+    /// heap property).
+    fn as_slice(self: &BinaryHeap<T>) -> &[T] {
+        self._data.as_slice()
+    }
+
+    /// Converts the heap into the underlying vector. The elements
+    /// are in no particular order (satisfying the heap property).
+    ///
+    /// `self` is emptied after this operation (like after [move]).
+    fn into_vector(self: &mut BinaryHeap<T>) -> Vector<T> {
+        self._data.move()
+    }
+
+    /// Converts the heap into the underlying vector. The elements
+    /// are additionally sorted in ascending order.
+    ///
+    /// `self` is emptied after this operation (like after [move]).
+    fn into_sorted_vector(self: &mut BinaryHeap<T>) -> Vector<T> {
+        unheapify(self._data.as_slice_mut());
+
+        self.into_vector()
+    }
+
+    /// Clears the heap, removing all values.
+    fn clear(self: &mut BinaryHeap<T>) {
+        self._data.clear();
+    }
+
+    /// Returns an iterator that removes all elements from the heap and yields them in
+    /// sorted order (descending).
+    fn iter_drain(self: &mut BinaryHeap<T>) -> HeapIterator<T> {
+        HeapIterator { heap: self }
+    }
+
+    /// @ mem::Freeable::free
+    fn free(self: &mut BinaryHeap<T>) {
+        self._data.free();
+    }
+
+    /// @ mem::Movable::move
+    fn move(self: &mut BinaryHeap<T>) -> BinaryHeap<T> {
+        BinaryHeap { _data: self._data.move() }
+    }
+
+    /// @ mem::Clonable::clone
+    fn clone(self: &BinaryHeap<T>) -> BinaryHeap<T> {
+        from_vector_raw(self._data.clone())
+    }
+}
+
+/// Draining heap iterator.
+///
+/// See [BinaryHeap::iter_drain].
+struct HeapIterator<T: Comparable<T>> {
+    heap: &mut BinaryHeap<T>,
+}
+
+impl HeapIterator<T: Comparable<T>> {
+    /// @ iter::Iterator::next
+    fn next(self: &mut HeapIterator<T>) -> Option<T> {
+        self.heap.pop()
+    }
+
+    /// @ iter::Iterator::size_hint
+    fn size_hint(self: &HeapIterator<T>) -> Option<usize> {
+        Option::some(self.heap.len())
+    }
+
+    mixin iter::Iterator<HeapIterator<T>, T>;
+    mixin iter::IteratorExt<HeapIterator<T>, T>;
+}
+
+/// Reorder the elements of a slice so they satisfy the (max) heap property.
+fn heapify<T: Comparable<T>>(self: &mut [T]) {
+    let n = self.len() / 2;
+    while n > 0 {
+        n -= 1;
+        self.sift_down(n);
+    }
+}
+
+/// Reorder the elements of a slice so they satisfy the (max) heap property.
+///
+/// This variant assumes that the prefix of the slice up to `start - 1` inclusive
+/// already satisfies the heap property.
+fn heapify_tail<T: Comparable<T>>(self: &mut [T], start: usize) {
+    if start == self.len() {
+        return;
+    }
+
+    let tail_len = self.len() - start;
+
+    fn log2_fast(x: usize) -> usize {
+        mem::size_of::<usize>() * 8 - (x.leading_zeros() as usize) - 1
+    }
+
+    let better_to_rebuild = if start < tail_len {
+        true
+    } else if self.len() <= 2048 {
+        2usize * self.len() < tail_len * log2_fast(start)
+    } else {
+        2usize * self.len() < tail_len * 11
+    };
+
+    if better_to_rebuild {
+        self.heapify();
+    } else {
+        for i in start..self.len() {
+            self.sift_up(0, i);
+        }
+    }
+}
+
+/// Sorts an array satisfying the max heap property in ascending order.
+fn unheapify<T: Comparable<T>>(self: &mut [T]) {
+    let end = self.len();
+    while end > 1 {
+        end -= 1;
+        mem::swap(&self[0], &self[end]);
+        self.sift_down_range(0, end);
+    }
+}
+
+/// Sifts an element up the heap until it reaches its correct position.
+fn sift_up<T: Comparable<T>>(self: &mut [T], start: usize, pos: usize) -> usize {
+    while pos > start {
+        let parent = (pos - 1) / 2;
+
+        if self[pos] <= self[parent] {
+            break;
+        }
+
+        mem::swap(&self[pos],  &self[parent]);
+        pos = parent;
+    }
+    pos
+}
+
+/// Sifts an element down the heap until it reaches its correct position.
+fn sift_down_range<T: Comparable<T>>(self: &mut [T], pos: usize, end: usize) {
+    let start = pos;
+    let child = 2usize * pos + 1;
+
+    while child + 2 <= end {
+        if self[child] <= self[child + 1] {
+            child += 1;
+        }
+
+        if self[pos] >= self[child] {
+            return;
+        }
+
+        std::mem::swap(&self[pos], &self[child]);
+        pos = child;
+        child = 2 * pos + 1;
+    }
+
+    if child == end - 1 && self[pos] < self[child] {
+        mem::swap(&self[pos], &self[child]);
+    }
+}
+
+/// Sifts an element down the heap until it reaches its correct position.
+fn sift_down<T: Comparable<T>>(self: &mut [T], pos: usize) {
+    let len = self.len();
+    self.sift_down_range(pos, len);
+}
+
+/// Sifts an element to the bottom of the heap, then sifts it up until it reaches
+/// its correct position.
+///
+/// This is apparently faster than just calling `sift_down` until the element
+/// reaches the correct position.
+fn sift_down_to_bottom<T: Comparable<T>>(self: &mut [T], pos: usize) {
+    let end = self.len();
+    let start = pos;
+
+    let child = 2usize * pos + 1;
+    while child + 2 <= end {
+        if self[child] <= self[child + 1] {
+            child += 1;
+        }
+        mem::swap(&self[pos], &self[child]);
+        pos = child;
+        child = 2 * pos + 1;
+    }
+    if child == end - 1 {
+        mem::swap(&self[pos], &self[child]);
+        pos = child;
+    }
+
+    self.sift_up(start, pos);
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_basic() {
+        let heap: BinaryHeap<i32> = BinaryHeap::new();
+        defer heap.free();
+
+        assert!(heap.is_empty());
+        assert_eq!(heap.len(), 0);
+
+        heap.push(2);
+        heap.push(6);
+        heap.push(5);
+
+        assert!(!heap.is_empty());
+        assert_eq!(heap.len(), 3);
+
+        assert_eq!(heap.pop(), Option::some(6));
+        assert_eq!(heap.pop(), Option::some(5));
+        assert_eq!(heap.pop(), Option::some(2));
+        assert_eq!(heap.pop(), Option::none());
+    }
+
+    #[test]
+    fn test_peek() {
+        let heap: BinaryHeap<i32> = BinaryHeap::new();
+        defer heap.free();
+
+        assert_eq!(heap.peek(), Option::none());
+
+        heap.push(2);
+        heap.push(6);
+        heap.push(5);
+
+        assert_eq!(heap.peek(), Option::some(6));
+        assert_eq!(heap.peek(), Option::some(6));
+    }
+
+    #[test]
+    fn test_from_slice() {
+        let heap = BinaryHeap::from_slice(&[ 5, 8, 2, 7, 6, 10, 3, 1, 9, 4 ]);
+        defer heap.free();
+
+        assert_eq!(heap.pop(), Option::some(10));
+        assert_eq!(heap.pop(), Option::some(9));
+        assert_eq!(heap.pop(), Option::some(8));
+        assert_eq!(heap.pop(), Option::some(7));
+        assert_eq!(heap.pop(), Option::some(6));
+        assert_eq!(heap.pop(), Option::some(5));
+        assert_eq!(heap.pop(), Option::some(4));
+        assert_eq!(heap.pop(), Option::some(3));
+        assert_eq!(heap.pop(), Option::some(2));
+        assert_eq!(heap.pop(), Option::some(1));
+        assert_eq!(heap.pop(), Option::none());
+    }
+
+    #[test]
+    fn test_from_iter() {
+        let heap: BinaryHeap<i32> = BinaryHeap::from_iter(&[ 5, 8, 2, 7, 6, 10, 3, 1, 9, 4 ].iter());
+        defer heap.free();
+
+        assert_eq!(heap.pop(), Option::some(10));
+        assert_eq!(heap.pop(), Option::some(9));
+        assert_eq!(heap.pop(), Option::some(8));
+        assert_eq!(heap.pop(), Option::some(7));
+        assert_eq!(heap.pop(), Option::some(6));
+        assert_eq!(heap.pop(), Option::some(5));
+        assert_eq!(heap.pop(), Option::some(4));
+        assert_eq!(heap.pop(), Option::some(3));
+        assert_eq!(heap.pop(), Option::some(2));
+        assert_eq!(heap.pop(), Option::some(1));
+        assert_eq!(heap.pop(), Option::none());
+    }
+
+    #[test]
+    fn test_extend_from_slice() {
+        let heap: BinaryHeap<i32> = BinaryHeap::new();
+        defer heap.free();
+
+        heap.push(6);
+        heap.push(10);
+        heap.push(3);
+        heap.extend_from_slice(&[ 5, 8, 2, 7, 1, 9, 4 ]);
+
+        assert_eq!(heap.pop(), Option::some(10));
+        assert_eq!(heap.pop(), Option::some(9));
+        assert_eq!(heap.pop(), Option::some(8));
+        assert_eq!(heap.pop(), Option::some(7));
+        assert_eq!(heap.pop(), Option::some(6));
+        assert_eq!(heap.pop(), Option::some(5));
+        assert_eq!(heap.pop(), Option::some(4));
+        assert_eq!(heap.pop(), Option::some(3));
+        assert_eq!(heap.pop(), Option::some(2));
+        assert_eq!(heap.pop(), Option::some(1));
+        assert_eq!(heap.pop(), Option::none());
+    }
+
+    #[test]
+    fn test_retain() {
+        let heap = BinaryHeap::from_slice(&[ 5, 8, 2, 7, 6, 10, 3, 1, 9, 4 ]);
+        defer heap.free();
+
+        heap.retain(|i: &i32| -> bool { *i > 3 });
+
+        assert_eq!(heap.pop(), Option::some(10));
+        assert_eq!(heap.pop(), Option::some(9));
+        assert_eq!(heap.pop(), Option::some(8));
+        assert_eq!(heap.pop(), Option::some(7));
+        assert_eq!(heap.pop(), Option::some(6));
+        assert_eq!(heap.pop(), Option::some(5));
+        assert_eq!(heap.pop(), Option::some(4));
+        assert_eq!(heap.pop(), Option::none());
+    }
+
+    #[test]
+    fn test_clear() {
+        let heap = BinaryHeap::from_slice(&[ 5, 8, 2, 7, 6, 10, 3, 1, 9, 4 ]);
+        defer heap.free();
+
+        heap.clear();
+
+        assert!(heap.is_empty());
+        assert_eq!(heap.len(), 0);
+    }
+
+    #[test]
+    fn test_into_vector() {
+        let heap = BinaryHeap::from_slice(&[ 5, 8, 2, 7, 6, 10, 3, 1, 9, 4 ]);
+        defer heap.free();
+
+        let vec = heap.into_vector();
+        defer vec.free();
+
+        // "Arbitrary" order that satisfies the heap property.
+        assert_eq!(vec.as_slice(), &[ 10, 9, 5, 8, 6, 2, 3, 1, 7, 4 ]);
+    }
+
+    #[test]
+    fn test_as_slice() {
+        let heap = BinaryHeap::from_slice(&[ 5, 8, 2, 7, 6, 10, 3, 1, 9, 4 ]);
+        defer heap.free();
+
+        // "Arbitrary" order that satisfies the heap property.
+        assert_eq!(heap.as_slice(), &[ 10, 9, 5, 8, 6, 2, 3, 1, 7, 4 ]);
+    }
+
+    #[test]
+    fn test_iter() {
+        let heap = BinaryHeap::from_slice(&[ 5, 8, 2, 7, 6, 10, 3, 1, 9, 4 ]);
+        defer heap.free();
+
+        let iter = heap.iter();
+        assert_eq!(iter.next(), Option::some(10));
+        assert_eq!(iter.next(), Option::some(9));
+        assert_eq!(iter.next(), Option::some(5));
+        assert_eq!(iter.next(), Option::some(8));
+        assert_eq!(iter.next(), Option::some(6));
+        assert_eq!(iter.next(), Option::some(2));
+        assert_eq!(iter.next(), Option::some(3));
+        assert_eq!(iter.next(), Option::some(1));
+        assert_eq!(iter.next(), Option::some(7));
+        assert_eq!(iter.next(), Option::some(4));
+        assert_eq!(iter.next(), Option::none());
+    }
+
+    #[test]
+    fn test_iter_ref() {
+        let heap = BinaryHeap::from_slice(&[ 5, 8, 2, 7, 6, 10, 3, 1, 9, 4 ]);
+        defer heap.free();
+
+        let iter = heap.iter_ref();
+        assert_eq!(*iter.next().unwrap(), 10);
+        assert_eq!(*iter.next().unwrap(), 9);
+        assert_eq!(*iter.next().unwrap(), 5);
+        assert_eq!(*iter.next().unwrap(), 8);
+        assert_eq!(*iter.next().unwrap(), 6);
+        assert_eq!(*iter.next().unwrap(), 2);
+        assert_eq!(*iter.next().unwrap(), 3);
+        assert_eq!(*iter.next().unwrap(), 1);
+        assert_eq!(*iter.next().unwrap(), 7);
+        assert_eq!(*iter.next().unwrap(), 4);
+        assert!(!iter.next().is_some());
+    }
+
+    #[test]
+    fn test_iter_drain() {
+        let heap = BinaryHeap::from_slice(&[ 5, 8, 2, 7, 6, 10, 3, 1, 9, 4 ]);
+        defer heap.free();
+
+        let iter = heap.iter_drain();
+        assert_eq!(iter.next(), Option::some(10));
+        assert_eq!(iter.next(), Option::some(9));
+        assert_eq!(iter.next(), Option::some(8));
+        assert_eq!(iter.next(), Option::some(7));
+        assert_eq!(iter.next(), Option::some(6));
+        assert_eq!(iter.next(), Option::some(5));
+        assert_eq!(iter.next(), Option::some(4));
+        assert_eq!(iter.next(), Option::some(3));
+        assert_eq!(iter.next(), Option::some(2));
+        assert_eq!(iter.next(), Option::some(1));
+        assert_eq!(iter.next(), Option::none());
+
+        assert!(heap.is_empty());
+        assert_eq!(heap.len(), 0);
+    }
+
+    #[test]
+    fn test_into_sorted_vector() {
+        let heap = BinaryHeap::from_slice(&[ 5, 8, 2, 7, 6, 10, 3, 1, 9, 4 ]);
+        defer heap.free();
+
+        let vec = heap.into_sorted_vector();
+        defer vec.free();
+
+        assert_eq!(vec.as_slice(), &[ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]);
+    }
+
+    #[test]
+    fn test_clone() {
+        let heap = BinaryHeap::from_slice(&[ 5, 8, 2, 7, 6, 10, 3, 1, 9, 4 ]);
+        defer heap.free();
+
+        let heap2 = heap.clone();
+        defer heap2.free();
+
+        assert_eq!(heap2.pop(), Option::some(10));
+        assert_eq!(heap2.pop(), Option::some(9));
+        assert_eq!(heap2.pop(), Option::some(8));
+        assert_eq!(heap2.pop(), Option::some(7));
+        assert_eq!(heap2.pop(), Option::some(6));
+        assert_eq!(heap2.pop(), Option::some(5));
+        assert_eq!(heap2.pop(), Option::some(4));
+        assert_eq!(heap2.pop(), Option::some(3));
+        assert_eq!(heap2.pop(), Option::some(2));
+        assert_eq!(heap2.pop(), Option::some(1));
+        assert_eq!(heap2.pop(), Option::none());
+    }
+}

--- a/sysroot/std/collections/vector.alu
+++ b/sysroot/std/collections/vector.alu
@@ -23,12 +23,12 @@ struct Vector<T> {
 }
 
 impl Vector<T> {
-    use std::mem::slice;
-    use std::iter::{Iterator, Iterable};
+    use mem::slice;
+    use iter::{Iterator, Iterable};
 
     /// Create an empty vector
     ///
-    /// This will not call allocate until the first element is inserted.
+    /// This will not allocate until the first element is inserted.
     fn new() -> Vector<T> {
         Vector {
             _data: slice::empty(),
@@ -331,7 +331,7 @@ impl Vector<T> {
         ret
     }
 
-    /// Create a shallow copy of the vector.
+    /// @ mem::Clonable::clone
     fn clone(self: &Vector<T>) -> Vector<T> {
         let vec = Vector::new::<T>();
         vec.extend_from_slice(self.as_slice());
@@ -340,7 +340,7 @@ impl Vector<T> {
 }
 
 impl Vector {
-    use std::fmt::{Formatter, Formattable};
+    use fmt::{Formatter, Formattable};
 
     /// @ std::fmt::Formatter::write_str
     fn write_str(self: &mut Vector<u8>, buf: &[u8]) -> Result<(), fmt::Error> {

--- a/sysroot/std/ffi.alu
+++ b/sysroot/std/ffi.alu
@@ -38,7 +38,7 @@ impl CString {
     ///
     /// Allocates memory.
     fn from_slice(s: &[u8]) -> CString {
-        use std::mem::slice;
+        use mem::slice;
 
         let ret = slice::alloc::<u8>(s.len() + 1);
         s.copy_to_nonoverlapping(&ret[0]);

--- a/sysroot/std/fs/unix.alu
+++ b/sysroot/std/fs/unix.alu
@@ -469,7 +469,7 @@ fn read_directory(path: Path) -> Result<DirIterator> {
 /// println!("Current directory: {}", cwd);
 /// ```
 fn canonicalize(path: Path) -> Result<PathBuf> {
-    use std::ffi::CString;
+    use ffi::CString;
 
     let path_c = CString::from_slice(path.inner);
     defer path_c.free();
@@ -506,7 +506,7 @@ impl FileType {
 
     /// @ fmt::Formattable::fmt
     fn fmt<F: std::fmt::Formatter<F>>(self: &FileType, fmt: &mut F) -> std::fmt::Result {
-        use std::fmt::write;
+        use fmt::write;
         switch *self {
             FileType::Unknown => write!(fmt, "unknown"),
             FileType::Fifo => write!(fmt, "fifo"),
@@ -573,7 +573,7 @@ impl FileAttr {
 #[cfg(all(test, test_std))]
 mod tests {
     use fmt::{hex, zero_pad, format, format_in};
-    use cmp::sort_by;
+    use cmp::sort_by_key;
     use collections::free_all;
     use string::StringBuf;
 
@@ -662,7 +662,7 @@ mod tests {
             .to_vector();
         defer entries.free_all();
 
-        entries.as_slice_mut().sort_by(|e: &StringBuf| -> &[u8] { e.as_slice() });
+        entries.as_slice_mut().sort_by_key(|e: &StringBuf| -> &[u8] { e.as_slice() });
 
         let it = entries.iter_ref().map(StringBuf::as_slice::<u8>);
 

--- a/sysroot/std/hash.alu
+++ b/sysroot/std/hash.alu
@@ -30,7 +30,7 @@
 /// assert_eq!(hash_of::<&[u8], CountingHash>("ab"), 2);
 /// ```
 protocol Hasher<Self> {
-    use std::mem::{size_of,slice::from_raw};
+    use mem::{size_of,slice::from_raw};
 
     /// Create a new hasher.
     fn new() -> Self;
@@ -98,7 +98,7 @@ protocol Hashable<Self, H: Hasher<H>> {
     /// See [Hashable] for details.
     #[inline]
     fn hash(a: &Self, hasher: &mut H) {
-        use std::mem::{size_of,slice::from_raw};
+        use mem::{size_of,slice::from_raw};
         hasher.write(from_raw(a as &u8, size_of::<Self>()));
     }
 }

--- a/sysroot/std/io.alu
+++ b/sysroot/std/io.alu
@@ -417,7 +417,7 @@ struct BufferedReader<R: Readable<R>> {
 }
 
 impl BufferedReader<R: Readable<R>> {
-    use std::mem::slice;
+    use mem::slice;
     use internal::default_read_exact;
 
     /// Create a BufferedReader with a heap-allocated buffer of the given size.
@@ -745,7 +745,7 @@ struct LineIterator<R: BufferedReadable<R>> {
 }
 
 impl LineIterator<R: BufferedReadable<R>> {
-    use std::iter::Iterator;
+    use iter::Iterator;
 
     /// Create a line iterator with a pre-allocated buffer.
     fn with_line_buffer(reader: &mut R, line_buf: string::StringBuf) -> LineIterator<R> {

--- a/sysroot/std/mem.alu
+++ b/sysroot/std/mem.alu
@@ -73,9 +73,9 @@ struct slice<Ptr: builtins::Pointer> {
 
 impl slice {
     use builtins::Pointer;
-    use std::cmp::{Equatable, Comparable, Ordering};
-    use std::hash::{Hasher, Hashable};
-    use std::builtins::{Primitive, PointerOf, ZeroSized};
+    use cmp::{Equatable, Comparable, Ordering};
+    use hash::{Hasher, Hashable};
+    use builtins::{Primitive, PointerOf, ZeroSized};
     use libc::memcmp;
 
     /// Empty slice
@@ -259,7 +259,7 @@ impl slice {
 
     /// @ std::cmp::Comparable::compare
     fn compare<T: Comparable<T>, Ptr: PointerOf<T>>(lhs: &slice<Ptr>, rhs: &slice<Ptr>) -> Ordering {
-        use std::cmp::min;
+        use cmp::min;
 
         when T: ZeroSized {
             lhs.len().compare(&rhs.len())

--- a/sysroot/std/option.alu
+++ b/sysroot/std/option.alu
@@ -407,10 +407,10 @@ impl Option<T> {
 }
 
 impl Option {
-    use std::cmp::{Equatable, Comparable, Ordering};
-    use std::fmt::{write, Formatter, Formattable};
-    use std::hash::{Hashable, Hasher};
-    use std::mem::{Freeable, Movable};
+    use cmp::{Equatable, Comparable, Ordering};
+    use fmt::{write, Formatter, Formattable};
+    use hash::{Hashable, Hasher};
+    use mem::{Freeable, Movable};
 
     /// Convert `Option<Result<T, E>>` to `Result<Option<T>, E>`
     ///

--- a/sysroot/std/process/unix.alu
+++ b/sysroot/std/process/unix.alu
@@ -466,8 +466,8 @@ impl Command {
 
 mod internal {
     use io::{Readable, AsFileDescriptor};
+    use io::unix::{ErrorKind, errno_try};
     use fs::Path;
-    use std::io::unix::{ErrorKind, errno_try};
     use string::StringBuf;
 
     extern "C" static environ: &&libc::c_char;
@@ -587,7 +587,7 @@ mod internal {
         }
 
         fn install(self: &mut ChildStdio, fd: libc::c_int) -> Result<()> {
-            use std::fs::{File, OpenOptions};
+            use fs::{File, OpenOptions};
             if self.theirs.is_some() {
                 errno_try!(libc::dup2(self.theirs.unwrap().value, fd));
             }

--- a/sysroot/std/random.alu
+++ b/sysroot/std/random.alu
@@ -18,7 +18,7 @@
 //! The module also provides a [Pcg32], a decent general purpose pseudo-random generator, [OsRng] backed by the OS-provided
 //! random number generator, and [thread_rng], a convenience thread-local random generator that does not need manual seeding.
 
-use std::builtins::{Unsigned, Integer, FloatingPoint};
+use builtins::{Unsigned, Integer, FloatingPoint};
 
 /// Random number generators
 ///
@@ -159,7 +159,7 @@ type DefaultRng = Pcg32;
     ///
     /// ## Usage notes
     /// `OsRng` is generally considered to be safe to use for cryptographic purposes. However, since
-    /// it results in a syscall for each operation, it may not be a good general-purpose RNG.
+    /// it results in a syscall for each operation, it may be too slow when used as a general-purpose RNG.
     ///
     /// Good choice for seeding other RNGs.
     struct OsRng {
@@ -273,7 +273,7 @@ protocol RngExt<Self: Rng<Self>> {
     /// ```
     fn next<T: Integer, R: builtins::RangeOf<T>>(rng: &mut Self, range: R) -> T {
         use builtins::unsigned_of;
-        use std::range::{Range, RangeInclusive, RangeTo, RangeToInclusive, RangeFrom, RangeFull};
+        use range::{Range, RangeInclusive, RangeTo, RangeToInclusive, RangeFrom, RangeFull};
 
         when R: Range<T> {
             assert!(range.lower < range.upper);
@@ -341,7 +341,7 @@ protocol RngExt<Self: Rng<Self>> {
     /// }
     /// ```
     fn shuffle<T>(rng: &mut Self, slice: &mut [T]) {
-        use std::mem::swap;
+        use mem::swap;
 
         let i = 0usize;
         while i < slice.len() {

--- a/sysroot/std/range.alu
+++ b/sysroot/std/range.alu
@@ -18,7 +18,7 @@
 //!
 //! See also [builtins::Range] and [builtins::RangeOf] for protocols that can be used for designing APIs that accept generic ranges.
 
-use std::builtins::Integer;
+use builtins::Integer;
 
 /// An unbounded range (`..`)
 #[lang(range_full)]
@@ -444,7 +444,7 @@ mod tests {
 
     #[test]
     fn test_hash() {
-        use std::hash::hash_of;
+        use hash::hash_of;
 
         assert_eq!(hash_of(..), hash_of(()));
         assert_ne!(hash_of(1..), hash_of(2..));

--- a/sysroot/std/result.alu
+++ b/sysroot/std/result.alu
@@ -90,7 +90,7 @@ union _ResultT<T, E> {
 }
 
 impl Result<T, E> {
-    use std::fmt::{write, Formatter, Formattable};
+    use fmt::{write, Formatter, Formattable};
 
     /// Create a success variant
     ///
@@ -330,10 +330,10 @@ impl Result<T, E> {
 }
 
 impl Result {
-    use std::fmt::{write, Formatter, Formattable};
-    use std::hash::{Hashable, Hasher};
-    use std::cmp::{Equatable};
-    use std::mem::{Freeable, Movable};
+    use fmt::{write, Formatter, Formattable};
+    use hash::{Hashable, Hasher};
+    use cmp::{Equatable};
+    use mem::{Freeable, Movable};
 
     /// Convert `Result<Option<T>, E>` to `Option<Result<T, E>>`
     ///
@@ -415,7 +415,7 @@ impl Result {
 }
 
 mod internal {
-    use std::fmt::{write, Formatter, Formattable};
+    use fmt::{write, Formatter, Formattable};
 
     #[cold]
     #[no_inline]

--- a/sysroot/std/runtime.alu
+++ b/sysroot/std/runtime.alu
@@ -2,9 +2,9 @@
 
 #[cfg(not(output_type = "library"))]
 mod internal {
-    use std::intrinsics::{aligned_alloca, size_of, align_of};
+    use intrinsics::{aligned_alloca, size_of, align_of};
     use builtins::{return_type_of, arguments_of, NamedFunction};
-    use std::mem::slice;
+    use mem::slice;
 
     #[cfg(all(test))]
     {

--- a/sysroot/std/string.alu
+++ b/sysroot/std/string.alu
@@ -9,7 +9,7 @@
 //! assert_eq!("\u{1f60a}", "\xf0\x9f\x98\x8a");
 //! "\xe2\x82\x28\x00\xf0\x01\x02"; // Not valid UTF-8, but a valid string literal
 //! ```
-use std::option::Option;
+use option::Option;
 
 const RADIX_DIGITS = "0123456789abcdefghijklmnopqrstuvwxyz";
 
@@ -299,7 +299,7 @@ struct ReplaceAdapter {
 }
 
 impl ReplaceAdapter {
-    use std::fmt::{write, Error, Formatter};
+    use fmt::{write, Error, Formatter};
 
     fn fmt<F: Formatter<F>>(self: &ReplaceAdapter, f: &mut F) -> Result<(), Error> {
         let first = true;
@@ -344,7 +344,7 @@ struct JoinAdapter<It: iter::Iterator<It, &[u8]>> {
 }
 
 impl JoinAdapter<It: iter::Iterator<It, &[u8]>> {
-    use std::fmt::{write, Error, Formatter};
+    use fmt::{write, Error, Formatter};
 
     fn fmt<F: fmt::Formatter<F>>(self: &JoinAdapter<It>, f: &mut F) -> Result<(), Error> {
         let first = true;

--- a/sysroot/std/thread.alu
+++ b/sysroot/std/thread.alu
@@ -2,8 +2,8 @@
 //!
 //! See also the [std::sync] module for synchronization primitives.
 
-use std::io::Error;
-use std::sync::{Atomic, Ordering};
+use io::Error;
+use sync::{Atomic, Ordering};
 
 enum JoinErrorKind {
     Os,

--- a/sysroot/std/time.alu
+++ b/sysroot/std/time.alu
@@ -29,7 +29,7 @@ struct Instant {
 }
 
 impl Instant {
-    use std::hash::Hasher;
+    use hash::Hasher;
 
     /// Current instant
     fn now() -> Instant {
@@ -209,7 +209,7 @@ struct Duration {
 }
 
 impl Duration {
-    use std::hash::Hasher;
+    use hash::Hasher;
 
     fn new(secs: i64, nanos: u32) -> Duration {
         Duration {

--- a/sysroot/test.alu
+++ b/sysroot/test.alu
@@ -51,7 +51,7 @@
 {
     use std::process::{Stdio, Forked};
     use std::collections::{Vector, free_all};
-    use std::cmp::sort_by;
+    use std::cmp::sort_by_key;
     use std::string::StringBuf;
     use std::runtime::internal::{TEST_CASES, TestCaseMeta};
     use std::time::{Instant, Duration};
@@ -216,7 +216,7 @@
 
         test_cases
             .as_slice_mut()
-            .sort_by(|m: &TestCaseMeta| -> (&[u8], &[u8]) {
+            .sort_by_key(|m: &TestCaseMeta| -> (&[u8], &[u8]) {
                 (m.path, m.name)
             });
 

--- a/tools/alumina-doc/common.alu
+++ b/tools/alumina-doc/common.alu
@@ -3,7 +3,7 @@ use std::string::{split, StringBuf};
 
 use tree_sitter::{Node, Parser, Tree};
 use std::collections::{free_all, HashMap};
-use std::cmp::sort_by;
+use std::cmp::sort_by_key;
 
 use aluminac::lib::arena::Arena;
 
@@ -368,7 +368,7 @@ impl ItemBag {
     fn sort(self: &mut ItemBag) {
         self.items
             .as_slice_mut()
-            .sort_by(|it: &&Item| -> (&[&[u8]], i32, usize, &[u8]) {
+            .sort_by_key(|it: &&Item| -> (&[&[u8]], i32, usize, &[u8]) {
                 use std::mem::slice::empty;
 
                 let item_loc = it.node.start_byte();
@@ -383,24 +383,24 @@ impl ItemBag {
     }
 
     fn get(self: &ItemBag, path: &Path) -> Option<&Item> {
-        self.lookup.get(*path)
+        self.lookup.get(path)
     }
 
     fn resolve(self: &ItemBag, scope: &Path, path: &Path, go_down: bool) -> Option<&Item> {
         let joined = scope.join_with(path);
         defer joined.free();
 
-        let proper = self.lookup.get(joined);
+        let proper = self.lookup.get(&joined);
         if proper.is_some() {
             return proper;
         }
 
-        let alias = self.aliases.get(joined);
+        let alias = self.aliases.get(&joined);
         if alias.is_some() {
             return self.resolve(scope, &alias.unwrap(), true);
         }
 
-        let star_alias = self.star_aliases.get(*scope);
+        let star_alias = self.star_aliases.get(scope);
         if star_alias.is_some() {
             let maybe_resolved = self.resolve(&star_alias.unwrap(), path, false);
             if maybe_resolved.is_some() {
@@ -435,7 +435,7 @@ impl ItemBag {
                 src_path.push(s);
             }
 
-            if !self.lookup.get(src_path).is_some() {
+            if !self.lookup.get(&src_path).is_some() {
                 self.add_item(Item {
                     kind: i.kind,
                     cfg_index: i.cfg_index,
@@ -463,7 +463,7 @@ impl ItemBag {
                 let resolved = self.resolve(&scope, &suffix, true);
                 if resolved.is_some() {
                     let item = resolved.unwrap();
-                    if !self.lookup.get(src).is_some() {
+                    if !self.lookup.get(&src).is_some() {
                         insertion_count += 1;
                         self.sync_reexport(&src, &item.defined_in);
                     }


### PR DESCRIPTION
- Adds `std::collections::BinaryHeap` ~shamelessly stolen from~ inspired by Rust
- Adds `std::cmp::binary_search{_by,_by_key}`

Also breaking change, `HashMap::get(...)` now takes a pointer as a parameter rather than a value. There may be further such changes coming up.