### PR TITLE
feat: Index types that implement AsSlice and AsSliceMut directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ else ifdef FAST_DEBUG
 	BUILD_DIR = $(BUILD_ROOT)/fast-debug
 	CARGO_FLAGS = --release
 	CARGO_TARGET_DIR = target/release
-	CFLAGS += -g3 -fPIE -rdynamic
+	CFLAGS += -g0
 	ALUMINA_FLAGS += --sysroot $(SYSROOT) --debug
 else
 	BUILD_DIR = $(BUILD_ROOT)/debug

--- a/docs/lang_guide.md
+++ b/docs/lang_guide.md
@@ -20,8 +20,6 @@ With regards to syntax, the language is very similar to Rust and in terms of sem
   - [Enums](#enums)
   - [Impl blocks](#impl-blocks)
   - [Type attributes](#type-attributes)
-  - [What about strings?](#what-about-strings)
-  - [Zero-sized types](#zero-sized-types)
 - [Macros](#macros)
 - [Statements and expressions](#statements-and-expressions)
   - [Variables](#variables)
@@ -637,6 +635,10 @@ let s = t[1..3]; // [2, 3]
 ```
 
 The syntax for slices (`&[T]`) implies that it is a kind of pointer to some `[T]` type. Unlike Rust, this is **NOT** the case in Alumina and `[T]` is simply invalid syntax. Under the hood slices are [just a struct](https://docs.alumina-lang.net/std/mem/slice.html) with a pointer to the first element and a length. They are commonly passed around by value, as they already contain a pointer inside.
+
+Collection types that are a backed by contiguous memory (e.g. [`Vector`](https://docs.alumina-lang.net/std/collections/Vector.html)) can be indexed directly without converting to a slice first. See [`AsSlice`](https://docs.alumina-lang.net/std/mem/AsSlice.html) and [`AsSliceMut`](https://docs.alumina-lang.net/std/mem/AsSliceMut.html) for more details.
+
+```rust
 
 ## What about strings?
 

--- a/examples/defer_and_move.alu
+++ b/examples/defer_and_move.alu
@@ -2,7 +2,7 @@ use std::string::StringBuf;
 
 fn accept_vector(vec: StringBuf) {
     // do something with it
-    println!("moved: {}", vec.as_slice());
+    println!("moved: {}", vec[..]);
     vec.free();
 }
 
@@ -21,5 +21,5 @@ fn main() {
     // `vec` nulled, so free is a no-op.
     accept_vector(vec.move());
 
-    println!("original: {}", vec.as_slice())
+    println!("original: {}", vec[..])
 }

--- a/examples/file_io.alu
+++ b/examples/file_io.alu
@@ -6,10 +6,9 @@ fn copy<S: Readable<S>, D: Writable<D>>(
     dst: &mut D
 ) -> Result<(), Error> {
     let buf: [u8; 1024];
-    let buf = buf.as_slice_mut();
 
     loop {
-        let n = src.read(buf)?;
+        let n = src.read(&buf)?;
         if n == 0 {
             break;
         }

--- a/examples/for_loop.alu
+++ b/examples/for_loop.alu
@@ -17,7 +17,7 @@ fn main() {
     defer hm.free();
 
     for i in vec {
-        hm.insert(i.as_slice(), thread_rng().next_u32());
+        hm.insert(i[..], thread_rng().next_u32());
     }
 
     for elem in hm {

--- a/examples/iterators.alu
+++ b/examples/iterators.alu
@@ -12,7 +12,7 @@ fn main() {
         .to_vector();
 
     defer without_wovels.free();
-    println!("{}", without_wovels.as_slice());
+    println!("{}", without_wovels[..]);
 
     let sum_of_squares = (0..100)
         .iter()

--- a/examples/line_numbering.alu
+++ b/examples/line_numbering.alu
@@ -21,7 +21,7 @@ fn main() {
             padded.insert(0, ' ');
         }
 
-        println!("{} | {}", padded.as_slice(), line.unwrap());
+        println!("{} | {}", padded[..], line.unwrap());
         i += 1;
     }
 }

--- a/examples/process.alu
+++ b/examples/process.alu
@@ -13,5 +13,5 @@ fn main() {
         .unwrap();
     defer output.free();
 
-    println!("Running on {}", output.stdout.as_slice().trim());
+    println!("Running on {}", output.stdout[..].trim());
 }

--- a/libraries/tree_sitter.alu
+++ b/libraries/tree_sitter.alu
@@ -96,7 +96,7 @@ extern "C" fn ts_language_field_name_for_id(self: &TSLanguage, id: TSFieldId) ->
 impl TSLanguage {
     fn symbol_name(self: &TSLanguage, id: TSSymbol) -> &[u8] {
         let name = ts_language_symbol_name(self, id);
-        CString::from_raw(name).as_slice()
+        CString::from_raw(name)[..]
     }
 
     fn symbol_type(self: &TSLanguage, id: TSSymbol) -> TSSymbolType {
@@ -105,7 +105,7 @@ impl TSLanguage {
 
     fn field_name(self: &TSLanguage, id: TSFieldId) -> &[u8] {
         let name = ts_language_field_name_for_id(self, id);
-        CString::from_raw(name).as_slice()
+        CString::from_raw(name)[..]
     }
 
     fn symbols(self: &TSLanguage) -> std::range::Range<TSSymbol> {
@@ -397,7 +397,7 @@ impl Node {
         let string = ts_node_string(self.inner);
         defer std::libc::free(string as &mut void);
 
-        write!(f, "{}", CString::from_raw(string).as_slice())
+        write!(f, "{}", CString::from_raw(string)[..])
     }
 
     fn equals(self: &Node, other: &Node) -> bool {

--- a/src/alumina-boot/src/ast/lang.rs
+++ b/src/alumina-boot/src/ast/lang.rs
@@ -10,6 +10,7 @@ pub enum LangItemKind {
     SliceRangeIndex,
     SliceConstCoerce,
     SliceConstCast,
+    SliceSlicify,
 
     RangeFull,
     RangeFrom,
@@ -138,6 +139,7 @@ impl TryFrom<&str> for LangItemKind {
             "slice_const_cast" => Ok(LangItemKind::SliceConstCast),
             "slice_index" => Ok(LangItemKind::SliceIndex),
             "slice_range_index" => Ok(LangItemKind::SliceRangeIndex),
+            "slice_slicify" => Ok(LangItemKind::SliceSlicify),
 
             "range_full" => Ok(LangItemKind::RangeFull),
             "range_from" => Ok(LangItemKind::RangeFrom),

--- a/src/aluminac/main.alu
+++ b/src/aluminac/main.alu
@@ -151,14 +151,14 @@ fn main() {
     let source = File::read_to_string(Path::new("./src/aluminac/main.alu")).unwrap();
     defer source.free();
 
-    let tree = parser.parse(source.as_slice());
+    let tree = parser.parse(source[..]);
     defer tree.free();
 
     let root_node = tree.root_node().unwrap();
     let cursor = root_node.walk();
     defer cursor.free();
 
-    let visitor = SampleVisitor::new(source.as_slice(), &cursor);
+    let visitor = SampleVisitor::new(source[..], &cursor);
     visitor.visit(root_node);
 
     llvm_example();

--- a/sysroot/std/cmp.alu
+++ b/sysroot/std/cmp.alu
@@ -143,10 +143,10 @@ fn compare<T: Comparable<T>>(a: &T, b: &T) -> Ordering {
 /// ```
 /// use std::cmp::{sort_by, reversed};
 ///
-/// let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
-/// slice.sort_by(reversed::<i32>);
+/// let arr = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5];
+/// arr[..].sort_by(reversed::<i32>);
 ///
-/// assert_eq!(slice, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+/// assert_eq!(arr[..], &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 /// ```
 #[inline]
 fn reversed<T: Comparable<T>>(a: &T, b: &T) -> Ordering {
@@ -227,11 +227,11 @@ fn min<T: Comparable<T>>(a: T, b: T) -> T {
 /// ```
 /// use std::cmp::{Ordering, is_sorted_by};
 ///
-/// let arr1 = [5, 3, 2, 4, 1].as_slice();
-/// let arr2 = [1, 2, 3, 4, 5].as_slice();
+/// let arr1 = [5, 3, 2, 4, 1];
+/// let arr2 = [1, 2, 3, 4, 5];
 ///
-/// assert!(!arr1.is_sorted_by(i32::compare));
-/// assert!(arr2.is_sorted_by(i32::compare));
+/// assert!(!arr1[..].is_sorted_by(i32::compare));
+/// assert!(arr2[..].is_sorted_by(i32::compare));
 /// ```
 fn is_sorted_by<T, F: CompareFunction<T>>(arr: &[T], f: F) -> bool {
     for i in 1usize..arr.len() {
@@ -249,10 +249,10 @@ fn is_sorted_by<T, F: CompareFunction<T>>(arr: &[T], f: F) -> bool {
 /// ```
 /// use std::cmp::is_sorted_by_key;
 ///
-/// let arr = [(5, 1), (3, 2), (2, 3), (4, 4), (1, 5)].as_slice();
+/// let arr = [(5, 1), (3, 2), (2, 3), (4, 4), (1, 5)];
 ///
-/// assert!(!arr.is_sorted_by_key(|e: &(i32, i32)| -> i32 { e.0 }));
-/// assert!(arr.is_sorted_by_key(|e: &(i32, i32)| -> i32 { e.1 }));
+/// assert!(!arr[..].is_sorted_by_key(|e: &(i32, i32)| -> i32 { e.0 }));
+/// assert!(arr[..].is_sorted_by_key(|e: &(i32, i32)| -> i32 { e.1 }));
 /// ```
 fn is_sorted_by_key<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &[T], key: F) -> bool {
     arr.is_sorted_by(|=key, a: &T, b: &T| -> Ordering { key(a).compare(&key(b)) })
@@ -264,11 +264,11 @@ fn is_sorted_by_key<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &[T], key: F) -> b
 /// ```
 /// use std::cmp::is_sorted;
 ///
-/// let arr1 = [5, 3, 2, 4, 1].as_slice();
-/// let arr2 = [1, 2, 3, 4, 5].as_slice();
+/// let arr1 = [5, 3, 2, 4, 1];
+/// let arr2 = [1, 2, 3, 4, 5];
 ///
-/// assert!(!arr1.is_sorted());
-/// assert!(arr2.is_sorted());
+/// assert!(!arr1[..].is_sorted());
+/// assert!(arr2[..].is_sorted());
 /// ```
 fn is_sorted<T: Comparable<T>>(arr: &[T]) -> bool {
     arr.is_sorted_by(|a: &T, b: &T| -> Ordering { a.compare(b) })
@@ -284,10 +284,10 @@ fn is_sorted<T: Comparable<T>>(arr: &[T]) -> bool {
 /// ```
 /// use std::cmp::{Ordering, sort_by};
 ///
-/// let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
-/// slice.sort_by(|a: &i32, b: &i32| -> Ordering { b.compare(a) });
+/// let arr = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5];
+/// arr[..].sort_by(|a: &i32, b: &i32| -> Ordering { b.compare(a) });
 ///
-/// assert_eq!(slice, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+/// assert_eq!(arr[..], &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 /// ```
 fn sort_by<T, F: CompareFunction<T>>(arr: &mut [T], f: F) {
     if arr.len() <= 1 {
@@ -307,10 +307,10 @@ fn sort_by<T, F: CompareFunction<T>>(arr: &mut [T], f: F) {
 /// ```
 /// use std::cmp::sort_by_key;
 ///
-/// let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
-/// slice.sort_by_key(|v: &i32| -> i32 { -*v });
+/// let arr = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5];
+/// arr[..].sort_by_key(|v: &i32| -> i32 { -*v });
 ///
-/// assert_eq!(slice, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+/// assert_eq!(arr[..], &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 /// ```
 fn sort_by_key<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &mut [T], key: F) {
     arr.sort_by(|=key, a: &T, b: &T| -> Ordering { key(a).compare(&key(b)) });
@@ -325,10 +325,10 @@ fn sort_by_key<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &mut [T], key: F) {
 /// ```
 /// use std::cmp::sort;
 ///
-/// let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
-/// slice.sort();
+/// let arr = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5];
+/// arr[..].sort();
 ///
-/// assert_eq!(slice, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+/// assert_eq!(arr[..], &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 /// ```
 fn sort<T: Comparable<T>>(arr: &mut [T]) {
     arr.sort_by(compare::<T>);
@@ -344,10 +344,10 @@ fn sort<T: Comparable<T>>(arr: &mut [T]) {
 /// ```
 /// use std::cmp::{Ordering, stable_sort_by};
 ///
-/// let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
-/// slice.stable_sort_by(|a: &i32, b: &i32| -> Ordering { b.compare(a) });
+/// let arr = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5];
+/// arr[..].stable_sort_by(|a: &i32, b: &i32| -> Ordering { b.compare(a) });
 ///
-/// assert_eq!(slice, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+/// assert_eq!(arr[..], &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 /// ```
 fn stable_sort_by<T, F: CompareFunction<T>>(arr: &mut [T], f: F) {
     if arr.len() < internal::MERGESORT_MIN_SIZE {
@@ -375,10 +375,10 @@ fn stable_sort_by<T, F: CompareFunction<T>>(arr: &mut [T], f: F) {
 /// ```
 /// use std::cmp::stable_sort_by_key;
 ///
-/// let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
-/// slice.stable_sort_by_key(|v: &i32| -> i32 { -*v });
+/// let arr = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5];
+/// arr[..].stable_sort_by_key(|v: &i32| -> i32 { -*v });
 ///
-/// assert_eq!(slice, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+/// assert_eq!(arr[..], &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 /// ```
 fn stable_sort_by_key<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &mut [T], key: F) {
     arr.stable_sort_by(|=key, a: &T, b: &T| -> Ordering { key(a).compare(&key(b)) });
@@ -393,10 +393,10 @@ fn stable_sort_by_key<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &mut [T], key: F
 /// ```
 /// use std::cmp::stable_sort;
 ///
-/// let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
-/// slice.stable_sort();
+/// let arr = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5];
+/// arr[..].stable_sort();
 ///
-/// assert_eq!(slice, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+/// assert_eq!(arr[..], &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 /// ```
 fn stable_sort<T: Comparable<T>>(arr: &mut [T]) {
     arr.stable_sort_by(compare::<T>);
@@ -412,9 +412,10 @@ fn stable_sort<T: Comparable<T>>(arr: &mut [T]) {
 /// ```
 /// use std::cmp::binary_search;
 ///
-/// let slice = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].as_slice();
-/// assert_eq!(slice.binary_search(&5), Result::ok(4usize));
-/// assert_eq!(slice.binary_search(&11), Result::err(10usize));
+/// let arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+///
+/// assert_eq!(arr[..].binary_search(&5), Result::ok(4usize));
+/// assert_eq!(arr[..].binary_search(&11), Result::err(10usize));
 /// ```
 fn binary_search<T: Comparable<T>>(arr: &[T], needle: &T) -> Result<usize, usize> {
     arr.binary_search_by(|=needle, k: &T| -> Ordering { k.compare(needle) })
@@ -429,9 +430,10 @@ fn binary_search<T: Comparable<T>>(arr: &[T], needle: &T) -> Result<usize, usize
 /// ```
 /// use std::cmp::{Ordering, binary_search_by};
 ///
-/// let slice = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].as_slice();
-/// assert_eq!(slice.binary_search_by(|k: &i32| -> Ordering { k.compare(&5) }), Result::ok(4usize));
-/// assert_eq!(slice.binary_search_by(|k: &i32| -> Ordering { k.compare(&11) }), Result::err(10usize));
+/// let arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+///
+/// assert_eq!(arr[..].binary_search_by(|k: &i32| -> Ordering { k.compare(&5) }), Result::ok(4usize));
+/// assert_eq!(arr[..].binary_search_by(|k: &i32| -> Ordering { k.compare(&11) }), Result::err(10usize));
 /// ```
 fn binary_search_by<T, F: Fn(&T) -> Ordering>(arr: &[T], f: F) -> Result<usize, usize> {
     let size = arr.len();
@@ -463,14 +465,14 @@ fn binary_search_by<T, F: Fn(&T) -> Ordering>(arr: &[T], f: F) -> Result<usize, 
 /// ```
 /// use std::cmp::binary_search_by_key;
 ///
-/// let slice = [
+/// let arr = [
 ///     (0, 0), (1, 2), (2, 4),
 ///     (3, 6), (4, 8), (5, 10),
 ///     (6, 12), (7, 14), (8, 16)
-/// ].as_slice();
+/// ];
 ///
-/// assert_eq!(slice.binary_search_by_key(&5, |v: &(i32, i32)| -> i32 { v.0 }), Result::ok(5usize));
-/// assert_eq!(slice.binary_search_by_key(&11, |v: &(i32, i32)| -> i32 { v.0 }), Result::err(9usize));
+/// assert_eq!(arr[..].binary_search_by_key(&5, |v: &(i32, i32)| -> i32 { v.0 }), Result::ok(5usize));
+/// assert_eq!(arr[..].binary_search_by_key(&11, |v: &(i32, i32)| -> i32 { v.0 }), Result::err(9usize));
 /// ```
 fn binary_search_by_key<T, F: Fn(&T) -> K, K: Comparable<K>>(arr: &[T], needle: &K, key: F) -> Result<usize, usize> {
     arr.binary_search_by(|=needle, =key, k: &T| -> Ordering { key(k).compare(needle) })
@@ -633,33 +635,34 @@ mod internal {
 mod tests {
     #[test]
     fn test_sort() {
-        let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
-        slice.sort();
+        let arr = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5];
+        arr[..].sort();
 
-        assert_eq!(slice, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        assert_eq!(arr[..], &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     }
 
     #[test]
     fn test_sort_by_key() {
-        let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
-        slice.sort_by_key(|x: &i32| -> i32 { -*x });
+        let arr = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5];
+        arr[..].sort_by_key(|x: &i32| -> i32 { -*x });
 
-        assert_eq!(slice, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+        assert_eq!(arr[..], &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
     }
 
     #[test]
     fn test_sort_by() {
-        let slice = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5].as_slice_mut();
-        slice.sort_by(reversed::<i32>);
+        let arr = [4, 8, 2, 9, 7, 10, 3, 1, 6, 5];
+        arr[..].sort_by(reversed::<i32>);
 
-        assert_eq!(slice, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+        assert_eq!(arr[..], &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
     }
 
     #[test]
     fn test_binary_search() {
-        let slice = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].as_slice();
-        assert_eq!(slice.binary_search(&5), Result::ok(4usize));
-        assert_eq!(slice.binary_search(&11), Result::err(10usize));
+        let arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+        assert_eq!(arr[..].binary_search(&5), Result::ok(4usize));
+        assert_eq!(arr[..].binary_search(&11), Result::err(10usize));
     }
 
     #[test]
@@ -667,7 +670,8 @@ mod tests {
         let vec = (0..6561).to_vector();
         defer vec.free();
 
-        vec.as_slice_mut().stable_sort_by_key(|i: &i32| -> i32 { (*i as u32).leading_zeros() as i32 });
+        vec[..]
+            .stable_sort_by_key(|i: &i32| -> i32 { (*i as u32).leading_zeros() as i32 });
 
         let expected = [
             (4096..6561),
@@ -690,29 +694,31 @@ mod tests {
         .enumerate();
 
         for (idx, val) in expected {
-            assert_eq!(vec.as_slice()[idx], val);
+            assert_eq!(vec[idx], val);
         }
     }
 
     #[test]
     fn test_binary_search_by() {
-        let slice = [
+        let arr = [
             (0, 0), (1, 2), (2, 4),
             (3, 6), (4, 8), (5, 10),
             (6, 12), (7, 14), (8, 16)
-        ].as_slice();
-        assert_eq!(slice.binary_search_by(|v: &(i32, i32)| -> Ordering { v.0.compare(&5) }), Result::ok(5usize));
-        assert_eq!(slice.binary_search_by(|v: &(i32, i32)| -> Ordering { v.0.compare(&11) }), Result::err(9usize));
+        ];
+
+        assert_eq!(arr[..].binary_search_by(|v: &(i32, i32)| -> Ordering { v.0.compare(&5) }), Result::ok(5usize));
+        assert_eq!(arr[..].binary_search_by(|v: &(i32, i32)| -> Ordering { v.0.compare(&11) }), Result::err(9usize));
     }
 
     #[test]
     fn test_binary_search_by_key() {
-        let slice = [
+        let arr = [
             (0, 0), (1, 2), (2, 4),
             (3, 6), (4, 8), (5, 10),
             (6, 12), (7, 14), (8, 16)
-        ].as_slice();
-        assert_eq!(slice.binary_search_by_key(&5, |v: &(i32, i32)| -> i32 { v.0 }), Result::ok(5usize));
-        assert_eq!(slice.binary_search_by_key(&11, |v: &(i32, i32)| -> i32 { v.0 }), Result::err(9usize));
+        ];
+
+        assert_eq!(arr[..].binary_search_by_key(&5, |v: &(i32, i32)| -> i32 { v.0 }), Result::ok(5usize));
+        assert_eq!(arr[..].binary_search_by_key(&11, |v: &(i32, i32)| -> i32 { v.0 }), Result::err(9usize));
     }
 }

--- a/sysroot/std/collections/deque.alu
+++ b/sysroot/std/collections/deque.alu
@@ -419,7 +419,7 @@ mod tests {
     macro assert_deque_eq($q, $elems) {
         let vec = $q.iter().to_vector();
         defer vec.free();
-        assert_eq!(vec.as_slice(), $elems);
+        assert_eq!(vec[..], $elems);
     }
 
     #[test]

--- a/sysroot/std/collections/heap.alu
+++ b/sysroot/std/collections/heap.alu
@@ -314,7 +314,7 @@ impl HeapIterator<T: Comparable<T>> {
 /// use std::cmp::compare;
 ///
 /// let v = [3, 5, 1, 2, 9, 8];
-/// v.as_slice_mut().heapify_by(compare::<i32>);
+/// v[..].heapify_by(compare::<i32>);
 ///
 /// assert_eq!(v[0], 9); // max element
 /// ```
@@ -340,9 +340,9 @@ fn heapify_by<T, F: CompareFunction<T>>(self: &mut [T], f: F) {
 /// use std::collections::heap::{heapify_by, heapify_tail_by};
 /// use std::cmp::compare;
 ///
-/// let v = [3, 5, 1, 2, 9, 8].as_slice_mut();
+/// let v = [3, 5, 1, 2, 9, 8];
 /// v[0..4].heapify_by(compare::<i32>);
-/// v.heapify_tail_by(4, compare::<i32>);
+/// v[..].heapify_tail_by(4, compare::<i32>);
 ///
 /// assert_eq!(v[0], 9); // max element
 /// ```
@@ -377,15 +377,15 @@ fn heapify_tail_by<T, F: CompareFunction<T>>(self: &mut [T], start: usize, f: F)
 /// use std::collections::heap::{heapify_by, sort_heap_by};
 /// use std::cmp::compare;
 ///
-/// fn heapsort(v: &mut [i32]) {
-///     v.heapify_by(compare::<i32>);
-///     v.sort_heap_by(compare::<i32>);
+/// fn heapsort(slice: &mut [i32]) {
+///     slice.heapify_by(compare::<i32>);
+///     slice.sort_heap_by(compare::<i32>);
 /// }
 ///
-/// let v = [3, 5, 1, 2, 9, 8].as_slice_mut();
-/// v.heapsort();
+/// let arr = [3, 5, 1, 2, 9, 8];
+/// arr[..].heapsort();
 ///
-/// assert_eq!(v, &[1, 2, 3, 5, 8, 9]);
+/// assert_eq!(arr[..], &[1, 2, 3, 5, 8, 9]);
 /// ```
 fn sort_heap_by<T, F: CompareFunction<T>>(self: &mut [T], f: F) {
     let end = self.len();
@@ -406,12 +406,12 @@ fn sort_heap_by<T, F: CompareFunction<T>>(self: &mut [T], f: F) {
 /// use std::collections::heap::{heapify_by, sift_up_by};
 /// use std::cmp::compare;
 ///
-/// let v = [1, 2, 3, 4, 5].as_slice_mut();
-/// v.heapify_by(compare::<i32>);
+/// let v = [1, 2, 3, 4, 5];
+/// v[..].heapify_by(compare::<i32>);
 /// assert_eq!(v[0], 5); // 5 is the max element
 ///
 /// v[4] = 100;
-/// v.sift_up_by(4, compare::<i32>);
+/// v[..].sift_up_by(4, compare::<i32>);
 /// assert_eq!(v[0], 100); // 100 is the new max element
 /// ```
 fn sift_up_by<T, F: CompareFunction<T>>(self: &mut [T], pos: usize, f: F) {
@@ -439,12 +439,12 @@ fn sift_up_by<T, F: CompareFunction<T>>(self: &mut [T], pos: usize, f: F) {
 /// use std::collections::heap::{heapify_by, sift_down_by};
 /// use std::cmp::compare;
 ///
-/// let v = [1, 2, 3, 4, 5].as_slice_mut();
-/// v.heapify_by(compare::<i32>);
+/// let v = [1, 2, 3, 4, 5];
+/// v[..].heapify_by(compare::<i32>);
 /// assert_eq!(v[0], 5); // 5 is the max element
 ///
 /// v[0] = 3;
-/// v.sift_down_by(0, compare::<i32>);
+/// v[..].sift_down_by(0, compare::<i32>);
 /// assert_eq!(v[0], 4); // 4 is the new max element
 /// ```
 fn sift_down_by<T, F: CompareFunction<T>>(self: &mut [T], pos: usize, f: F) {
@@ -661,7 +661,7 @@ mod tests {
         defer vec.free();
 
         // "Arbitrary" order that satisfies the heap property.
-        assert_eq!(vec.as_slice(), &[ 10, 9, 5, 8, 6, 2, 3, 1, 7, 4 ]);
+        assert_eq!(vec[..], &[ 10, 9, 5, 8, 6, 2, 3, 1, 7, 4 ]);
     }
 
     #[test]
@@ -670,7 +670,7 @@ mod tests {
         defer heap.free();
 
         // "Arbitrary" order that satisfies the heap property.
-        assert_eq!(heap.as_slice(), &[ 10, 9, 5, 8, 6, 2, 3, 1, 7, 4 ]);
+        assert_eq!(heap[..], &[ 10, 9, 5, 8, 6, 2, 3, 1, 7, 4 ]);
     }
 
     #[test]
@@ -741,7 +741,7 @@ mod tests {
         let vec = heap.into_sorted_vector();
         defer vec.free();
 
-        assert_eq!(vec.as_slice(), &[ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]);
+        assert_eq!(vec[..], &[ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]);
     }
 
     #[test]

--- a/sysroot/std/collections/vector.alu
+++ b/sysroot/std/collections/vector.alu
@@ -8,14 +8,13 @@
 /// defer vec.free();
 ///
 /// vec.push(1);
-/// assert_eq!(vec.len(), 1);
-/// assert_eq!(vec.as_slice(), &[1]);
 /// vec.push(2);
-/// assert_eq!(vec.len(), 2);
-/// assert_eq!(vec.as_slice(), &[1, 2]);
 /// vec.push(3);
+///
 /// assert_eq!(vec.len(), 3);
-/// assert_eq!(vec.as_slice(), &[1, 2, 3]);
+/// assert_eq!(vec[0], 1);
+/// assert_eq!(vec[1], 2);
+/// assert_eq!(vec[2], 3);
 /// ```
 struct Vector<T> {
     _data: &mut [T],
@@ -63,7 +62,7 @@ impl Vector<T> {
     ///
     /// let vec = Vector::from_slice(&[1, 2, 3]);
     /// assert_eq!(vec.len(), 3);
-    /// assert_eq!(vec.as_slice(), &[1, 2, 3]);
+    /// assert_eq!(vec[..], &[1, 2, 3]);
     /// ```
     fn from_slice(slice: &[T]) -> Vector<T> {
         let vec = with_capacity::<T>(slice.len());
@@ -84,7 +83,7 @@ impl Vector<T> {
     ///
     /// let vec: Vector<i32> = Vector::from_iter(&(0..3));
     /// assert_eq!(vec.len(), 3);
-    /// assert_eq!(vec.as_slice(), &[0, 1, 2]);
+    /// assert_eq!(vec[..], &[0, 1, 2]);
     /// ```
     fn from_iter<I: Iterator<I, T>>(iter: &mut I) -> Vector<T> {
         let vec = Vector::new::<T>();
@@ -111,7 +110,7 @@ impl Vector<T> {
     /// vec.extend_from_slice(&[1, 2, 3]);
     /// vec.extend_from_slice(&[4, 5, 6]);
     /// assert_eq!(vec.len(), 6);
-    /// assert_eq!(vec.as_slice(), &[1, 2, 3, 4, 5, 6]);
+    /// assert_eq!(vec[..], &[1, 2, 3, 4, 5, 6]);
     /// ```
     fn extend_from_slice(self: &mut Vector<T>, value: &[T]) {
         if value.len() == 0 {
@@ -148,7 +147,7 @@ impl Vector<T> {
     /// vec.insert(0, 100);
     /// vec.insert(4, 200);
     /// vec.insert(7, 300);
-    /// assert_eq!(vec.as_slice(), &[100, 0, 1, 2, 200, 3, 4, 300]);
+    /// assert_eq!(vec[..], &[100, 0, 1, 2, 200, 3, 4, 300]);
     /// ```
     fn insert(self: &mut Vector<T>, index: usize, value: T) {
         self.reserve(1);
@@ -266,7 +265,7 @@ impl Vector<T> {
     /// defer vec.free();
     ///
     /// vec.retain(|x: &i32| -> bool { *x % 2 == 0 });
-    /// assert_eq!(vec.as_slice(), &[0, 2, 4, 6, 8, 10]);
+    /// assert_eq!(vec[..], &[0, 2, 4, 6, 8, 10]);
     /// ```
     fn retain<F: Fn(&T) -> bool>(self: &mut Vector<T>, func: F) {
         let i = 0usize;
@@ -304,7 +303,7 @@ impl Vector<T> {
     /// for elem in vec.iter_mut() {
     ///     *elem *= 2;
     /// }
-    /// assert_eq!(vec.as_slice(), &[2, 4, 6]);
+    /// assert_eq!(vec[..], &[2, 4, 6]);
     /// ```
     #[inline]
     fn iter_mut(self: &mut Vector<T>) -> mem::SliceRefIterator<&mut T> {
@@ -334,7 +333,7 @@ impl Vector<T> {
     /// @ mem::Clonable::clone
     fn clone(self: &Vector<T>) -> Vector<T> {
         let vec = Vector::new::<T>();
-        vec.extend_from_slice(self.as_slice());
+        vec.extend_from_slice(self[..]);
         vec
     }
 }
@@ -356,7 +355,7 @@ impl Vector {
 
     /// @ std::fmt::Formattable::fmt
     fn fmt<F: Formatter<F>>(self: &Vector<u8>, fmt: &mut F) -> Result<(), fmt::Error> {
-        fmt.write_str(self.as_slice())
+        fmt.write_str(self[..])
     }
 }
 
@@ -378,7 +377,7 @@ mod tests {
         defer vec.free();
 
         assert_eq!(vec.len(), 3);
-        assert_eq!(vec.as_slice(), &[1, 2, 3]);
+        assert_eq!(vec[..], &[1, 2, 3]);
     }
 
     #[test]
@@ -387,7 +386,7 @@ mod tests {
         defer vec.free();
 
         assert_eq!(vec.len(), 3);
-        assert_eq!(vec.as_slice(), &[1, 2, 3]);
+        assert_eq!(vec[..], &[1, 2, 3]);
     }
 
     #[test]
@@ -397,7 +396,7 @@ mod tests {
 
         vec.reserve(10);
         assert_eq!(vec.len(), 0);
-        assert_eq!(vec.as_slice(), &[]);
+        assert_eq!(vec[..], &[]);
     }
 
     #[test]
@@ -407,7 +406,7 @@ mod tests {
 
         vec.extend_from_slice(&[1, 2, 3]);
         assert_eq!(vec.len(), 3);
-        assert_eq!(vec.as_slice(), &[1, 2, 3]);
+        assert_eq!(vec[..], &[1, 2, 3]);
     }
 
     #[test]
@@ -417,7 +416,7 @@ mod tests {
 
         vec.extend(&[1, 2, 3].iter());
         assert_eq!(vec.len(), 3);
-        assert_eq!(vec.as_slice(), &[1, 2, 3]);
+        assert_eq!(vec[..], &[1, 2, 3]);
     }
 
     #[test]
@@ -427,13 +426,13 @@ mod tests {
 
         vec.insert(0, 1);
         assert_eq!(vec.len(), 1);
-        assert_eq!(vec.as_slice(), &[1]);
+        assert_eq!(vec[..], &[1]);
         vec.insert(0, 2);
         assert_eq!(vec.len(), 2);
-        assert_eq!(vec.as_slice(), &[2, 1]);
+        assert_eq!(vec[..], &[2, 1]);
         vec.insert(1, 3);
         assert_eq!(vec.len(), 3);
-        assert_eq!(vec.as_slice(), &[2, 3, 1]);
+        assert_eq!(vec[..], &[2, 3, 1]);
     }
 
     #[test]
@@ -459,13 +458,13 @@ mod tests {
 
         vec.push(1);
         assert_eq!(vec.len(), 1);
-        assert_eq!(vec.as_slice(), &[1]);
+        assert_eq!(vec[..], &[1]);
         vec.push(2);
         assert_eq!(vec.len(), 2);
-        assert_eq!(vec.as_slice(), &[1, 2]);
+        assert_eq!(vec[..], &[1, 2]);
         vec.push(3);
         assert_eq!(vec.len(), 3);
-        assert_eq!(vec.as_slice(), &[1, 2, 3]);
+        assert_eq!(vec[..], &[1, 2, 3]);
     }
 
     #[test]
@@ -503,7 +502,7 @@ mod tests {
 
         vec.clear();
         assert_eq!(vec.len(), 0);
-        assert_eq!(vec.as_slice(), &[]);
+        assert_eq!(vec[..], &[]);
     }
 
     #[test]
@@ -527,32 +526,30 @@ mod tests {
 
         assert_eq!(vec.len(), 0);
         assert_eq!(vec2.len(), 3);
-        assert_eq!(vec2.as_slice(), &[1, 2, 3]);
+        assert_eq!(vec2[..], &[1, 2, 3]);
     }
 
     #[test]
     fn test_iter_ref() {
         let vec = Vector::from_slice(&[1, 2, 3]);
-        let as_slice = vec.as_slice();
 
         let it = vec.iter_ref();
 
-        assert_eq!(it.next().unwrap(), &as_slice[0]);
-        assert_eq!(it.next().unwrap(), &as_slice[1]);
-        assert_eq!(it.next().unwrap(), &as_slice[2]);
+        assert_eq!(it.next().unwrap(), &vec[0]);
+        assert_eq!(it.next().unwrap(), &vec[1]);
+        assert_eq!(it.next().unwrap(), &vec[2]);
         assert!(!it.next().is_some());
     }
 
     #[test]
     fn test_iter_mut() {
         let vec = Vector::from_slice(&[1, 2, 3]);
-        let as_slice = vec.as_slice_mut();
 
         let it = vec.iter_mut();
 
-        assert_eq!(it.next().unwrap(), &as_slice[0]);
-        assert_eq!(it.next().unwrap(), &as_slice[1]);
-        assert_eq!(it.next().unwrap(), &as_slice[2]);
+        assert_eq!(it.next().unwrap(), &vec[0]);
+        assert_eq!(it.next().unwrap(), &vec[1]);
+        assert_eq!(it.next().unwrap(), &vec[2]);
         assert!(!it.next().is_some());
     }
 
@@ -562,15 +559,15 @@ mod tests {
         defer vec.free();
 
         vec.retain(|x: &i32| -> bool { true });
-        assert_eq!(vec.as_slice(), &[0, 1, 2, 3, 4, 5, 6]);
+        assert_eq!(vec[..], &[0, 1, 2, 3, 4, 5, 6]);
 
         vec.retain(|x: &i32| -> bool { *x % 2 == 0 });
-        assert_eq!(vec.as_slice(), &[0, 2, 4, 6]);
+        assert_eq!(vec[..], &[0, 2, 4, 6]);
 
         vec.retain(|x: &i32| -> bool { *x % 3 == 0 });
-        assert_eq!(vec.as_slice(), &[0, 6]);
+        assert_eq!(vec[..], &[0, 6]);
 
         vec.retain(|x: &i32| -> bool { false });
-        assert_eq!(vec.as_slice(), &[]);
+        assert_eq!(vec[..], &[]);
     }
 }

--- a/sysroot/std/ffi.alu
+++ b/sysroot/std/ffi.alu
@@ -74,7 +74,7 @@ impl CString {
 
     /// @ mem::Clonable::clone
     fn clone(self: &CString) -> CString {
-        from_slice(self.as_slice())
+        from_slice(self[..])
     }
 
     /// @ mem::Movable::move
@@ -92,7 +92,7 @@ mod tests {
     fn test_cstring() {
         let s = CString::from_raw(c_str!("Hello, World"));
 
-        assert_eq!(s.as_slice(), "Hello, World");
+        assert_eq!(s[..], "Hello, World");
     }
 
     #[test]
@@ -103,7 +103,7 @@ mod tests {
 
         *(s2.ptr as &mut u8) = 'Y';
 
-        assert_eq!(s1.as_slice(), "Hello, World");
-        assert_eq!(s2.as_slice(), "Yello, World");
+        assert_eq!(s1[..], "Hello, World");
+        assert_eq!(s2[..], "Yello, World");
     }
 }

--- a/sysroot/std/fmt.alu
+++ b/sysroot/std/fmt.alu
@@ -106,7 +106,7 @@ protocol Formattable<Self, F: Formatter<F> = NullFormatter> {
 /// ```
 /// use std::fmt::{write, SliceFormatter};
 /// let buf: [u8; 64];
-/// let fmt = SliceFormatter::new(buf.as_slice_mut());
+/// let fmt = SliceFormatter::new(&buf);
 ///
 /// write!(&fmt, "{} + {} = {}", 1, 2, 3);
 ///
@@ -137,7 +137,7 @@ macro writeln($fmt, $fmt_str, $arg...) {
 /// let s: StringBuf = format!("{} + {} = {}", 1, 2, 3).unwrap();
 /// defer s.free();
 ///
-/// assert_eq!(s.as_slice(), "1 + 2 = 3");
+/// assert_eq!(s[..] as &[u8], "1 + 2 = 3");
 /// ```
 macro format($fmt_str, $arg...) {
     let vec = collections::Vector::with_capacity::<u8>($fmt_str.len());
@@ -281,7 +281,6 @@ mod internal {
         assert!(radix >= 2 && radix <= 36);
 
         let buf: [u8; 128];
-        let buf = buf.as_slice_mut();
 
         when T: builtins::Signed {
             if val < 0 {
@@ -437,13 +436,13 @@ mod internal {
         fn fmt<T: Formattable<T, F>, F: Formatter<F>>(self: &GenericPadAdapter<T>, fmt: &mut F) -> Result {
             let buf: [u8; 32];
             let res = format_in!(&buf, "{}", self.inner);
-            let s = if res.is_ok() {
+            let s: &[u8] = if res.is_ok() {
                 res.unwrap()
             } else {
                 // We fall back to the heap-allocating variant if the stack buffer was not large enough.
                 let res = format!("{}", self.inner)?;
                 defer res.free();
-                res.as_slice()
+                res[..]
             };
 
             if s.len() < self.len {

--- a/sysroot/std/fs.alu
+++ b/sysroot/std/fs.alu
@@ -331,7 +331,7 @@ impl PathBuf {
 
     /// View path as [Path] object
     fn as_path(self: &PathBuf) -> Path {
-        Path::new(self.inner.as_slice())
+        Path::new(self.inner[..])
     }
 
     /// Extend the path buffer from an iterator of path segments
@@ -459,11 +459,10 @@ mod tests {
     #[test]
     fn test_path_fmt() {
         let buf: [u8; 512];
-        let buf = buf.as_slice_mut();
 
         macro chk($path, $expected) {
             let path = Path::new($path);
-            let ret = format_in!(buf, "{}", path).unwrap();
+            let ret = format_in!(&buf, "{}", path).unwrap();
             assert_eq!(ret, $expected);
         }
 

--- a/sysroot/std/fs/unix.alu
+++ b/sysroot/std/fs/unix.alu
@@ -235,7 +235,7 @@ fn remove_directory(path: Path) -> Result<()> {
 ///
 /// file.read_to_end(&buf).unwrap();
 ///
-/// println!("{}", buf.as_slice());
+/// println!("{}", buf[..]);
 /// ```
 struct File {
     fd: FileDescriptor
@@ -411,7 +411,7 @@ struct DirEntry {
 impl DirEntry {
     /// Return the name of the item in directory
     fn name(self: &DirEntry) -> &[u8] {
-        std::ffi::CString::from_raw(&self.inner.d_name[0]).as_slice()
+        std::ffi::CString::from_raw(&self.inner.d_name[0])[..]
     }
 
     /// Returns the file type
@@ -602,7 +602,6 @@ mod tests {
     #[test]
     fn test_open() {
         let filename = mktemp();
-        let buf = BUF.as_slice_mut();
         defer filename.free();
 
         let file = File::create(filename.as_path()).unwrap();
@@ -613,13 +612,13 @@ mod tests {
         let file = File::open(filename.as_path()).unwrap();
         defer file.close();
 
-        let read = file.read(buf).unwrap();
-        assert_eq!(buf[..read] as &[u8], "Hello, world!");
+        let read = file.read(&BUF).unwrap();
+        assert_eq!(BUF[..read] as &[u8], "Hello, world!");
 
         file.seek(SeekFrom::Beginning, 7).unwrap();
 
-        let read = file.read(buf).unwrap();
-        assert_eq!(buf[..read] as &[u8], "world!");
+        let read = file.read(&BUF).unwrap();
+        assert_eq!(BUF[..read] as &[u8], "world!");
 
         let attrs = file.attributes().unwrap();
         assert_eq!(attrs.size(), 13);
@@ -633,7 +632,7 @@ mod tests {
         let read_back = File::read_to_string(filename.as_path()).unwrap();
         defer read_back.free();
 
-        assert_eq!(read_back.as_slice(), "Hello, world!");
+        assert_eq!(read_back[..] as &[u8], "Hello, world!");
     }
 
 
@@ -662,7 +661,8 @@ mod tests {
             .to_vector();
         defer entries.free_all();
 
-        entries.as_slice_mut().sort_by_key(|e: &StringBuf| -> &[u8] { e.as_slice() });
+        entries[..]
+            .sort_by_key(|e: &StringBuf| -> &[u8] { e[..] });
 
         let it = entries.iter_ref().map(StringBuf::as_slice::<u8>);
 

--- a/sysroot/std/hash/xxhash.alu
+++ b/sysroot/std/hash/xxhash.alu
@@ -189,9 +189,9 @@ mod tests {
             (0..i)
                 .iter()
                 .map(std::util::cast::<i32, u8>)
-                .fill_slice(buf.as_slice_mut());
+                .fill_slice(&buf);
 
-            buf.as_slice()[0..(i as usize)].hash(&h);
+            buf[0..(i as usize)].hash(&h);
             h.finish()
         }
 

--- a/sysroot/std/io.alu
+++ b/sysroot/std/io.alu
@@ -117,11 +117,11 @@ protocol Readable<Self> {
             // return EOF by using a small stack buffer instead.
             if buf.capacity() == buf.len() && buf.capacity() == start_cap {
                 let probe: [u8; 32];
-                let read = self.read(probe.as_slice_mut())?;
+                let read = self.read(&probe)?;
                 if read == 0 {
                     return Result::ok(buf.len() - start_len);
                 } else {
-                    buf.extend_from_slice(probe.as_slice()[..read])
+                    buf.extend_from_slice(probe[..read])
                 }
             }
         }
@@ -704,10 +704,10 @@ fn read_byte<R: Readable<R>>(reader: &mut R) -> Result<u8> {
 /// defer buf.free();
 ///
 /// stream.read_until('\n', &buf).unwrap();
-/// assert_eq!(buf.as_slice(), "Hello\n");
+/// assert_eq!(buf[..] as &[u8], "Hello\n");
 /// buf.clear();
 /// stream.read_until('\n', &buf).unwrap();
-/// assert_eq!(buf.as_slice(), "World\n");
+/// assert_eq!(buf[..] as &[u8], "World\n");
 /// ```
 fn read_until<R: BufferedReadable<R>>(r: &mut R, delim: u8, buf: &mut string::StringBuf) -> Result<usize> {
     use string::find_char;
@@ -785,7 +785,7 @@ impl LineIterator<R: BufferedReadable<R>> {
             }
         }
 
-        Option::some(Result::ok(self.line_buf.as_slice()))
+        Option::some(Result::ok(self.line_buf[..] as &[u8]))
     }
 
     /// @ std::mem::Freeable::free
@@ -850,8 +850,8 @@ mod tests {
     use string::StringBuf;
 
     macro read_n($reader, $n) {
-        let read = $reader.read(BUF.as_slice_mut()[..$n]).unwrap();
-        BUF.as_slice()[..read]
+        let read = $reader.read(BUF[..$n]).unwrap();
+        BUF[..read] as &[u8]
     }
 
     #[test]
@@ -861,19 +861,18 @@ mod tests {
         assert_eq!(read_n!(text, 14), "dolor sit amet");
         assert_eq!(read_n!(text, 100), "");
 
-        let buf = BUF.as_slice_mut();
         let text = SliceReader::new("Lorem ipsum dolor sit amet");
-        assert_eq!(text.read_exact(buf[..100]), Result::err(Error::eof()));
+        assert_eq!(text.read_exact(BUF[..100]), Result::err(Error::eof()));
 
         let text = SliceReader::new("Lorem ipsum dolor sit amet");
-        assert_eq!(text.read_exact(buf[..26]), Result::ok(()));
+        assert_eq!(text.read_exact(BUF[..26]), Result::ok(()));
 
         let text = SliceReader::new("Lorem ipsum dolor sit amet");
         let read : StringBuf = StringBuf::new();
         defer read.free();
 
         text.read_to_end(&read).unwrap();
-        assert_eq!(read.as_slice(), "Lorem ipsum dolor sit amet");
+        assert_eq!(read[..] as &[u8], "Lorem ipsum dolor sit amet");
     }
 
     #[test]
@@ -923,15 +922,15 @@ mod tests {
         let dst: StringBuf = StringBuf::new();
 
         copy(&src, &StringWriter::new(&dst)).unwrap();
-        assert_eq!(dst.as_slice(), "Lorem ipsum dolor sit amet");
+        assert_eq!(dst[..] as &[u8], "Lorem ipsum dolor sit amet");
     }
 
     #[test]
     fn test_null() {
         let src = NullStream::new();
         let buf: [u8; 32];
-        assert_eq!(src.read(buf.as_slice_mut()), Result::ok(0usize));
-        assert_eq!(src.read_exact(buf.as_slice_mut()), Result::err(Error::eof()));
+        assert_eq!(src.read(&buf), Result::ok(0usize));
+        assert_eq!(src.read_exact(&buf), Result::err(Error::eof()));
         assert_eq!(src.read_exact(mem::slice::empty()), Result::ok(()));
         let s: StringBuf = StringBuf::new();
         defer s.free();
@@ -950,10 +949,10 @@ mod tests {
         defer s.free();
 
         assert_eq!(src.take(5).read_to_end(&s), Result::ok(5usize));
-        assert_eq!(s.as_slice(), "Lorem");
+        assert_eq!(s[..] as &[u8], "Lorem");
 
         assert_eq!(src.read_to_end(&s), Result::ok(21usize));
-        assert_eq!(s.as_slice(), "Lorem ipsum dolor sit amet");
+        assert_eq!(s[..] as &[u8], "Lorem ipsum dolor sit amet");
     }
 
     #[test]
@@ -965,6 +964,6 @@ mod tests {
         defer s.free();
 
         assert_eq!(src1.chain(&src2).read_to_end(&s), Result::ok(26usize));
-        assert_eq!(s.as_slice(), "Lorem ipsum dolor sit amet");
+        assert_eq!(s[..] as &[u8], "Lorem ipsum dolor sit amet");
     }
 }

--- a/sysroot/std/io/unix.alu
+++ b/sysroot/std/io/unix.alu
@@ -78,14 +78,13 @@ impl Error {
             ErrorKind::UnexpectedEof => f.write_str("unexpected end of file"),
             ErrorKind::GetAddrInfo => {
                 f.write_str("failed to lookup address information: ")?;
-                f.write_str(ffi::CString::from_raw(libc::gai_strerror(self.inner.gai_err)).as_slice())
+                f.write_str(ffi::CString::from_raw(libc::gai_strerror(self.inner.gai_err))[..])
             }
             ErrorKind::UserDefined => {
                 f.write_str(self.inner.message)
             }
             ErrorKind::Os => {
                 let buf: [u8; 128];
-                let buf = buf.as_slice_mut();
 
                 if libc::strerror_r(self.inner.errno, &buf[0] as &mut libc::c_char, 128) < 0 {
                     panic!("strerror_r failed");

--- a/sysroot/std/iter.alu
+++ b/sysroot/std/iter.alu
@@ -1246,7 +1246,7 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     ///         let f = format!("{}", x).unwrap();
     ///         defer f.free();
     ///
-    ///         println!("{}", f.as_slice());
+    ///         println!("{}", f[..]);
     ///     });
     /// ```
     fn foreach<F: Fn(T)>(iter: &mut Self, fun: F) {
@@ -1496,7 +1496,7 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// defer range.free();
     ///
     /// assert_eq!(range.len(), 5);
-    /// assert_eq!(range.as_slice(), &[0, 1, 2, 3, 4]);
+    /// assert_eq!(range[..], &[0, 1, 2, 3, 4]);
     /// ```
     fn to_vector(self: &mut Self) -> collections::Vector<T> {
         collections::Vector::from_iter::<T, Self>(self)
@@ -1513,9 +1513,9 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// ## Example
     /// ```
     /// let buf: [i32; 5];
-    /// (0..5).fill_slice(buf.as_slice_mut());
+    /// (0..5).fill_slice(buf[..]);
     ///
-    /// assert_eq!(buf.as_slice(), &[0, 1, 2, 3, 4]);
+    /// assert_eq!(buf[..], &[0, 1, 2, 3, 4]);
     /// ```
     fn fill_slice(self: &mut Self, slice: &mut [T]) -> usize {
         let index = 0usize;
@@ -1614,7 +1614,7 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// let v = iter.to_vector();
     /// defer v.free();
     ///
-    /// assert_eq!(v.as_slice(), &['H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd']);
+    /// assert_eq!(v[..], &['H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd']);
     /// ```
     fn flatten(self: &mut Self) -> FlattenIterator<Self, T, iterable_yield_t<T>> {
         FlattenIterator {
@@ -2031,7 +2031,7 @@ mod tests {
     #[test]
     fn test_to_vector() {
         let vec = (0..5).to_vector();
-        assert_eq!(vec.as_slice(), &[0, 1, 2, 3, 4]);
+        assert_eq!(vec[..], &[0, 1, 2, 3, 4]);
     }
 
     #[test]
@@ -2085,15 +2085,14 @@ mod tests {
     #[test]
     fn fill_slice() {
         let buf: [i32; 10];
-        let slice = buf.as_slice_mut();
 
-        let written = (0..5).fill_slice(slice);
+        let written = (0..5).fill_slice(&buf);
         assert_eq!(written, 5);
-        assert_eq!(slice[..5], &[0, 1, 2, 3, 4]);
+        assert_eq!(buf[..5], &[0, 1, 2, 3, 4]);
 
-        let written = (10..200).fill_slice(slice);
+        let written = (10..200).fill_slice(&buf);
         assert_eq!(written, 10);
-        assert_eq!(slice, &[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
+        assert_eq!(buf[..], &[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
     }
 
     #[test]

--- a/sysroot/std/mem.alu
+++ b/sysroot/std/mem.alu
@@ -44,12 +44,42 @@ protocol Clonable<Self> {
     fn clone(self: &Self) -> Self;
 }
 
-/// Types that can be viewed as slices
+/// Types that can be viewed as const slices
+///
+/// Types that implement this trait can be indexed as if they were slices.
+///
+/// ## Example
+/// ```
+/// use std::collections::Vector;
+///
+/// let v: Vector<i32> = Vector::new();
+/// v.push(1);
+/// v.push(2);
+/// v.push(3);
+///
+/// assert_eq!(v[1], 2);
+/// ```
 protocol AsSlice<Self, T> {
     fn as_slice(self: &Self) -> &[T];
 }
 
 /// Types that can be viewed as mutable slices
+///
+/// Types that implement this trait can be indexed as if they were slices.
+///
+/// ## Example
+/// ```
+/// use std::collections::Vector;
+///
+/// let v: Vector<i32> = Vector::new();
+/// v.push(1);
+/// v.push(2);
+/// v.push(3);
+///
+/// v[2] = 4;
+///
+/// assert_eq!(v.pop(), Option::some(4));
+/// ```
 protocol AsSliceMut<Self: AsSlice<Self, T>, T> {
     fn as_slice_mut(self: &mut Self) -> &mut [T];
 }
@@ -194,7 +224,7 @@ impl slice {
     /// let hw = "Hello, world";
     /// let hw: [u8; 5] = hw[..5].to_array();
     ///
-    /// assert_eq!(hw.as_slice(), "Hello");
+    /// assert_eq!(hw[..] as &[u8], "Hello");
     /// ```
     fn to_array<T, Arr: builtins::ArrayOf<T>>(self: &[T]) -> Arr {
         let ret: Arr;
@@ -410,6 +440,30 @@ mod internal {
             if !$cond {
                 panic!($msg, $args...);
             }
+        }
+    }
+
+    // Some gnarly metaprogramming to determine whether collection-to-slice coercion is possible,
+    // what the slice element type is, and with what mutability.
+    type slicify_element_t<T> = typeof(*(null as &T).as_slice()._ptr);
+    type slicify_slice_t<T: AsSlice<T, slicify_element_t<T>>, Ptr: builtins::PointerOf<T>> = when Ptr: &T {
+        &[slicify_element_t<T>]
+    } else when T: AsSliceMut<T, slicify_element_t<T>> {
+        &mut [slicify_element_t<T>]
+    } else {
+        &[slicify_element_t<T>]
+    };
+
+    /// Convert anything that has the appropriate as_slice/as_slice_mut methods to a slice.
+    /// Invoked by the compiler when indexing into a collection.
+    #[lang(slice_slicify)]
+    fn slice_slicify<T, Ptr>(ptr: Ptr) -> slicify_slice_t<T, Ptr> {
+        when Ptr: &T {
+            ptr.as_slice()
+        } else when T: AsSliceMut<T, slicify_element_t<T>> {
+            ptr.as_slice_mut()
+        } else {
+            ptr.as_slice()
         }
     }
 
@@ -674,9 +728,9 @@ mod tests {
     #[test]
     fn test_fill() {
         let a: [u8; 10];
-        a.as_slice_mut().fill('a');
+        a[..].fill('a');
 
-        assert_eq!(a.as_slice(), "aaaaaaaaaa");
+        assert_eq!(a[..] as &[u8], "aaaaaaaaaa");
     }
 
     #[test]
@@ -684,13 +738,12 @@ mod tests {
         let a: [u8; 32];
         "hello world".copy_to_nonoverlapping(&a[0]);
 
-        assert_eq!(a.as_slice()[0..11], "hello world");
+        assert_eq!(a[..11] as &[u8], "hello world");
     }
 
     #[test]
     fn test_copy() {
         let a: [u8; 32];
-        let a = a.as_slice_mut();
 
         "hello world".copy_to_nonoverlapping(&a[0]);
         a[0..11].copy_to(&a[6]);

--- a/sysroot/std/net/address.alu
+++ b/sysroot/std/net/address.alu
@@ -145,7 +145,7 @@ impl Ipv6Addr {
         }
 
         if right.1 > 0 {
-            right.0.as_slice()[..right.1]
+            right.0[..right.1]
                 .copy_to_nonoverlapping(&left.0[8 - right.1]);
         }
 
@@ -210,12 +210,12 @@ impl Ipv6Addr {
 
     /// @ cmp::Equatable::equals
     fn equals(self: &Ipv6Addr, other: &Ipv6Addr) -> bool {
-        self.inner.s6_addr.as_slice() == other.inner.s6_addr.as_slice()
+        self.inner.s6_addr[..] == other.inner.s6_addr[..]
     }
 
     /// @ hash::Hashable::hash
     fn hash<H: Hasher<H>>(self: &Ipv6Addr, hasher: &mut H) {
-        self.inner.s6_addr.as_slice().hash(hasher);
+        self.inner.s6_addr[..].hash(hasher);
     }
 
     mixin cmp::Equatable<Ipv6Addr>;

--- a/sysroot/std/net/unix.alu
+++ b/sysroot/std/net/unix.alu
@@ -435,7 +435,7 @@ const MSG_NOSIGNAL: libc::c_int = 0;
 ///     socket.send_to(request, &remote_addr)?;
 ///
 ///     let buf: [u8; 65536];
-///     let (size, src) = socket.recv_from(buf.as_slice_mut())?;
+///     let (size, src) = socket.recv_from(&buf)?;
 ///
 ///     println!("Received {} bytes from {}", size, src);
 ///     println!("  {} questions",   (&buf[4]  as &u16).from_be());
@@ -648,7 +648,7 @@ mod tests {
             let buf: StringBuf = StringBuf::new();
             socket.read_to_end(&buf).unwrap();
 
-            assert_eq!(buf.as_slice(), "Hello, world!");
+            assert_eq!(buf[..] as &[u8], "Hello, world!");
         }
     }
 
@@ -667,9 +667,9 @@ mod tests {
             peer2.send_to("Hello, world!", &peer1_addr).unwrap();
         } else {
             let buf: [u8; 128];
-            let (n, peer) = peer1.recv_from(buf.as_slice_mut()).unwrap();
+            let (n, peer) = peer1.recv_from(&buf).unwrap();
 
-            assert_eq!(buf.as_slice()[..n], "Hello, world!");
+            assert_eq!(buf[..n] as &[u8], "Hello, world!");
         }
     }
 
@@ -690,17 +690,17 @@ mod tests {
             peer2.connect(&peer1_addr).unwrap();
             peer2.send("Hello, world!").unwrap();
 
-            let n = peer2.recv(buf.as_slice_mut()).unwrap();
-            peer2.send(buf.as_slice()[..n]).unwrap();
+            let n = peer2.recv(&buf).unwrap();
+            peer2.send(buf[..n]).unwrap();
 
         } else {
             let buf: [u8; 128];
-            let (n, peer) = peer1.recv_from(buf.as_slice_mut()).unwrap();
+            let (n, peer) = peer1.recv_from(&buf).unwrap();
 
             peer1.send_to("AAAAAAA", &peer).unwrap();
 
-            let (n, peer) = peer1.recv_from(buf.as_slice_mut()).unwrap();
-            assert_eq!(buf.as_slice()[..n], "AAAAAAA");
+            let (n, peer) = peer1.recv_from(&buf).unwrap();
+            assert_eq!(buf[..n] as &[u8], "AAAAAAA");
         }
     }
 
@@ -720,11 +720,11 @@ mod tests {
         } else {
             let buf1: [u8; 128];
             let buf2: [u8; 128];
-            let (n, peer) = peer1.peek_from(buf1.as_slice_mut()).unwrap();
-            assert_eq!(buf1.as_slice()[..n], "Hello, world!");
+            let (n, peer) = peer1.peek_from(&buf1).unwrap();
+            assert_eq!(buf1[..n] as &[u8], "Hello, world!");
 
-            let (n, peer) = peer1.recv_from(buf2.as_slice_mut()).unwrap();
-            assert_eq!(buf2.as_slice()[..n], "Hello, world!");
+            let (n, peer) = peer1.recv_from(&buf2).unwrap();
+            assert_eq!(buf2[..n] as &[u8], "Hello, world!");
         }
     }
 }

--- a/sysroot/std/process/unix.alu
+++ b/sysroot/std/process/unix.alu
@@ -31,7 +31,7 @@ impl EnvVars {
                 break Option::none();
             }
 
-            let env_str = CString::from_raw(*self.ptr).as_slice();
+            let env_str = CString::from_raw(*self.ptr)[..];
             self.ptr += 1;
 
             if env_str.len() == 0 {
@@ -114,7 +114,7 @@ fn current_dir() -> Result<fs::PathBuf> {
 fn set_current_dir(path: fs::Path) -> Result<()> {
     use ffi::CString;
 
-    let path = CString::from_slice(path.as_slice());
+    let path = CString::from_slice(path[..]);
     defer path.free();
 
     errno_try!(libc::chdir(path.ptr as &libc::c_char));
@@ -349,7 +349,7 @@ impl Forked {
 /// defer output.free();
 ///
 /// // Prints "Running on Linux"
-/// println!("Running on {}", output.stdout.as_slice().trim());
+/// println!("Running on {}", output.stdout[..].trim());
 /// ```
 struct Command {
     _path: fs::Path,
@@ -639,7 +639,7 @@ mod internal {
                 }
             }
 
-            let ptr = &storage.as_slice()[0];
+            let ptr = &storage[0];
             let ptrs: Vector<&u8> = args_idxs
                 .iter()
                 .map(|&ptr, idx: usize| -> &u8 { ptr + idx })
@@ -659,15 +659,15 @@ mod internal {
         }
 
         fn name(self: &ExecParams) -> &libc::c_char {
-            &self._chars.as_slice()[0] as &libc::c_char
+            &self._chars[0] as &libc::c_char
         }
 
         fn argv(self: &ExecParams) -> &&libc::c_char {
-            &self._ptrs.as_slice()[0] as &&libc::c_char
+            &self._ptrs[0] as &&libc::c_char
         }
 
         fn envp(self: &ExecParams) -> &&libc::c_char {
-            &self._ptrs.as_slice()[self._argc + 1] as &&libc::c_char
+            &self._ptrs[self._argc + 1] as &&libc::c_char
         }
 
         fn free(self: &mut ExecParams) {
@@ -695,8 +695,8 @@ mod tests {
         defer output.free();
 
         assert_eq!(output.status, 0);
-        assert_eq!(output.stdout.as_slice(), "Hello, World!\n");
-        assert_eq!(output.stderr.as_slice(), &[]);
+        assert_eq!(output.stdout[..] as &[u8], "Hello, World!\n");
+        assert_eq!(output.stderr[..] as &[u8], &[]);
     }
 
     #[test]
@@ -715,8 +715,8 @@ mod tests {
         defer output.free();
 
         assert_eq!(output.status, 0);
-        assert_eq!(output.stdout.as_slice(), "HELLO=world\nFOO=bar\n");
-        assert_eq!(output.stderr.as_slice(), &[]);
+        assert_eq!(output.stdout[..] as &[u8], "HELLO=world\nFOO=bar\n");
+        assert_eq!(output.stderr[..] as &[u8], &[]);
     }
 
     #[test]
@@ -762,8 +762,8 @@ mod tests {
             defer output.free();
 
             assert_eq!((output.status & 0xff00) >> 8, 123);
-            assert_eq!(output.stdout.as_slice(), "Hello");
-            assert_eq!(output.stderr.as_slice(), "World");
+            assert_eq!(output.stdout[..] as &[u8], "Hello");
+            assert_eq!(output.stderr[..] as &[u8], "World");
         }
     }
 

--- a/sysroot/std/random.alu
+++ b/sysroot/std/random.alu
@@ -103,7 +103,6 @@ struct Pcg32  {
 impl Pcg32 {
     /// Create a Pcg32 random number generator from a given seed.
     fn from_seed(seed: &[u8; 16]) -> Pcg32 {
-        let seed = seed.as_slice();
         let pcg: Pcg32;
 
         seed[0..8].copy_to_nonoverlapping(&pcg.state as &mut u8);
@@ -474,10 +473,10 @@ mod tests {
     fn test_shuffle() {
         let rng = Pcg32::from_seed(&SEED)
         let v = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-        rng.shuffle(v.as_slice_mut());
+        rng.shuffle(&v);
 
-        assert_ne!(v.as_slice(), &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        cmp::sort(v.as_slice_mut());
-        assert_eq!(v.as_slice(), &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        assert_ne!(v[..], &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        cmp::sort(&v);
+        assert_eq!(v[..], &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     }
 }

--- a/sysroot/std/string.alu
+++ b/sysroot/std/string.alu
@@ -592,15 +592,15 @@ mod tests {
     fn test_join() {
         let vec = ".".join(&["192", "168", "0", "1"].iter());
         defer vec.free();
-        assert_eq!(vec.as_slice(), "192.168.0.1");
+        assert_eq!(vec[..] as &[u8], "192.168.0.1");
 
         let vec = "".join(&["192", "168", "0", "1"].iter());
         defer vec.free();
-        assert_eq!(vec.as_slice(), "19216801");
+        assert_eq!(vec[..] as &[u8], "19216801");
 
         let vec = "%".join(&["192.168.0.1"].iter());
         defer vec.free();
-        assert_eq!(vec.as_slice(), "192.168.0.1");
+        assert_eq!(vec[..] as &[u8], "192.168.0.1");
     }
 
     #[test]
@@ -608,6 +608,6 @@ mod tests {
         let f = "192.168.0.1".replace(".", "::");
         defer f.free();
 
-        assert_eq!(f.as_slice(), "192::168::0::1");
+        assert_eq!(f[..] as &[u8], "192::168::0::1");
     }
 }

--- a/sysroot/std/sync.alu
+++ b/sysroot/std/sync.alu
@@ -72,7 +72,7 @@ impl Atomic<T: Primitive + !ZeroSized> {
     ///     i.fetch_add(1, Ordering::Relaxed);
     /// }
     ///
-    /// assert_eq!(arr.as_slice(), &[2, 3, 4]);
+    /// assert_eq!(arr[..], &[2, 3, 4]);
     /// ```
     #[inline]
     fn from_mut_slice(inner: &mut [T]) -> &mut [Atomic<T>] {

--- a/sysroot/std/time.alu
+++ b/sysroot/std/time.alu
@@ -442,11 +442,10 @@ mod tests {
     #[test]
     fn test_fmt() {
         let buf: [u8; 1024];
-        let buf = buf.as_slice_mut();
 
         macro chk($dur, $expected) {
             assert_eq!(
-                format_in!(buf, "{}", $dur).unwrap(),
+                format_in!(&buf, "{}", $dur).unwrap(),
                 $expected
             );
         }

--- a/sysroot/std/typing.alu
+++ b/sysroot/std/typing.alu
@@ -87,7 +87,7 @@ struct Self {}
 /// assert_eq!(variants[1].1, Foo::Quux);
 /// ```
 fn enum_variants<E: builtins::Enum>() -> &[(&[u8], E)] {
-    (internal::ENUM_VARIANTS::<E>).as_slice()
+    (internal::ENUM_VARIANTS::<E>)[..]
 }
 
 /// Asserts that the types are equal.

--- a/sysroot/test.alu
+++ b/sysroot/test.alu
@@ -282,12 +282,12 @@
                     }
                     if result.stdout.len() > 0 {
                         eprintln!("---- {}::{} stdout ----", result.test.path[2..], result.test.name);
-                        eprintln!("{}", result.stdout.as_slice());
+                        eprintln!("{}", result.stdout[..]);
                         eprintln!("");
                     }
                     if result.stderr.len() > 0 {
                         eprintln!("---- {}::{} stderr ----", result.test.path[2..], result.test.name);
-                        eprintln!("{}", result.stderr.as_slice());
+                        eprintln!("{}", result.stderr[..]);
                         eprintln!("");
                     }
                 }

--- a/tools/alumina-doc/common.alu
+++ b/tools/alumina-doc/common.alu
@@ -62,7 +62,7 @@ impl Path {
         if self.segments.len() < prefix.segments.len() {
             return false;
         }
-        self.as_slice()[0..prefix.len()] == prefix.as_slice()
+        self[0..prefix.len()] == prefix[..]
     }
 
     fn pop(self: &mut Path) -> &[u8] {


### PR DESCRIPTION
This change adds the ability to index types like `Vector` directly rather than coaxing them into a slice first. The way this is doe is through a lang-item that allows items that implement `std::mem::AsSlice` and/or `std::mem::AsSliceMut` to be implicitly converted into a slice before indexing.

Both direct and range indexing is supported. This means that `vec[..]` is also shorthand syntax for `vec.as_slice()` now.