### PR TITLE
fix(compiler): Fix miscompilation in ZST elider

### DIFF
--- a/src/alumina-boot/src/ast/lang.rs
+++ b/src/alumina-boot/src/ast/lang.rs
@@ -120,12 +120,10 @@ impl LangItemKind {
     }
 
     pub fn is_builtin_impl(&self) -> bool {
-        match self {
-            LangItemKind::ImplBuiltin(_) | LangItemKind::ImplTuple(_) | LangItemKind::ImplArray => {
-                true
-            }
-            _ => false,
-        }
+        matches!(
+            self,
+            LangItemKind::ImplBuiltin(_) | LangItemKind::ImplTuple(_) | LangItemKind::ImplArray
+        )
     }
 }
 

--- a/src/alumina-boot/src/ir/elide_zst.rs
+++ b/src/alumina-boot/src/ir/elide_zst.rs
@@ -172,7 +172,7 @@ impl<'ir> ZstElider<'ir> {
                 let inner = self.elide_zst_expr(inner);
                 if inner.ty.is_zero_sized() {
                     builder.block(
-                        [Statement::Expression(self.elide_zst_expr(inner))],
+                        [Statement::Expression(inner)],
                         builder.ret(builder.void(expr.ty, expr.value_type)),
                     )
                 } else {


### PR DESCRIPTION
Due to some weird mechanics in elide_zst, the following

```rust
fn bar() -> bool {
    true
}

fn foo() { 
    if bar() {
        return;
    } else if bar() {
        foo();
    } else {
        foo();
    }
}
```

looped endlessly, as it was compiled to the equivalent of 

```c
void foo() {
    if (bar()) {
        __builtin_unreachable();
    } else {
        if (bar()) {
            foo();
        } else {
            foo();
        }
    }
}
```

This PR fixes it.