### PR TITLE
chore: Polish sorting & heap implementations

### DIFF
--- a/sysroot/std.alu
+++ b/sysroot/std.alu
@@ -84,7 +84,7 @@ macro compile_note($reason) {
 /// ```
 macro assert($cond) {
     if !$cond {
-        panic!("assertion failed");
+        internal::panic_assert(file!(), line!(), column!());
     }
 }
 
@@ -287,56 +287,83 @@ mod internal {
     // These are in a function instead of a macro so we can typecheck and display a nice
     // error message if the argument is Formattable.
 
-    fn assert_eq<T>(file: &[u8], line: i32, column: i32, lhs: T, rhs: T)  {
+    #[cold]
+    #[no_inline]
+    fn panic_assert(file: &[u8], line: i32, column: i32) -> ! {
         use panicking::internal::panic_impl;
         use fmt::{Formattable, internal::format_arg};
 
-        if !(lhs == rhs) {
-            when T: Formattable<T, panicking::internal::PanicFormatter> {
-                panic_impl(
-                    file, line, column,
-                    &fmt::format_args!(
-                        "assertion failed ({} != {}))",
-                        lhs,
-                        rhs
-                    )
-                )
-            }
-            else {
-                panic_impl(
-                    file, line, column,
-                    &fmt::format_args!(
-                        "assertion failed (does not equal))",
-                    )
-                )
-            }
+        panic_impl(
+            file, line, column,
+            &fmt::format_args!(
+                "assertion failed"
+            )
+        )
+    }
 
+    #[inline]
+    fn assert_eq<T>(file: &[u8], line: i32, column: i32, lhs: T, rhs: T)  {
+        if !(lhs == rhs) {
+            panic_assert_eq(file, line, column, lhs, rhs)
         }
     }
 
+    #[inline]
     fn assert_ne<T>(file: &[u8], line: i32, column: i32, lhs: T, rhs: T)  {
+        if lhs == rhs {
+            panic_assert_ne(file, line, column, lhs, rhs)
+        }
+    }
+
+    #[cold]
+    #[no_inline]
+    fn panic_assert_eq<T>(file: &[u8], line: i32, column: i32, lhs: T, rhs: T) -> ! {
         use panicking::internal::panic_impl;
         use fmt::{Formattable, internal::format_arg};
 
-        if lhs == rhs {
-            when T: Formattable<T, panicking::internal::PanicFormatter> {
-                panic_impl(
-                    file, line, column,
-                    &fmt::format_args!(
-                        "assertion failed ({} == {}))",
-                        lhs,
-                        rhs
-                    )
+        when T: Formattable<T, panicking::internal::PanicFormatter> {
+            panic_impl(
+                file, line, column,
+                &fmt::format_args!(
+                    "assertion failed ({} != {}))",
+                    lhs,
+                    rhs
                 )
-            }
-            else {
-                panic_impl(
-                    file, line, column,
-                    &fmt::format_args!(
-                        "assertion failed (equals))",
-                    )
+            )
+        }
+        else {
+            panic_impl(
+                file, line, column,
+                &fmt::format_args!(
+                    "assertion failed (does not equal))",
                 )
-            }
+            )
+        }
+    }
+
+    #[cold]
+    #[no_inline]
+    fn panic_assert_ne<T>(file: &[u8], line: i32, column: i32, lhs: T, rhs: T) -> ! {
+        use panicking::internal::panic_impl;
+        use fmt::{Formattable, internal::format_arg};
+
+        when T: Formattable<T, panicking::internal::PanicFormatter> {
+            panic_impl(
+                file, line, column,
+                &fmt::format_args!(
+                    "assertion failed ({} == {}))",
+                    lhs,
+                    rhs
+                )
+            )
+        }
+        else {
+            panic_impl(
+                file, line, column,
+                &fmt::format_args!(
+                    "assertion failed (equals))",
+                )
+            )
         }
     }
 

--- a/sysroot/std/cmp.alu
+++ b/sysroot/std/cmp.alu
@@ -120,41 +120,37 @@ protocol Comparable<Self: Equatable<Self>> {
     }
 }
 
-/// A wrapper that can be used to reverse the ordering of a Comparable.
+/// Protocol for comparison functions.
 ///
-/// See [reversed] for details.
-struct Reversed<T: Comparable<T>> {
-    value: &T,
+/// See [Comparable] for details.
+type CompareFunction<T> = Fn(&T, &T) -> Ordering;
+
+/// Compare two values using the [Comparable::compare] method of a type
+/// implementing the [Comparable] protocol.
+///
+/// See [Comparable] for details.
+#[inline]
+fn compare<T: Comparable<T>>(a: &T, b: &T) -> Ordering {
+    a.compare(b)
 }
 
-impl Reversed<T: Comparable<T>> {
-    /// @ Comparable::compare
-    fn compare(self: &Reversed<T>, other: &Reversed<T>) -> Ordering {
-        other.value.compare(self.value)
-    }
-
-    /// @ Equatable::equals
-    fn equals(self: &Reversed<T>, other: &Reversed<T>) -> bool {
-        self.value.equals(other.value)
-    }
-
-    mixin Equatable<Reversed<T>>;
-    mixin Comparable<Reversed<T>>;
-}
-
-/// Reverses the ordering of a Comparable.
+/// Compare two values using the [Comparable::compare] method of a type
+/// implementing the [Comparable] protocol, but in reverse order.
+///
+/// Useful for sorting collections in descending order. See also [compare].
 ///
 /// ## Example
 /// ```
-/// use std::cmp::{sort_by_key, reversed};
+/// use std::cmp::{sort_by, reversed};
 ///
 /// let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
-/// slice.sort_by_key(reversed::<i32>);
+/// slice.sort_by(reversed::<i32>);
 ///
 /// assert_eq!(slice, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 /// ```
-fn reversed<T: Comparable<T>>(value: &T) -> Reversed<T> {
-    Reversed { value: value }
+#[inline]
+fn reversed<T: Comparable<T>>(a: &T, b: &T) -> Ordering {
+    b.compare(a)
 }
 
 /// Helper macro for implementing a lexicographic order.
@@ -237,7 +233,7 @@ fn min<T: Comparable<T>>(a: T, b: T) -> T {
 /// assert!(!arr1.is_sorted_by(i32::compare));
 /// assert!(arr2.is_sorted_by(i32::compare));
 /// ```
-fn is_sorted_by<T, F: Fn(&T, &T) -> Ordering>(arr: &[T], f: F) -> bool {
+fn is_sorted_by<T, F: CompareFunction<T>>(arr: &[T], f: F) -> bool {
     for i in 1usize..arr.len() {
         if f(&arr[i - 1], &arr[i]) == Ordering::Greater {
             return false;
@@ -293,7 +289,7 @@ fn is_sorted<T: Comparable<T>>(arr: &[T]) -> bool {
 ///
 /// assert_eq!(slice, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 /// ```
-fn sort_by<T, F: Fn(&T, &T) -> Ordering>(arr: &mut [T], f: F) {
+fn sort_by<T, F: CompareFunction<T>>(arr: &mut [T], f: F) {
     if arr.len() <= 1 {
         return;
     }
@@ -335,7 +331,7 @@ fn sort_by_key<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &mut [T], key: F) {
 /// assert_eq!(slice, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 /// ```
 fn sort<T: Comparable<T>>(arr: &mut [T]) {
-    arr.sort_by(internal::default_compare::<T>);
+    arr.sort_by(compare::<T>);
 }
 
 /// Sorts a slice using a custom comparison function. The sort is stable (i.e. preserves the
@@ -353,7 +349,7 @@ fn sort<T: Comparable<T>>(arr: &mut [T]) {
 ///
 /// assert_eq!(slice, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 /// ```
-fn stable_sort_by<T, F: Fn(&T, &T) -> Ordering>(arr: &mut [T], f: F) {
+fn stable_sort_by<T, F: CompareFunction<T>>(arr: &mut [T], f: F) {
     if arr.len() < internal::MERGESORT_MIN_SIZE {
         // Avoid an allocation in case the array is small.
         return internal::insertion_sort_by(arr, f);
@@ -362,7 +358,11 @@ fn stable_sort_by<T, F: Fn(&T, &T) -> Ordering>(arr: &mut [T], f: F) {
     let scratch = mem::slice::alloc::<T>(arr.len());
     defer scratch.free();
 
-    internal::merge_sort_by(arr, scratch, f);
+    // Alternating buffers are used to minimize copying and since we
+    // do not know the depth, we ensure that both buffers have the same
+    // by doing a full copy first.
+    arr.copy_to_nonoverlapping(&scratch[0]);
+    internal::merge_sort_by(scratch, arr, f);
 }
 
 /// Sorts a slice using a key extraction function. The sort is stable (i.e. preserves the
@@ -399,7 +399,7 @@ fn stable_sort_by_key<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &mut [T], key: F
 /// assert_eq!(slice, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 /// ```
 fn stable_sort<T: Comparable<T>>(arr: &mut [T]) {
-    arr.stable_sort_by(internal::default_compare::<T>);
+    arr.stable_sort_by(compare::<T>);
 }
 
 
@@ -476,7 +476,6 @@ fn binary_search_by_key<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &[T], needle: 
     arr.binary_search_by(|=needle, =key, k: &T| -> Ordering { key(k).compare(needle) })
 }
 
-
 mod internal {
     const NINTHER_THRESHOLD: usize = 128;
     const INTROSORT_MIN_SIZE: usize = 24;
@@ -518,27 +517,21 @@ mod internal {
         lhs.greater_than_or_equal(rhs)
     }
 
-    /// Passthrough for T::compare, but friendlier to the type inferer.
     #[inline]
-    fn default_compare<T: Comparable<T>>(a: &T, b: &T) -> Ordering {
-        a.compare(b)
-    }
-
-    #[inline]
-    fn sort2<T, F: Fn(&T, &T) -> Ordering>(a: &mut T, b: &mut T, f: F) {
+    fn sort2<T, F: CompareFunction<T>>(a: &mut T, b: &mut T, f: F) {
         if f(a, b) == Ordering::Greater {
             std::mem::swap(a, b);
         }
     }
 
     #[inline]
-    fn sort3<T, F: Fn(&T, &T) -> Ordering>(a: &mut T, b: &mut T, c: &mut T, f: F) {
+    fn sort3<T, F: CompareFunction<T>>(a: &mut T, b: &mut T, c: &mut T, f: F) {
         sort2(a, b, f);
         sort2(b, c, f);
         sort2(a, b, f);
     }
 
-    fn partition_by<T, F: Fn(&T, &T) -> Ordering>(arr: &mut [T], f: F) -> usize {
+    fn partition_by<T, F: CompareFunction<T>>(arr: &mut [T], f: F) -> usize {
         use mem::swap;
 
         let mid = arr.len() / 2;
@@ -568,7 +561,7 @@ mod internal {
         i
     }
 
-    fn insertion_sort_by<T, F: Fn(&T, &T) -> Ordering>(arr: &mut [T], f: F) {
+    fn insertion_sort_by<T, F: CompareFunction<T>>(arr: &mut [T], f: F) {
         for i in 1usize..arr.len() {
             let j = i;
             let elem = arr[i];
@@ -580,54 +573,54 @@ mod internal {
         }
     }
 
-    fn merge_sort_by<T, F: Fn(&T, &T) -> Ordering>(arr: &mut [T], scratch: &mut [T], f: F) {
-        if arr.len() < MERGESORT_MIN_SIZE {
-            // Switch to insertion sort when the array is small enough
-            return insertion_sort_by(arr, f);
-        }
-
-        let mid = arr.len() / 2;
-
-        merge_sort_by(arr[..mid], scratch[..mid], f);
-        merge_sort_by(arr[mid..], scratch[mid..], f);
-
+    fn merge<T, F: CompareFunction<T>>(left: &[T], right: &[T], dest: &mut [T], f: F) {
         let i = 0usize;
-        let j = mid;
+        let j = 0usize;
         let k = 0usize;
-
-        while i < mid && j < arr.len() {
-            if f(&arr[i], &arr[j]) != Ordering::Greater {
-                scratch[k] = arr[i];
+        while i < left.len() && j < right.len() {
+            if f(&left[i], &right[j]) != Ordering::Greater {
+                dest[k] = left[i];
                 i += 1;
             } else {
-                scratch[k] = arr[j];
+                dest[k] = right[j];
                 j += 1;
             }
             k += 1;
         }
-
-        while i < mid {
-            scratch[k] = arr[i];
+        while i < left.len() {
+            dest[k] = left[i];
             i += 1;
             k += 1;
         }
-
-        while j < arr.len() {
-            scratch[k] = arr[j];
+        while j < right.len() {
+            dest[k] = right[j];
             j += 1;
             k += 1;
         }
-
-        scratch.copy_to_nonoverlapping(&arr[0]);
     }
 
-    fn introsort_by<T, F: Fn(&T, &T) -> Ordering>(arr: &mut [T], max_depth: usize, f: F) {
+    fn merge_sort_by<T, F: CompareFunction<T>>(src: &mut [T], dest: &mut [T], f: F) {
+        if src.len() < MERGESORT_MIN_SIZE {
+            // Switch to insertion sort when the array is small enough
+            return insertion_sort_by(dest, f);
+        }
+
+        let mid = src.len() / 2;
+
+        // Swap the source and destination arrays in the recursive calls
+        merge_sort_by(dest[..mid], src[..mid], f);
+        merge_sort_by(dest[mid..], src[mid..], f);
+
+        merge(src[..mid], src[mid..], dest, f);
+    }
+
+    fn introsort_by<T, F: CompareFunction<T>>(arr: &mut [T], max_depth: usize, f: F) {
         if arr.len() < INTROSORT_MIN_SIZE {
             internal::insertion_sort_by(arr, f);
         } else if max_depth == 0 {
             // Fall back to heapsort
             collections::heap::heapify_by(arr, f);
-            collections::heap::unheapify_by(arr, f);
+            collections::heap::sort_heap_by(arr, f);
         } else {
             let p = partition_by(arr, f);
             introsort_by(arr[..p], max_depth - 1,  f);
@@ -641,7 +634,7 @@ mod tests {
     #[test]
     fn test_sort() {
         let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
-        sort(slice);
+        slice.sort();
 
         assert_eq!(slice, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     }
@@ -649,7 +642,7 @@ mod tests {
     #[test]
     fn test_sort_by_key() {
         let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
-        sort_by_key(slice, |x: &i32| -> i32 { -*x });
+        slice.sort_by_key(|x: &i32| -> i32 { -*x });
 
         assert_eq!(slice, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
     }
@@ -657,9 +650,9 @@ mod tests {
     #[test]
     fn test_sort_by() {
         let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
-        sort_by(slice, |x: &i32, y: &i32| -> Ordering { x.compare(y) });
+        slice.sort_by(reversed::<i32>);
 
-        assert_eq!(slice, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        assert_eq!(slice, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
     }
 
     #[test]

--- a/sysroot/std/collections/heap.alu
+++ b/sysroot/std/collections/heap.alu
@@ -3,7 +3,7 @@
 //! This module provides an allocating binary heap collection type, [BinaryHeap] as well as
 //! methods for in-place binary heaps over raw slices ([heapify_by], [sift_up_by], [sift_down_by], ...).
 
-use cmp::{Comparable, Ordering};
+use cmp::{Comparable, Ordering, CompareFunction};
 
 /// A binary max-heap (priority queue).
 ///
@@ -59,6 +59,7 @@ struct BinaryHeap<T: Comparable<T>> {
 
 impl BinaryHeap<T: Comparable<T>> {
     use iter::Iterator;
+    use cmp::compare;
 
     /// Creates an empty binary heap.
     ///
@@ -77,15 +78,17 @@ impl BinaryHeap<T: Comparable<T>> {
     /// The vector will be heapified in-place.
     fn from_vector(vector: Vector<T>) -> BinaryHeap<T> {
         let heap = BinaryHeap { _data: vector };
-        heapify_by(heap._data.as_slice_mut(), cmp::internal::default_compare::<T>);
+        heap._data
+            .as_slice_mut()
+            .heapify_by(compare::<T>);
 
         heap
     }
 
     /// Creates a heap from an existing vector.
     ///
-    /// The vector is assumed to be heapified. If it is not, the behavior is
-    /// undefined.
+    /// The vector is assumed to satisfy the max heap property. If it does not,
+    /// the behavior is unspecified.
     fn from_vector_raw(vector: Vector<T>) -> BinaryHeap<T> {
         BinaryHeap { _data: vector }
     }
@@ -144,7 +147,9 @@ impl BinaryHeap<T: Comparable<T>> {
     fn extend_from_slice(self: &mut BinaryHeap<T>, slice: &[T]) {
         let old_len = self.len();
         self._data.extend_from_slice(slice);
-        heapify_tail_by(self._data.as_slice_mut(), old_len, cmp::internal::default_compare::<T>);
+        self._data
+            .as_slice_mut()
+            .heapify_tail_by(old_len, compare::<T>);
     }
 
     /// Inserts an element into the heap.
@@ -152,7 +157,9 @@ impl BinaryHeap<T: Comparable<T>> {
         let old_len = self._data.len();
         self._data.push(value);
 
-        sift_up_by(self._data.as_slice_mut(), 0, old_len, cmp::internal::default_compare::<T>);
+        self._data
+            .as_slice_mut()
+            .sift_up_by(old_len, compare::<T>);
     }
 
     /// Returns the largest element in the heap without removing it.
@@ -169,11 +176,9 @@ impl BinaryHeap<T: Comparable<T>> {
         self._data.pop().map(|=self, item: T| -> T {
             if !self.is_empty() {
                 mem::swap(&item, &self._data._data[0]);
-                sift_down_to_bottom_by(
-                    self._data.as_slice_mut(),
-                    0,
-                    cmp::internal::default_compare::<T>
-                );
+                self._data
+                    .as_slice_mut()
+                    .sift_down_to_bottom_by(0, compare::<T>);
             }
 
             item
@@ -187,6 +192,8 @@ impl BinaryHeap<T: Comparable<T>> {
     }
 
     /// Removes the elements not mathing the given predicate.
+    ///
+    /// The heap property is maintained after the operation.
     ///
     /// Does not remove excess capacity, call [shrink_to_fit] afterwards, if this
     /// is desired.
@@ -203,11 +210,9 @@ impl BinaryHeap<T: Comparable<T>> {
             keep
         });
 
-        heapify_tail_by(
-            self._data.as_slice_mut(),
-            first_removed,
-            cmp::internal::default_compare::<T>
-        );
+        self._data
+            .as_slice_mut()
+            .heapify_tail_by(first_removed, compare::<T>);
     }
 
     /// Returns an iterator over the elements in the heap.
@@ -245,7 +250,9 @@ impl BinaryHeap<T: Comparable<T>> {
     ///
     /// `self` is emptied after this operation (like after [move]).
     fn into_sorted_vector(self: &mut BinaryHeap<T>) -> Vector<T> {
-        unheapify_by(self._data.as_slice_mut(), cmp::internal::default_compare::<T>);
+        self._data
+            .as_slice_mut()
+            .sort_heap_by(compare::<T>);
 
         self.into_vector()
     }
@@ -300,7 +307,18 @@ impl HeapIterator<T: Comparable<T>> {
 }
 
 /// Reorder the elements of a slice so they satisfy the (max) heap property.
-fn heapify_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], f: F) {
+///
+/// ## Example
+/// ```
+/// use std::collections::heap::heapify_by;
+/// use std::cmp::compare;
+///
+/// let v = [3, 5, 1, 2, 9, 8];
+/// v.as_slice_mut().heapify_by(compare::<i32>);
+///
+/// assert_eq!(v[0], 9); // max element
+/// ```
+fn heapify_by<T, F: CompareFunction<T>>(self: &mut [T], f: F) {
     let n = self.len() / 2;
     while n > 0 {
         n -= 1;
@@ -310,9 +328,25 @@ fn heapify_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], f: F) {
 
 /// Reorder the elements of a slice so they satisfy the (max) heap property.
 ///
-/// This variant assumes that the prefix of the slice up to `start - 1` inclusive
-/// already satisfies the heap property.
-fn heapify_tail_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], start: usize, f: F) {
+/// This variant assumes that the slice before `start` already satisfies the
+/// heap property and sifts up the elements in the tail.
+///
+/// The method is adaptive and will perform a standard heapification if that
+/// would be more efficient (if the tail is too long with respect to the existing
+/// heap in the head).
+///
+/// ## Example
+/// ```
+/// use std::collections::heap::{heapify_by, heapify_tail_by};
+/// use std::cmp::compare;
+///
+/// let v = [3, 5, 1, 2, 9, 8].as_slice_mut();
+/// v[0..4].heapify_by(compare::<i32>);
+/// v.heapify_tail_by(4, compare::<i32>);
+///
+/// assert_eq!(v[0], 9); // max element
+/// ```
+fn heapify_tail_by<T, F: CompareFunction<T>>(self: &mut [T], start: usize, f: F) {
     if start == self.len() {
         return;
     }
@@ -331,25 +365,58 @@ fn heapify_tail_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], start: usize, f
         self.heapify_by(f);
     } else {
         for i in start..self.len() {
-            self.sift_up_by(0, i, f);
+            self.sift_up_by(i, f);
         }
     }
 }
 
 /// Sorts an array satisfying the max heap property in ascending order.
-fn unheapify_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], f: F) {
+///
+/// ## Example
+/// ```
+/// use std::collections::heap::{heapify_by, sort_heap_by};
+/// use std::cmp::compare;
+///
+/// fn heapsort(v: &mut [i32]) {
+///     v.heapify_by(compare::<i32>);
+///     v.sort_heap_by(compare::<i32>);
+/// }
+///
+/// let v = [3, 5, 1, 2, 9, 8].as_slice_mut();
+/// v.heapsort();
+///
+/// assert_eq!(v, &[1, 2, 3, 5, 8, 9]);
+/// ```
+fn sort_heap_by<T, F: CompareFunction<T>>(self: &mut [T], f: F) {
     let end = self.len();
     while end > 1 {
         end -= 1;
         mem::swap(&self[0], &self[end]);
-        self.sift_down_range_by(0, end, f);
+        self[..end].sift_down_by(0, f);
     }
 }
 
 /// Sifts an element up the heap until it reaches its correct position.
-fn sift_up_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], start: usize, pos: usize, f: F) {
+///
+/// This is used e.g. to restore the heap property after appending an element to the
+/// end of the heap.
+///
+/// ## Example
+/// ```
+/// use std::collections::heap::{heapify_by, sift_up_by};
+/// use std::cmp::compare;
+///
+/// let v = [1, 2, 3, 4, 5].as_slice_mut();
+/// v.heapify_by(compare::<i32>);
+/// assert_eq!(v[0], 5); // 5 is the max element
+///
+/// v[4] = 100;
+/// v.sift_up_by(4, compare::<i32>);
+/// assert_eq!(v[0], 100); // 100 is the new max element
+/// ```
+fn sift_up_by<T, F: CompareFunction<T>>(self: &mut [T], pos: usize, f: F) {
     let elem = self[pos];
-    while pos > start {
+    while pos > 0 {
         let parent = (pos - 1) / 2;
         if f(&elem, &self[parent]) != Ordering::Greater {
             break;
@@ -361,11 +428,30 @@ fn sift_up_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], start: usize, pos: u
 }
 
 /// Sifts an element down the heap until it reaches its correct position.
-fn sift_down_range_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], pos: usize, end: usize, f: F) {
+///
+/// This is used e.g. to restore the heap property after removing the root element.
+/// If replacing the root element with the last element of the heap, consider using
+/// [sift_down_to_bottom_by] instead, as it can be more efficient when the element
+/// should be close to the bottom of the heap.
+///
+/// ## Example
+/// ```
+/// use std::collections::heap::{heapify_by, sift_down_by};
+/// use std::cmp::compare;
+///
+/// let v = [1, 2, 3, 4, 5].as_slice_mut();
+/// v.heapify_by(compare::<i32>);
+/// assert_eq!(v[0], 5); // 5 is the max element
+///
+/// v[0] = 3;
+/// v.sift_down_by(0, compare::<i32>);
+/// assert_eq!(v[0], 4); // 4 is the new max element
+/// ```
+fn sift_down_by<T, F: CompareFunction<T>>(self: &mut [T], pos: usize, f: F) {
     let child = 2usize * pos + 1;
     let elem = self[pos];
 
-    while child + 2 <= end {
+    while child + 1 < self.len() {
         if f(&self[child], &self[child + 1]) == Ordering::Less {
             child += 1;
         }
@@ -380,7 +466,7 @@ fn sift_down_range_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], pos: usize, 
         child = 2 * pos + 1;
     }
 
-    if child == end - 1 && f(&elem, &self[child]) == Ordering::Less {
+    if child == self.len() - 1 && f(&elem, &self[child]) == Ordering::Less {
         self[pos] = self[child];
         pos = child;
     }
@@ -388,24 +474,35 @@ fn sift_down_range_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], pos: usize, 
     self[pos] = elem;
 }
 
-/// Sifts an element down the heap until it reaches its correct position.
-fn sift_down_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], pos: usize, f: F) {
-    let len = self.len();
-    self.sift_down_range_by(pos, len, f);
-}
-
-/// Sifts an element to the bottom of the heap, then sifts it up until it reaches
+/// Sifts an element at index `pos` to the bottom of the heap, then sifts it up until it reaches
 /// its correct position.
 ///
-/// This is faster than just calling `sift_down` until the element reaches the
-/// correct position when the element should be near the bottom of the heap.
-fn sift_down_to_bottom_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], pos: usize, f: F) {
+/// This avoids extra comparisons on the way down and hence can be faster than just calling
+/// [sift_down_by] until the element reaches the correct position when the element is known
+/// to have to be near the bottom of the heap.
+///
+/// ## Example
+/// ```
+/// use std::collections::heap::{heapify_by, sift_down_to_bottom_by};
+/// use std::cmp::compare;
+/// use std::mem::swap;
+///
+/// let v = [1, 2, 3, 4, 5].as_slice_mut();
+/// v.heapify_by(compare::<i32>);
+///
+/// swap(&v[0], &v[4]);
+/// v = v[..4]; // remove the last element
+///
+/// v.sift_down_to_bottom_by(0, compare::<i32>);
+/// assert_eq!(v[0], 4); // 4 is the new max element
+/// ```
+fn sift_down_to_bottom_by<T, F: CompareFunction<T>>(self: &mut [T], pos: usize, f: F) {
     let end = self.len();
     let start = pos;
     let elem = self[pos];
 
     let child = 2usize * pos + 1;
-    while child + 2 <= end {
+    while child + 1 < end {
         if f(&self[child], &self[child + 1]) == Ordering::Less {
             child += 1;
         }
@@ -420,7 +517,7 @@ fn sift_down_to_bottom_by<T, F: Fn(&T, &T) -> Ordering>(self: &mut [T], pos: usi
     }
 
     self[pos] = elem;
-    self.sift_up_by(start, pos, f);
+    self.sift_up_by(pos, f);
 }
 
 mod internal {

--- a/sysroot/std/iter.alu
+++ b/sysroot/std/iter.alu
@@ -489,6 +489,104 @@ impl ChainIterator<It1: DoubleEndedIterator<It1, T>, It2: DoubleEndedIterator<It
     mixin DoubleEndedIteratorExt<ChainIterator<It1, It2, T>, T>;
 }
 
+/// Merge iterator.
+///
+/// See [IteratorExt::merge_sorted].
+struct MergeIterator<It1: Iterator<It1, T>, It2: Iterator<It2, T>, T: cmp::Comparable<T>> {
+    it1: Option<PeekableIterator<It1, T>>,
+    it2: Option<PeekableIterator<It2, T>>,
+}
+
+impl MergeIterator<It1: Iterator<It1, T>, It2: Iterator<It2, T>, T: cmp::Comparable<T>> {
+    /// @ Iterator::next
+    fn next(self: &mut MergeIterator<It1, It2, T>) -> Option<T> {
+        if self.it1.is_none() {
+            return self.it2.as_mut_ptr().unwrap().next();
+        } else if self.it2.is_none() {
+            return self.it1.as_mut_ptr().unwrap().next();
+        }
+
+        let it1 = self.it1.as_mut_ptr().unwrap();
+        let it2 = self.it2.as_mut_ptr().unwrap();
+
+        let v1 = it1.peek();
+        let v2 = it2.peek();
+
+        if v1.is_none() {
+            it1.next();
+            self.it1 = Option::none();
+
+            it2.next()
+        } else if v2.is_none() {
+            it2.next();
+            self.it2 = Option::none();
+
+            it1.next()
+        } else if v1.unwrap() <= v2.unwrap() {
+            it1.next()
+        } else {
+            it2.next()
+        }
+    }
+
+    /// @ Iterator::size_hint
+    fn size_hint(self: &MergeIterator<It1, It2, T>) -> Option<usize> {
+        if self.it1.is_none() {
+            self.it2.as_ptr().unwrap().size_hint()
+        } else if self.it2.is_none() {
+            self.it1.as_ptr().unwrap().size_hint()
+        } else {
+            self.it1.as_ptr().unwrap().size_hint()
+                .zip(self.it2.as_ptr().unwrap().size_hint())
+                .map(|v: (usize, usize)| -> usize {
+                    v.0 + v.1
+                })
+        }
+    }
+
+    mixin Iterator<MergeIterator<It1, It2, T>, T>;
+    mixin IteratorExt<MergeIterator<It1, It2, T>, T>;
+}
+
+
+impl MergeIterator<It1: DoubleEndedIterator<It1, T>, It2: DoubleEndedIterator<It2, T>, T: cmp::Comparable<T>> {
+    /// @ DoubleEndedIterator::next_back
+    fn next_back(self: &mut MergeIterator<It1, It2, T>) -> Option<T> {
+        if self.it1.is_none() {
+            return self.it2.as_mut_ptr().unwrap().next_back();
+        } else if self.it2.is_none() {
+            return self.it1.as_mut_ptr().unwrap().next_back();
+        }
+
+        let it1 = self.it1.as_mut_ptr().unwrap();
+        let it2 = self.it2.as_mut_ptr().unwrap();
+
+        let v1 = it1.peek_back();
+        let v2 = it2.peek_back();
+
+        if v1.is_none() {
+            it1.next_back();
+            self.it1 = Option::none();
+
+            it2.next_back()
+        } else if v2.is_none() {
+            it2.next_back();
+            self.it2 = Option::none();
+
+            it1.next_back()
+        } else if v1.unwrap() > v2.unwrap() {
+            // Strict greater than to ensure "stable" ordering.
+            it1.next_back()
+        } else {
+            it2.next_back()
+        }
+    }
+
+    mixin DoubleEndedIterator<MergeIterator<It1, It2, T>, T>;
+    mixin DoubleEndedIteratorExt<MergeIterator<It1, It2, T>, T>;
+}
+
+
 /// Inspect iterator.
 ///
 /// See [IteratorExt::inspect].
@@ -660,6 +758,7 @@ impl ChunksIterator<It: Iterator<It, T>, T> {
 struct PeekableIterator<It: Iterator<It, T>, T> {
     it: &mut It,
     peeked: Option<T>,
+    peeked_back: when It: DoubleEndedIterator<It, T> { Option<T> } else { () },
 }
 
 impl PeekableIterator<It: Iterator<It, T>, T> {
@@ -668,25 +767,53 @@ impl PeekableIterator<It: Iterator<It, T>, T> {
         if self.peeked.is_some() {
             self.peeked.move()
         } else {
-            self.it.next()
+            when It: DoubleEndedIterator<It, T> {
+                let next = self.it.next();
+                if !next.is_some() {
+                    self.peeked_back.move()
+                } else {
+                    next
+                }
+            } else {
+                self.it.next()
+            }
         }
     }
 
     /// Return the next element in the iterator without consuming it.
     fn peek(self: &mut PeekableIterator<It, T>) -> Option<T> {
-        if !self.peeked.is_some() {
-            self.peeked = self.it.next();
+        when It: DoubleEndedIterator<It, T> {
+            if !self.peeked.is_some() {
+                self.peeked = self.it.next();
+                if self.peeked.is_some(){
+                    self.peeked
+                } else {
+                    self.peeked_back
+                }
+            } else {
+                self.peeked
+            }
+        } else {
+            if !self.peeked.is_some() {
+                self.peeked = self.it.next();
+            }
+            self.peeked
         }
-        self.peeked
     }
 
     /// @ Iterator::size_hint
     fn size_hint(self: &PeekableIterator<It, T>) -> Option<usize> {
         self.it.size_hint().map(|=self, x: usize| -> usize {
-            if self.peeked.is_some() {
-                x + 1
-            } else {
+            when It: DoubleEndedIterator<It, T> {
                 x
+                + (if self.peeked.is_some() { 1 } else { 0 })
+                + (if self.peeked_back.is_some() { 1 } else { 0 })
+            } else {
+                if self.peeked.is_some() {
+                    x + 1
+                } else {
+                    x
+                }
             }
         })
     }
@@ -695,6 +822,38 @@ impl PeekableIterator<It: Iterator<It, T>, T> {
     mixin IteratorExt<PeekableIterator<It, T>, T>;
 }
 
+impl PeekableIterator<It: DoubleEndedIterator<It, T>, T> {
+    /// @ DoubleEndedIterator::next_back
+    fn next_back(self: &mut PeekableIterator<It, T>) -> Option<T> {
+        if self.peeked_back.is_some() {
+            self.peeked_back.move()
+        } else {
+            let next_back = self.it.next_back();
+            if !next_back.is_some() {
+                self.peeked.move()
+            } else {
+                next_back
+            }
+        }
+    }
+
+    /// Return the next element from the back in the iterator without consuming it.
+    fn peek_back(self: &mut PeekableIterator<It, T>) -> Option<T> {
+        if !self.peeked_back.is_some() {
+            self.peeked_back = self.it.next_back();
+            if self.peeked_back.is_some(){
+                self.peeked_back
+            } else {
+                self.peeked
+            }
+        } else {
+            self.peeked_back
+        }
+    }
+
+    mixin DoubleEndedIterator<PeekableIterator<It, T>, T>;
+    mixin DoubleEndedIteratorExt<PeekableIterator<It, T>, T>;
+}
 
 /// Zip iterator
 ///
@@ -830,6 +989,30 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
         ChainIterator {
             it1: FusedIterator { done: false, it: self },
             it2: FusedIterator { done: false, it: other }
+        }
+    }
+
+    /// Returns an iterator that merges two sorted iterators into one sorted iterator.
+    ///
+    /// `T` must implement [cmp::Comparable]. If the two iterators are not sorted, the
+    /// resulting order is unspecified.
+    ///
+    /// ## Example
+    /// ```
+    /// let range = [0, 2, 4].iter().merge_sorted(&[1, 3].iter());
+    /// assert_eq!(range.size_hint(), Option::some(5usize));
+    ///
+    /// assert_eq!(range.next(), Option::some(0));
+    /// assert_eq!(range.next(), Option::some(1));
+    /// assert_eq!(range.next(), Option::some(2));
+    /// assert_eq!(range.next(), Option::some(3));
+    /// assert_eq!(range.next(), Option::some(4));
+    /// assert_eq!(range.next(), Option::none());
+    /// ```
+    fn merge_sorted<Other: Iterator<Other, T>>(self: &mut Self, other: &mut Other) -> MergeIterator<Self, Other, T> {
+        MergeIterator {
+            it1: Option::some(self.peekable()),
+            it2: Option::some(other.peekable())
         }
     }
 
@@ -1360,6 +1543,11 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
         PeekableIterator {
             it: self,
             peeked: Option::none(),
+            peeked_back: when Self: DoubleEndedIterator<Self, T> {
+                Option::none()
+            } else {
+                ()
+            }
         }
     }
 
@@ -1922,6 +2110,41 @@ mod tests {
     }
 
     #[test]
+    fn test_peekable_rev() {
+        let range = (0..3).peekable();
+        assert_eq!(range.size_hint(), Option::some(3usize));
+        assert_eq!(range.peek_back(), Option::some(2));
+
+        assert_eq!(range.size_hint(), Option::some(3usize));
+        assert_eq!(range.next_back(), Option::some(2));
+        assert_eq!(range.next_back(), Option::some(1));
+        assert_eq!(range.next_back(), Option::some(0));
+        assert_eq!(range.next_back(), Option::none());
+    }
+
+    #[test]
+    fn test_peekable_bidirectional() {
+        let range = (0..3).peekable();
+        assert_eq!(range.size_hint(), Option::some(3usize));
+
+        assert_eq!(range.peek(), Option::some(0));
+        assert_eq!(range.peek_back(), Option::some(2));
+
+        assert_eq!(range.size_hint(), Option::some(3usize));
+        assert_eq!(range.next(), Option::some(0));
+        assert_eq!(range.next_back(), Option::some(2));
+
+        assert_eq!(range.size_hint(), Option::some(1usize));
+        assert_eq!(range.peek(), Option::some(1));
+        assert_eq!(range.peek_back(), Option::some(1));
+
+        assert_eq!(range.next(), Option::some(1));
+        assert_eq!(range.next_back(), Option::none());
+
+        assert_eq!(range.size_hint(), Option::some(0usize));
+    }
+
+    #[test]
     fn test_group_by() {
         let values: &[(i32, i32)] = &[
             (0, 0),
@@ -2270,5 +2493,112 @@ mod tests {
     #[test(should_fail)]
     fn test_chunks_0() {
         (0..10).chunks(0);
+    }
+
+    #[test]
+    fn test_merge_sorted_1() {
+        let iter = [1,3,5,7].iter().merge_sorted(&[2,4,6,8].iter());
+        assert_eq!(iter.size_hint(), Option::some(8usize));
+
+        assert_eq!(iter.next(), Option::some(1));
+        assert_eq!(iter.next(), Option::some(2));
+        assert_eq!(iter.next(), Option::some(3));
+        assert_eq!(iter.next(), Option::some(4));
+        assert_eq!(iter.next(), Option::some(5));
+        assert_eq!(iter.next(), Option::some(6));
+        assert_eq!(iter.next(), Option::some(7));
+        assert_eq!(iter.next(), Option::some(8));
+        assert_eq!(iter.next(), Option::none());
+    }
+
+    #[test]
+    fn test_merge_sorted_reversed() {
+        let iter = [1,3,5,7].iter().merge_sorted(&[2,4,6,8].iter()).rev();
+        assert_eq!(iter.size_hint(), Option::some(8usize));
+
+        assert_eq!(iter.next(), Option::some(8));
+        assert_eq!(iter.next(), Option::some(7));
+        assert_eq!(iter.next(), Option::some(6));
+        assert_eq!(iter.next(), Option::some(5));
+        assert_eq!(iter.next(), Option::some(4));
+        assert_eq!(iter.next(), Option::some(3));
+        assert_eq!(iter.next(), Option::some(2));
+        assert_eq!(iter.next(), Option::some(1));
+        assert_eq!(iter.next(), Option::none());
+    }
+
+    #[test]
+    fn test_merge_sorted_2() {
+        let iter = [1,2,3,4].iter().merge_sorted(&[5,6,7,8].iter());
+        assert_eq!(iter.size_hint(), Option::some(8usize));
+
+        assert_eq!(iter.next(), Option::some(1));
+        assert_eq!(iter.next(), Option::some(2));
+        assert_eq!(iter.next(), Option::some(3));
+        assert_eq!(iter.next(), Option::some(4));
+        assert_eq!(iter.next(), Option::some(5));
+        assert_eq!(iter.next(), Option::some(6));
+        assert_eq!(iter.next(), Option::some(7));
+        assert_eq!(iter.next(), Option::some(8));
+        assert_eq!(iter.next(), Option::none());
+    }
+
+
+    #[test]
+    fn test_merge_sorted_3() {
+        let iter = [5,6,7,8].iter().merge_sorted(&[1,2,3,4].iter());
+        assert_eq!(iter.size_hint(), Option::some(8usize));
+
+        assert_eq!(iter.next(), Option::some(1));
+        assert_eq!(iter.next(), Option::some(2));
+        assert_eq!(iter.next(), Option::some(3));
+        assert_eq!(iter.next(), Option::some(4));
+        assert_eq!(iter.next(), Option::some(5));
+        assert_eq!(iter.next(), Option::some(6));
+        assert_eq!(iter.next(), Option::some(7));
+        assert_eq!(iter.next(), Option::some(8));
+        assert_eq!(iter.next(), Option::none());
+    }
+
+    #[test]
+    fn test_merge_sorted_exhausted_left() {
+        let iter = [1,3].iter().merge_sorted(&[2,4,6,8].iter());
+        assert_eq!(iter.size_hint(), Option::some(6usize));
+
+        assert_eq!(iter.next(), Option::some(1));
+        assert_eq!(iter.size_hint(), Option::some(5usize));
+        assert_eq!(iter.next(), Option::some(2));
+        assert_eq!(iter.size_hint(), Option::some(4usize));
+        assert_eq!(iter.next(), Option::some(3));
+        assert_eq!(iter.size_hint(), Option::some(3usize));
+        assert_eq!(iter.next(), Option::some(4));
+        assert_eq!(iter.size_hint(), Option::some(2usize));
+        assert_eq!(iter.next(), Option::some(6));
+        assert_eq!(iter.size_hint(), Option::some(1usize));
+        assert_eq!(iter.next(), Option::some(8));
+        assert_eq!(iter.size_hint(), Option::some(0usize));
+        assert_eq!(iter.next(), Option::none());
+        assert_eq!(iter.size_hint(), Option::some(0usize));
+    }
+
+    #[test]
+    fn test_merge_sorted_exhausted_right() {
+        let iter = [2,4,6,8].iter().merge_sorted(&[1,3].iter());
+        assert_eq!(iter.size_hint(), Option::some(6usize));
+
+        assert_eq!(iter.next(), Option::some(1));
+        assert_eq!(iter.size_hint(), Option::some(5usize));
+        assert_eq!(iter.next(), Option::some(2));
+        assert_eq!(iter.size_hint(), Option::some(4usize));
+        assert_eq!(iter.next(), Option::some(3));
+        assert_eq!(iter.size_hint(), Option::some(3usize));
+        assert_eq!(iter.next(), Option::some(4));
+        assert_eq!(iter.size_hint(), Option::some(2usize));
+        assert_eq!(iter.next(), Option::some(6));
+        assert_eq!(iter.size_hint(), Option::some(1usize));
+        assert_eq!(iter.next(), Option::some(8));
+        assert_eq!(iter.size_hint(), Option::some(0usize));
+        assert_eq!(iter.next(), Option::none());
+        assert_eq!(iter.size_hint(), Option::some(0usize));
     }
 }

--- a/sysroot/std/mem.alu
+++ b/sysroot/std/mem.alu
@@ -50,7 +50,7 @@ protocol AsSlice<Self, T> {
 }
 
 /// Types that can be viewed as mutable slices
-protocol AsSliceMut<Self, T> {
+protocol AsSliceMut<Self: AsSlice<Self, T>, T> {
     fn as_slice_mut(self: &mut Self) -> &mut [T];
 }
 


### PR DESCRIPTION
- Add `std::cmp::merge_sorted` combinator
- Alternate buffers in mergesort implementation
- Clean up and document the extra methods in `std::collections::heap`