### PR TITLE
feat(stdlib): Better sorting algorithms

### DIFF
--- a/sysroot/std/cmp.alu
+++ b/sysroot/std/cmp.alu
@@ -225,7 +225,64 @@ fn min<T: Comparable<T>>(a: T, b: T) -> T {
     }
 }
 
-/// Sorts a slice using a custom comparison function.
+/// Returns `true` if the array is sorted by the given comparison function.
+///
+/// ## Example
+/// ```
+/// use std::cmp::{Ordering, is_sorted_by};
+///
+/// let arr1 = [5, 3, 2, 4, 1].as_slice();
+/// let arr2 = [1, 2, 3, 4, 5].as_slice();
+///
+/// assert!(!arr1.is_sorted_by(i32::compare));
+/// assert!(arr2.is_sorted_by(i32::compare));
+/// ```
+fn is_sorted_by<T, F: Fn(&T, &T) -> Ordering>(arr: &[T], f: F) -> bool {
+    for i in 1usize..arr.len() {
+        if f(&arr[i - 1], &arr[i]) == Ordering::Greater {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Returns `true` if the array is sorted using a key extraction function.
+///
+/// ## Example
+/// ```
+/// use std::cmp::is_sorted_by_key;
+///
+/// let arr = [(5, 1), (3, 2), (2, 3), (4, 4), (1, 5)].as_slice();
+///
+/// assert!(!arr.is_sorted_by_key(|e: &(i32, i32)| -> i32 { e.0 }));
+/// assert!(arr.is_sorted_by_key(|e: &(i32, i32)| -> i32 { e.1 }));
+/// ```
+fn is_sorted_by_key<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &[T], key: F) -> bool {
+    arr.is_sorted_by(|=key, a: &T, b: &T| -> Ordering { key(a).compare(&key(b)) })
+}
+
+/// Returns `true` if the array is sorted.
+///
+/// ## Example
+/// ```
+/// use std::cmp::is_sorted;
+///
+/// let arr1 = [5, 3, 2, 4, 1].as_slice();
+/// let arr2 = [1, 2, 3, 4, 5].as_slice();
+///
+/// assert!(!arr1.is_sorted());
+/// assert!(arr2.is_sorted());
+/// ```
+fn is_sorted<T: Comparable<T>>(arr: &[T]) -> bool {
+    arr.is_sorted_by(|a: &T, b: &T| -> Ordering { a.compare(b) })
+}
+
+/// Sorts a slice using a custom comparison function. The sort is unstable (i.e. does not
+/// preserve the order of equal elements).
+///
+/// The algorithm used is introsort (quicksort with a fallback to heapsort and insertion sort
+/// when the recursion depth exceeds a certain limit and when the array is small, respectively).
 ///
 /// ## Example
 /// ```
@@ -240,13 +297,15 @@ fn sort_by<T, F: Fn(&T, &T) -> Ordering>(arr: &mut [T], f: F) {
     if arr.len() <= 1 {
         return;
     }
-
-    let p = internal::partition_by(arr, f);
-    sort_by(arr[..p], f);
-    sort_by(arr[p+1..], f);
+    let max_depth = collections::heap::internal::log2_fast(arr.len()) * 2;
+    internal::introsort_by(arr, max_depth, f);
 }
 
-/// Sorts a slice using a key extraction function.
+/// Sorts a slice using a key extraction function. The sort is unstable (i.e. does not
+/// preserve the order of equal elements).
+///
+/// The algorithm used is introsort (quicksort with a fallback to heapsort and insertion sort
+/// when the recursion depth exceeds a certain limit and when the array is small, respectively).
 ///
 /// ## Example
 /// ```
@@ -261,9 +320,10 @@ fn sort_by_key<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &mut [T], key: F) {
     arr.sort_by(|=key, a: &T, b: &T| -> Ordering { key(a).compare(&key(b)) });
 }
 
-/// Sorts a slice.
+/// Sorts a slice. The sort is unstable (i.e. does not preserve the order of equal elements).
 ///
-/// Uses quicksort with naive partitioning. Sort is not stable.
+/// The algorithm used is introsort (quicksort with a fallback to heapsort and insertion sort
+/// when the recursion depth exceeds a certain limit and when the array is small, respectively).
 ///
 /// ## Example
 /// ```
@@ -275,7 +335,71 @@ fn sort_by_key<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &mut [T], key: F) {
 /// assert_eq!(slice, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 /// ```
 fn sort<T: Comparable<T>>(arr: &mut [T]) {
-    arr.sort_by(|a: &T, b: &T| -> Ordering { a.compare(b) });
+    arr.sort_by(internal::default_compare::<T>);
+}
+
+/// Sorts a slice using a custom comparison function. The sort is stable (i.e. preserves the
+/// order of equal elements).
+///
+/// The algorithm used is mergesort. it internally allocates a temporary buffer the size of
+/// the slice.
+///
+/// ## Example
+/// ```
+/// use std::cmp::{Ordering, stable_sort_by};
+///
+/// let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
+/// slice.stable_sort_by(|a: &i32, b: &i32| -> Ordering { b.compare(a) });
+///
+/// assert_eq!(slice, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+/// ```
+fn stable_sort_by<T, F: Fn(&T, &T) -> Ordering>(arr: &mut [T], f: F) {
+    if arr.len() < internal::MERGESORT_MIN_SIZE {
+        // Avoid an allocation in case the array is small.
+        return internal::insertion_sort_by(arr, f);
+    }
+
+    let scratch = mem::slice::alloc::<T>(arr.len());
+    defer scratch.free();
+
+    internal::merge_sort_by(arr, scratch, f);
+}
+
+/// Sorts a slice using a key extraction function. The sort is stable (i.e. preserves the
+/// order of equal elements).
+///
+/// The algorithm used is mergesort. it internally allocates a temporary buffer the size of
+/// the slice.
+///
+/// ## Example
+/// ```
+/// use std::cmp::stable_sort_by_key;
+///
+/// let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
+/// slice.stable_sort_by_key(|v: &i32| -> i32 { -*v });
+///
+/// assert_eq!(slice, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+/// ```
+fn stable_sort_by_key<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &mut [T], key: F) {
+    arr.stable_sort_by(|=key, a: &T, b: &T| -> Ordering { key(a).compare(&key(b)) });
+}
+
+/// Sorts a slice. The sort is stable (i.e. preserves the order of equal elements).
+///
+/// The algorithm used is mergesort. it internally allocates a temporary buffer the size of
+/// the slice.
+///
+/// ## Example
+/// ```
+/// use std::cmp::stable_sort;
+///
+/// let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
+/// slice.stable_sort();
+///
+/// assert_eq!(slice, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+/// ```
+fn stable_sort<T: Comparable<T>>(arr: &mut [T]) {
+    arr.stable_sort_by(internal::default_compare::<T>);
 }
 
 
@@ -354,6 +478,10 @@ fn binary_search_by_key<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &[T], needle: 
 
 
 mod internal {
+    const NINTHER_THRESHOLD: usize = 128;
+    const INTROSORT_MIN_SIZE: usize = 24;
+    const MERGESORT_MIN_SIZE: usize = 32;
+
     #[force_inline]
     #[lang(operator_eq)]
     fn operator_eq<T: Equatable<T>>(lhs: &T, rhs: &T) -> bool {
@@ -390,14 +518,47 @@ mod internal {
         lhs.greater_than_or_equal(rhs)
     }
 
+    /// Passthrough for T::compare, but friendlier to the type inferer.
+    #[inline]
+    fn default_compare<T: Comparable<T>>(a: &T, b: &T) -> Ordering {
+        a.compare(b)
+    }
+
+    #[inline]
+    fn sort2<T, F: Fn(&T, &T) -> Ordering>(a: &mut T, b: &mut T, f: F) {
+        if f(a, b) == Ordering::Greater {
+            std::mem::swap(a, b);
+        }
+    }
+
+    #[inline]
+    fn sort3<T, F: Fn(&T, &T) -> Ordering>(a: &mut T, b: &mut T, c: &mut T, f: F) {
+        sort2(a, b, f);
+        sort2(b, c, f);
+        sort2(a, b, f);
+    }
+
     fn partition_by<T, F: Fn(&T, &T) -> Ordering>(arr: &mut [T], f: F) -> usize {
         use mem::swap;
+
+        let mid = arr.len() / 2;
+        if arr.len() >= NINTHER_THRESHOLD {
+            // Tukey ninther for larger slices
+            sort3(&arr[0], &arr[mid], &arr[arr.len() - 1], f);
+            sort3(&arr[1], &arr[mid - 1], &arr[arr.len() - 2], f);
+            sort3(&arr[2], &arr[mid + 1], &arr[arr.len() - 3], f);
+            sort3(&arr[mid - 1], &arr[mid], &arr[mid + 1], f);
+            std::mem::swap(&arr[arr.len() - 1], &arr[mid]);
+        } else {
+            // Median-of-three for smaller slices
+            sort3(&arr[0], &arr[arr.len() - 1], &arr[mid], f);
+        }
 
         let pivot = arr[arr.len() - 1];
         let i = 0usize;
         let j = 0usize;
         while j < arr.len() - 1 {
-            if f(&arr[j], &pivot) != Ordering::Greater {
+            if f(&arr[j], &pivot) == Ordering::Less {
                 swap(&arr[i], &arr[j]);
                 i += 1;
             }
@@ -405,6 +566,73 @@ mod internal {
         }
         swap(&arr[i], &arr[arr.len() - 1]);
         i
+    }
+
+    fn insertion_sort_by<T, F: Fn(&T, &T) -> Ordering>(arr: &mut [T], f: F) {
+        for i in 1usize..arr.len() {
+            let j = i;
+            let elem = arr[i];
+            while j > 0 && f(&arr[j - 1], &elem) == Ordering::Greater {
+                arr[j] = arr[j - 1];
+                j -= 1;
+            }
+            arr[j] = elem;
+        }
+    }
+
+    fn merge_sort_by<T, F: Fn(&T, &T) -> Ordering>(arr: &mut [T], scratch: &mut [T], f: F) {
+        if arr.len() < MERGESORT_MIN_SIZE {
+            // Switch to insertion sort when the array is small enough
+            return insertion_sort_by(arr, f);
+        }
+
+        let mid = arr.len() / 2;
+
+        merge_sort_by(arr[..mid], scratch[..mid], f);
+        merge_sort_by(arr[mid..], scratch[mid..], f);
+
+        let i = 0usize;
+        let j = mid;
+        let k = 0usize;
+
+        while i < mid && j < arr.len() {
+            if f(&arr[i], &arr[j]) != Ordering::Greater {
+                scratch[k] = arr[i];
+                i += 1;
+            } else {
+                scratch[k] = arr[j];
+                j += 1;
+            }
+            k += 1;
+        }
+
+        while i < mid {
+            scratch[k] = arr[i];
+            i += 1;
+            k += 1;
+        }
+
+        while j < arr.len() {
+            scratch[k] = arr[j];
+            j += 1;
+            k += 1;
+        }
+
+        scratch.copy_to_nonoverlapping(&arr[0]);
+    }
+
+    fn introsort_by<T, F: Fn(&T, &T) -> Ordering>(arr: &mut [T], max_depth: usize, f: F) {
+        if arr.len() < INTROSORT_MIN_SIZE {
+            internal::insertion_sort_by(arr, f);
+        } else if max_depth == 0 {
+            // Fall back to heapsort
+            collections::heap::heapify_by(arr, f);
+            collections::heap::unheapify_by(arr, f);
+        } else {
+            let p = partition_by(arr, f);
+            introsort_by(arr[..p], max_depth - 1,  f);
+            introsort_by(arr[p+1..], max_depth - 1, f);
+        }
     }
 }
 
@@ -439,6 +667,38 @@ mod tests {
         let slice = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].as_slice();
         assert_eq!(slice.binary_search(&5), Result::ok(4usize));
         assert_eq!(slice.binary_search(&11), Result::err(10usize));
+    }
+
+    #[test]
+    fn test_sort_stability() {
+        let vec = (0..6561).to_vector();
+        defer vec.free();
+
+        vec.as_slice_mut().stable_sort_by_key(|i: &i32| -> i32 { (*i as u32).leading_zeros() as i32 });
+
+        let expected = [
+            (4096..6561),
+            (2048..4096),
+            (1024..2048),
+            (512..1024),
+            (256..512),
+            (128..256),
+            (64..128),
+            (32..64),
+            (16..32),
+            (8..16),
+            (4..8),
+            (2..4),
+            (1..2),
+            (0..1)
+        ]
+        .iter()
+        .flatten()
+        .enumerate();
+
+        for (idx, val) in expected {
+            assert_eq!(vec.as_slice()[idx], val);
+        }
     }
 
     #[test]

--- a/sysroot/std/collections/heap.alu
+++ b/sysroot/std/collections/heap.alu
@@ -1,9 +1,9 @@
 //! Binary heap collection and utilities.
 //!
 //! This module provides an allocating binary heap collection type, [BinaryHeap] as well as
-//! methods for in-place binary heaps over raw slices ([heapify], [sift_up], [sift_down], ...).
+//! methods for in-place binary heaps over raw slices ([heapify_by], [sift_up_by], [sift_down_by], ...).
 
-use cmp::Comparable;
+use cmp::{Comparable, Ordering};
 
 /// A binary max-heap (priority queue).
 ///
@@ -77,7 +77,7 @@ impl BinaryHeap<T: Comparable<T>> {
     /// The vector will be heapified in-place.
     fn from_vector(vector: Vector<T>) -> BinaryHeap<T> {
         let heap = BinaryHeap { _data: vector };
-        heapify(heap._data.as_slice_mut());
+        heapify_by(heap._data.as_slice_mut(), cmp::internal::default_compare::<T>);
 
         heap
     }
@@ -144,7 +144,7 @@ impl BinaryHeap<T: Comparable<T>> {
     fn extend_from_slice(self: &mut BinaryHeap<T>, slice: &[T]) {
         let old_len = self.len();
         self._data.extend_from_slice(slice);
-        heapify_tail(self._data.as_slice_mut(), old_len);
+        heapify_tail_by(self._data.as_slice_mut(), old_len, cmp::internal::default_compare::<T>);
     }
 
     /// Inserts an element into the heap.
@@ -152,7 +152,7 @@ impl BinaryHeap<T: Comparable<T>> {
         let old_len = self._data.len();
         self._data.push(value);
 
-        sift_up(self._data.as_slice_mut(), 0, old_len);
+        sift_up_by(self._data.as_slice_mut(), 0, old_len, cmp::internal::default_compare::<T>);
     }
 
     /// Returns the largest element in the heap without removing it.
@@ -169,7 +169,11 @@ impl BinaryHeap<T: Comparable<T>> {
         self._data.pop().map(|=self, item: T| -> T {
             if !self.is_empty() {
                 mem::swap(&item, &self._data._data[0]);
-                sift_down_to_bottom(self._data.as_slice_mut(), 0);
+                sift_down_to_bottom_by(
+                    self._data.as_slice_mut(),
+                    0,
+                    cmp::internal::default_compare::<T>
+                );
             }
 
             item
@@ -199,7 +203,11 @@ impl BinaryHeap<T: Comparable<T>> {
             keep
         });
 
-        heapify_tail(self._data.as_slice_mut(), first_removed);
+        heapify_tail_by(
+            self._data.as_slice_mut(),
+            first_removed,
+            cmp::internal::default_compare::<T>
+        );
     }
 
     /// Returns an iterator over the elements in the heap.
@@ -237,7 +245,7 @@ impl BinaryHeap<T: Comparable<T>> {
     ///
     /// `self` is emptied after this operation (like after [move]).
     fn into_sorted_vector(self: &mut BinaryHeap<T>) -> Vector<T> {
-        unheapify(self._data.as_slice_mut());
+        unheapify_by(self._data.as_slice_mut(), cmp::internal::default_compare::<T>);
 
         self.into_vector()
     }
@@ -292,11 +300,11 @@ impl HeapIterator<T: Comparable<T>> {
 }
 
 /// Reorder the elements of a slice so they satisfy the (max) heap property.
-fn heapify<T: Comparable<T>>(self: &mut [T]) {
+fn heapify_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], f: F) {
     let n = self.len() / 2;
     while n > 0 {
         n -= 1;
-        self.sift_down(n);
+        self.sift_down_by(n, f);
     }
 }
 
@@ -304,116 +312,125 @@ fn heapify<T: Comparable<T>>(self: &mut [T]) {
 ///
 /// This variant assumes that the prefix of the slice up to `start - 1` inclusive
 /// already satisfies the heap property.
-fn heapify_tail<T: Comparable<T>>(self: &mut [T], start: usize) {
+fn heapify_tail_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], start: usize, f: F) {
     if start == self.len() {
         return;
     }
 
     let tail_len = self.len() - start;
 
-    fn log2_fast(x: usize) -> usize {
-        mem::size_of::<usize>() * 8 - (x.leading_zeros() as usize) - 1
-    }
-
     let better_to_rebuild = if start < tail_len {
         true
     } else if self.len() <= 2048 {
-        2usize * self.len() < tail_len * log2_fast(start)
+        2usize * self.len() < tail_len * internal::log2_fast(start)
     } else {
         2usize * self.len() < tail_len * 11
     };
 
     if better_to_rebuild {
-        self.heapify();
+        self.heapify_by(f);
     } else {
         for i in start..self.len() {
-            self.sift_up(0, i);
+            self.sift_up_by(0, i, f);
         }
     }
 }
 
 /// Sorts an array satisfying the max heap property in ascending order.
-fn unheapify<T: Comparable<T>>(self: &mut [T]) {
+fn unheapify_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], f: F) {
     let end = self.len();
     while end > 1 {
         end -= 1;
         mem::swap(&self[0], &self[end]);
-        self.sift_down_range(0, end);
+        self.sift_down_range_by(0, end, f);
     }
 }
 
 /// Sifts an element up the heap until it reaches its correct position.
-fn sift_up<T: Comparable<T>>(self: &mut [T], start: usize, pos: usize) -> usize {
+fn sift_up_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], start: usize, pos: usize, f: F) {
+    let elem = self[pos];
     while pos > start {
         let parent = (pos - 1) / 2;
-
-        if self[pos] <= self[parent] {
+        if f(&elem, &self[parent]) != Ordering::Greater {
             break;
         }
-
-        mem::swap(&self[pos],  &self[parent]);
+        self[pos] = self[parent];
         pos = parent;
     }
-    pos
+    self[pos] = elem;
 }
 
 /// Sifts an element down the heap until it reaches its correct position.
-fn sift_down_range<T: Comparable<T>>(self: &mut [T], pos: usize, end: usize) {
-    let start = pos;
+fn sift_down_range_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], pos: usize, end: usize, f: F) {
     let child = 2usize * pos + 1;
+    let elem = self[pos];
 
     while child + 2 <= end {
-        if self[child] <= self[child + 1] {
+        if f(&self[child], &self[child + 1]) == Ordering::Less {
             child += 1;
         }
 
-        if self[pos] >= self[child] {
+        if f(&elem, &self[child]) != Ordering::Less {
+            self[pos] = elem;
             return;
         }
 
-        std::mem::swap(&self[pos], &self[child]);
+        self[pos] = self[child];
         pos = child;
         child = 2 * pos + 1;
     }
 
-    if child == end - 1 && self[pos] < self[child] {
-        mem::swap(&self[pos], &self[child]);
+    if child == end - 1 && f(&elem, &self[child]) == Ordering::Less {
+        self[pos] = self[child];
+        pos = child;
     }
+
+    self[pos] = elem;
 }
 
 /// Sifts an element down the heap until it reaches its correct position.
-fn sift_down<T: Comparable<T>>(self: &mut [T], pos: usize) {
+fn sift_down_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], pos: usize, f: F) {
     let len = self.len();
-    self.sift_down_range(pos, len);
+    self.sift_down_range_by(pos, len, f);
 }
 
 /// Sifts an element to the bottom of the heap, then sifts it up until it reaches
 /// its correct position.
 ///
-/// This is apparently faster than just calling `sift_down` until the element
-/// reaches the correct position.
-fn sift_down_to_bottom<T: Comparable<T>>(self: &mut [T], pos: usize) {
+/// This is faster than just calling `sift_down` until the element reaches the
+/// correct position when the element should be near the bottom of the heap.
+fn sift_down_to_bottom_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], pos: usize, f: F) {
     let end = self.len();
     let start = pos;
+    let elem = self[pos];
 
     let child = 2usize * pos + 1;
     while child + 2 <= end {
-        if self[child] <= self[child + 1] {
+        if f(&self[child], &self[child + 1]) == Ordering::Less {
             child += 1;
         }
-        mem::swap(&self[pos], &self[child]);
+        self[pos] = self[child];
         pos = child;
         child = 2 * pos + 1;
     }
+
     if child == end - 1 {
-        mem::swap(&self[pos], &self[child]);
+        self[pos] = self[child];
         pos = child;
     }
 
-    self.sift_up(start, pos);
+    self[pos] = elem;
+    self.sift_up_by(start, pos, f);
 }
 
-#[cfg(test)]
+mod internal {
+    #[inline]
+    fn log2_fast(x: usize) -> usize {
+        mem::size_of::<usize>() * 8 - (x.leading_zeros() as usize) - 1
+    }
+}
+
+#[cfg(all(test, test_std))]
 mod tests {
     #[test]
     fn test_basic() {

--- a/sysroot/std/option.alu
+++ b/sysroot/std/option.alu
@@ -118,6 +118,12 @@ impl Option<T> {
         self._is_some
     }
 
+    /// Returns `true` if the option is empty, `false` otherwise.
+    #[force_inline]
+    fn is_none(self: &Option<T>) -> bool {
+        !self._is_some
+    }
+
     /// Returns a value, if present, panic otherwise.
     ///
     /// ## Examples


### PR DESCRIPTION
This PR

- Introduces `std::cmp::stable_sort{_by,_by_key}` family of sorting functions based on mergesort (allocating)
- replaces naive quicksort for `std::cmp::sort{_by,_by_key}` family with introsort (+better pivoting)

Only did basic benchmarks on an array of floats. New introsort is not terrible, not great (Rust's pdqsort is ~2x faster), but mergesort is roughly on par. Both stable and unstable variants are fast when the array is already sorted. However, it should be much more robust against common and pathological arrays and has a strict `O(n log n)` worst case now as it falls back to heapsort.