### PR TITLE
fix: Fix wrong expression type in if/else expressions

### DIFF
--- a/docs/lang_guide.md
+++ b/docs/lang_guide.md
@@ -308,7 +308,7 @@ fn main() {
 
 ## Other function attributes
 
-- `#[inline]`, `#[force_inline]` and `#[no_inline]` control the inlining behavior of the function.
+- `#[inline]`, `#[inline(always)]` and `#[inline(never)]` control the inlining behavior of the function.
 - `#[cold]` marks the function as unlikely to be called. Any branch that leads to the function call is marked as unlikely to be taken. Usually used on error handling functions to to optimize for the happy path with regards to branch prediction.
 - `#[link_name("name")]` allows to specify the name of the function in the generated object file. This is useful for linking to C libraries that use non-standard naming conventions.
 
@@ -1353,6 +1353,15 @@ fn fill_with_random_bytes(buf: &mut [u8]) {
     #[cfg(target_os = "macos")]
     libc::getentropy(&buf[0], buf.len());
 }
+```
+
+`#[cfg_attr(cond, ...)]` can be used to apply attributes to items based on the configuration.
+
+For example, to change the symbol name for the import on MacOS:
+
+```rust
+#[cfg_attr(target_os="macos", link_name("_opendir$INODE64"))]
+extern "C" fn opendir(dirname: &c_char) -> &mut DIR;
 ```
 
 ## `typeof` type

--- a/docs/lang_guide.md
+++ b/docs/lang_guide.md
@@ -20,6 +20,7 @@ With regards to syntax, the language is very similar to Rust and in terms of sem
   - [Enums](#enums)
   - [Impl blocks](#impl-blocks)
   - [Type attributes](#type-attributes)
+  - [Slices](#slices)
   - [What about strings?](#what-about-strings)
   - [Zero-sized types](#zero-sized-types)
 - [Macros](#macros)
@@ -610,10 +611,8 @@ let rotated = Point::rotate_180deg::<f64>(&point);
 
 Named types can have attributes.
 
-```rust
-
-- `#[align(n)]` specifies the minimum alignment of the type. The default is 1.
--
+- `#[align(n)]` specifies the minimum alignment of the type. Alignment must be a power of two.
+- `#[packed]` on a struct specifies that the type should be packed (no padding between fields).
 
 ## Slices
 

--- a/src/alumina-boot/src/ast/mod.rs
+++ b/src/alumina-boot/src/ast/mod.rs
@@ -705,6 +705,7 @@ pub enum Attribute {
     TestMain,
     Inline,
     Align(u32),
+    Packed,
     NoInline,
     ThreadLocal,
     Builtin,

--- a/src/alumina-boot/src/ast/mod.rs
+++ b/src/alumina-boot/src/ast/mod.rs
@@ -696,11 +696,6 @@ impl BinOp {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum CodegenType {
-    CMain,
-}
-
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Attribute {
@@ -716,7 +711,6 @@ pub enum Attribute {
     ForceInline,
     Intrinsic,
     StaticConstructor,
-    Codegen(CodegenType),
     LinkName(usize, [u8; 255]),
 }
 

--- a/src/alumina-boot/src/codegen/functions.rs
+++ b/src/alumina-boot/src/codegen/functions.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast::{Attribute, BinOp, BuiltinType, CodegenType, UnOp},
+    ast::{Attribute, BinOp, BuiltinType, UnOp},
     codegen::CName,
     common::AluminaError,
     intrinsics::CodegenIntrinsicKind,
@@ -36,6 +36,7 @@ pub fn write_function_signature<'ir, 'gen>(
     id: IrId,
     item: &'ir Function<'ir>,
     is_static: bool,
+    is_body: bool,
 ) -> Result<(), AluminaError> {
     let name = ctx.get_name(id);
     let mut is_inline = false;
@@ -107,7 +108,9 @@ pub fn write_function_signature<'ir, 'gen>(
         .next();
 
     if let Some(link_name) = link_name {
-        w!(buf, " asm({})", link_name);
+        if !is_body {
+            w!(buf, " asm({})", link_name);
+        }
     }
 
     Ok(())
@@ -507,17 +510,10 @@ impl<'ir, 'gen> FunctionWriter<'ir, 'gen> {
             self.type_writer.add_type(arg.ty)?;
         }
 
-        if item
-            .attributes
-            .contains(&Attribute::Codegen(CodegenType::CMain))
-        {
-            return Ok(());
-        }
-
         if item.body.get().is_none() || should_export {
             self.ctx
                 .register_name(id, CName::Native(item.name.unwrap()));
-            write_function_signature(self.ctx, &mut self.fn_decls, id, item, false)?;
+            write_function_signature(self.ctx, &mut self.fn_decls, id, item, false, false)?;
         } else {
             self.ctx.register_name(
                 id,
@@ -532,6 +528,7 @@ impl<'ir, 'gen> FunctionWriter<'ir, 'gen> {
                 id,
                 item,
                 !self.ctx.global_ctx.has_flag("debug"),
+                false,
             )?;
         }
 
@@ -594,26 +591,14 @@ impl<'ir, 'gen> FunctionWriter<'ir, 'gen> {
             return Ok(());
         }
 
-        if item
-            .attributes
-            .contains(&Attribute::Codegen(CodegenType::CMain))
-        {
-            // Clang expects an exact signature
-            w!(
-                self.fn_bodies,
-                "int main(int {}, char **{})",
-                self.ctx.get_name(item.args[0].id),
-                self.ctx.get_name(item.args[1].id)
-            );
-        } else {
-            write_function_signature(
-                self.ctx,
-                &mut self.fn_bodies,
-                id,
-                item,
-                !should_export && !self.ctx.global_ctx.has_flag("debug"),
-            )?;
-        }
+        write_function_signature(
+            self.ctx,
+            &mut self.fn_bodies,
+            id,
+            item,
+            !should_export && !self.ctx.global_ctx.has_flag("debug"),
+            true,
+        )?;
 
         let body = item.body.get().unwrap();
         w!(self.fn_bodies, "{{\n");

--- a/src/alumina-boot/src/codegen/mod.rs
+++ b/src/alumina-boot/src/codegen/mod.rs
@@ -151,6 +151,11 @@ pub fn codegen(global_ctx: GlobalCtx, items: &[IRItemP<'_>]) -> Result<String, A
     writeln!(buf, "#include <stddef.h>").unwrap();
     writeln!(
         buf,
+        "#pragma clang diagnostic ignored \"-Wunknown-warning-option\""
+    )
+    .unwrap();
+    writeln!(
+        buf,
         "#pragma clang diagnostic ignored \"-Wparentheses-equality\""
     )
     .unwrap();
@@ -159,12 +164,12 @@ pub fn codegen(global_ctx: GlobalCtx, items: &[IRItemP<'_>]) -> Result<String, A
         "#pragma clang diagnostic ignored \"-Wincompatible-library-redeclaration\""
     )
     .unwrap();
+    writeln!(buf, "#pragma clang diagnostic ignored \"-Wunused-value\"").unwrap();
     writeln!(
         buf,
         "#pragma GCC diagnostic ignored \"-Wbuiltin-declaration-mismatch\""
     )
     .unwrap();
-    writeln!(buf, "#pragma clang diagnostic ignored \"-Wunused-value\"").unwrap();
     type_writer.write(&mut buf);
     function_writer.write(&mut buf);
 

--- a/src/alumina-boot/src/common.rs
+++ b/src/alumina-boot/src/common.rs
@@ -76,10 +76,10 @@ pub enum CodeErrorKind {
     MismatchedBranchTypes(String, String),
     #[error("invalid escape sequence")]
     InvalidEscapeSequence,
-    #[error("invalid `#[cfg(...)]` attribute")]
-    InvalidCfgAttribute,
-    #[error("invalid `#[align(...)]` attribute")]
-    InvalidAlignAttribute,
+    #[error("invalid attribute")]
+    InvalidAttribute,
+    #[error("invalid attribute ({})", .0)]
+    InvalidAttributeDetail(String),
     #[error("cannot perform {:?} between `{}` and `{}`", .0, .1, .2)]
     InvalidBinOp(crate::ast::BinOp, String, String),
     #[error("cannot perform {:?} on `{}`", .0, .1)]

--- a/src/alumina-boot/src/ir/mono.rs
+++ b/src/alumina-boot/src/ir/mono.rs
@@ -3202,10 +3202,15 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                 // If the user supplied a type hint to the if expression, we can try coercing to it
                 // this is mostly for &T and &U -> &dyn Proto coercion where T and U are distinct types
                 // but satisfy the same protocol
-
                 if let (Ok(a), Ok(b)) = (self.try_coerce(hint, then), self.try_coerce(hint, els)) {
                     then = a;
                     els = b;
+                } else {
+                    return Err(CodeErrorKind::MismatchedBranchTypes(
+                        self.mono_ctx.type_name(then.ty).unwrap(),
+                        self.mono_ctx.type_name(els.ty).unwrap(),
+                    ))
+                    .with_span(els_.span);
                 }
             } else {
                 return Err(CodeErrorKind::MismatchedBranchTypes(

--- a/src/alumina-boot/src/name_resolution/pass1.rs
+++ b/src/alumina-boot/src/name_resolution/pass1.rs
@@ -326,6 +326,10 @@ impl<'ast, 'src> AluminaVisitor<'src> for FirstPassVisitor<'ast, 'src> {
                 }
             } else if &self.scope.path() == path
                 && name == "main"
+                && !attributes.contains(&Attribute::Export)
+                && !attributes
+                    .iter()
+                    .any(|a| matches!(a, Attribute::LinkName(..)))
                 && self.main_candidate.replace(item).is_some()
             {
                 return Err(CodeErrorKind::MultipleMainFunctions).with_span_from(&self.scope, node);

--- a/src/alumina-boot/src/visitors.rs
+++ b/src/alumina-boot/src/visitors.rs
@@ -1,7 +1,7 @@
 use tree_sitter::Node;
 
 use crate::ast::expressions::parse_string_literal;
-use crate::ast::{AstCtx, Attribute, CodegenType, ItemP, TestMetadata};
+use crate::ast::{AstCtx, Attribute, ItemP, TestMetadata};
 use crate::common::{AluminaError, ArenaAllocatable, CodeErrorKind, WithSpanDuringParsing};
 
 use crate::global_ctx::GlobalCtx;
@@ -418,18 +418,6 @@ impl<'ast, 'src> AluminaVisitor<'src> for AttributeVisitor<'ast, 'src> {
                         .ok_or(CodeErrorKind::CannotBeALangItem)
                         .with_span_from(&self.scope, inner)?,
                 );
-            }
-            "codegen" => {
-                if let Some(argument) = inner
-                    .child_by_field_name("arguments")
-                    .and_then(|n| n.child_by_field_name("argument"))
-                {
-                    let codegen_type = self.code.node_text(argument);
-                    match codegen_type {
-                        "c_main" => self.attributes.push(Attribute::Codegen(CodegenType::CMain)),
-                        _ => {}
-                    }
-                }
             }
             _ => {}
         }

--- a/src/alumina-boot/src/visitors.rs
+++ b/src/alumina-boot/src/visitors.rs
@@ -356,9 +356,17 @@ impl<'ast, 'src> AluminaVisitor<'src> for AttributeVisitor<'ast, 'src> {
                     .ok_or(CodeErrorKind::InvalidAttribute)
                     .with_span_from(&self.scope, node)?;
 
+                if !align.is_power_of_two() {
+                    return Err(CodeErrorKind::InvalidAttributeDetail(
+                        "alignment must be a power of two".to_string(),
+                    ))
+                    .with_span_from(&self.scope, node);
+                }
+
                 self.attributes.push(Attribute::Align(align))
             }
             "cold" => self.attributes.push(Attribute::Cold),
+            "packed" => self.attributes.push(Attribute::Packed),
             "inline" => {
                 match node
                     .child_by_field_name("arguments")

--- a/src/tests/lang.alu
+++ b/src/tests/lang.alu
@@ -57,3 +57,38 @@ fn test_linear_scope_shadowing_mixed() {
     use bar as foo;
     assert_eq!(foo(), 4);
 }
+
+#[test]
+fn test_align_attribute() {
+    use std::mem::align_of;
+
+    #[align(1)] struct A1 { val: u8 }
+    #[align(2)] struct A2 { val: u8 }
+    #[align(4)] struct A4 { val: u8 }
+    #[align(8)] struct A8 { val: u8 }
+    #[align(16)] struct A16 { val: u8 }
+    #[align(32)] struct A32 { val: u8 }
+    #[align(64)] struct A64 { val: u8 }
+
+    assert_eq!(align_of::<A1>(), 1);
+    assert_eq!(align_of::<A2>(), 2);
+    assert_eq!(align_of::<A4>(), 4);
+    assert_eq!(align_of::<A8>(), 8);
+    assert_eq!(align_of::<A16>(), 16);
+    assert_eq!(align_of::<A32>(), 32);
+    assert_eq!(align_of::<A64>(), 64);
+}
+
+#[test]
+fn test_packed_attribute() {
+    use std::mem::align_of;
+
+    struct S1 { val: u8, ptr: &void }
+    #[packed] struct S2 { val: u8, ptr: &void }
+
+    let s1: S1;
+    let s2: S2;
+
+    assert!((&s1.ptr as usize) - (&s1 as usize) > 1usize);
+    assert_eq!((&s2.ptr as usize) - (&s2 as usize), 1usize);
+}

--- a/sysroot/libc.alu
+++ b/sysroot/libc.alu
@@ -425,14 +425,10 @@ extern "C" fn puts(s: &c_char) -> c_int;
 
     extern "C" fn signal(signum: c_int, handler: sighandler_t) -> sighandler_t;
 
-    #[cfg(target_os="macos")]
+    #[cfg(any(target_os="macos", target_os="linux"))]
     extern "C" fn ioctl(fd: c_int, request: c_ulong, ...) -> c_int;
     #[cfg(target_os="android")]
     extern "C" fn ioctl(fd: c_int, request: c_int, ...) -> c_int;
-    #[cfg(target_os="linux")]
-    extern "C" fn ioctl(fd: c_int, request: c_ulong, ...) -> c_int;
-
-    #[codegen(varargs)]
     extern "C" fn fcntl(fd: c_int, cmd: c_int, ...) -> c_int;
 
     #[cfg(target_os="linux")]
@@ -1093,21 +1089,14 @@ extern "C" fn puts(s: &c_char) -> c_int;
 #[cfg(target_os = "linux")] {
     type pthread_t = c_ulong;
 
-    #[cfg(target_arch = "aarch64")]
     struct pthread_attr_t {
-        __size: [usize; 8]
-    }
-
-    #[cfg(any(target_arch = "x86", target_arch = "arm"))]
-    struct pthread_attr_t {
-        __size: [u32; 9]
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    struct pthread_attr_t {
-        #[cfg(target_pointer_width = "32")]
+        #[cfg(target_arch = "aarch64")]
+        __size: [usize; 8],
+        #[cfg(any(target_arch = "x86", target_arch = "arm"))]
+        __size: [u32; 9],
+        #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __size: [u32; 8],
-        #[cfg(target_pointer_width = "64")]
+        #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
         __size: [u64; 7]
     }
 
@@ -1146,50 +1135,70 @@ extern "C" fn puts(s: &c_char) -> c_int;
         const PTHREAD_RWLOCK_T_SIZE: usize = 32;
     }
 
-    #[cfg(target_arch = "x86")]
-    #[align(4)]
+    #[cfg_attr(target_arch = "x86", align(4))]
+    #[cfg_attr(not(target_arch = "x86"), align(8))]
     struct pthread_cond_t {
         __size: [u8; PTHREAD_COND_T_SIZE],
     }
 
-    #[cfg(not(target_arch = "x86"))]
-    #[align(8)]
-    struct pthread_cond_t {
-        __size: [u8; PTHREAD_COND_T_SIZE],
-    }
-
-    #[cfg(any(target_pointer_width = "64", not(any(target_arch = "arm", target_arch = "x86_64", target_arch = "x86")))]
-    #[align(8)]
+    #[cfg_attr(
+        all(
+            target_pointer_width = "32",
+            any(target_arch = "arm", target_arch = "x86_64", target_arch = "x86")
+        ),
+        align(4)
+    )]
+    #[cfg_attr(
+        not(
+            all(
+                target_pointer_width = "32",
+                any(target_arch = "arm", target_arch = "x86_64", target_arch = "x86")
+            )
+        ),
+        align(8)
+    )]
     struct pthread_mutex_t {
         __size: [u8; PTHREAD_MUTEX_T_SIZE],
     }
 
-    #[cfg(all(target_pointer_width = "32", any(target_arch = "arm", target_arch = "x86_64", target_arch = "x86"))]
-    #[align(4)]
-    struct pthread_mutex_t {
-        __size: [u8; PTHREAD_MUTEX_T_SIZE],
-    }
-
-    #[cfg(any(target_pointer_width = "64", not(any(target_arch = "arm", target_arch = "x86_64", target_arch = "x86")))]
-    #[align(8)]
+    #[cfg_attr(
+        all(
+            target_pointer_width = "32",
+            any(target_arch = "arm", target_arch = "x86_64", target_arch = "x86")
+        ),
+        align(4)
+    )]
+    #[cfg_attr(
+        not(
+            all(
+                target_pointer_width = "32",
+                any(target_arch = "arm", target_arch = "x86_64", target_arch = "x86")
+            )
+        ),
+        align(8)
+    )]
     struct pthread_rwlock_t {
         __size: [u8; PTHREAD_RWLOCK_T_SIZE],
     }
 
-    #[cfg(all(target_pointer_width = "32", any(target_arch = "arm", target_arch = "x86_64", target_arch = "x86"))]
-    #[align(4)]
-    struct pthread_rwlock_t {
-        __size: [u8; PTHREAD_RWLOCK_T_SIZE],
-    }
-
-    #[cfg(any(target_pointer_width = "32", target_arch = "x86_64", target_arch = "aarch64"))]
-    #[align(4)]
-    struct pthread_mutexattr_t {
-        __size: [u8; PTHREAD_MUTEXATTR_T_SIZE],
-    }
-
-    #[cfg(not(any(target_pointer_width = "32", target_arch = "x86_64", target_arch = "aarch64")))]
-    #[align(8)]
+    #[cfg_attr(
+        any(
+            target_pointer_width = "32",
+            target_arch = "x86_64",
+            target_arch = "aarch64"
+        ),
+        align(4)
+    )]
+    #[cfg_attr(
+        not(
+            any(
+                target_pointer_width = "32",
+                target_arch = "x86_64",
+                target_arch = "aarch64"
+            )
+        ),
+        align(8)
+    )]
     struct pthread_mutexattr_t {
         __size: [u8; PTHREAD_MUTEXATTR_T_SIZE],
     }
@@ -1199,14 +1208,8 @@ extern "C" fn puts(s: &c_char) -> c_int;
         __size: [u8; PTHREAD_CONDATTR_T_SIZE],
     }
 
-    #[cfg(target_pointer_width = "32")]
-    #[align(4)]
-    struct pthread_rwlockattr_t {
-        __size: [u8; PTHREAD_RWLOCKATTR_T_SIZE],
-    }
-
-    #[cfg(target_pointer_width = "64")]
-    #[align(8)]
+    #[cfg_attr(target_pointer_width = "32", align(4))]
+    #[cfg_attr(target_pointer_width = "64", align(8))]
     struct pthread_rwlockattr_t {
         __size: [u8; PTHREAD_RWLOCKATTR_T_SIZE],
     }

--- a/sysroot/libc.alu
+++ b/sysroot/libc.alu
@@ -521,49 +521,32 @@ extern "C" fn puts(s: &c_char) -> c_int;
     ) -> c_int;
     extern "C" fn shutdown(socket: c_int, how: c_int) -> c_int;
 
-    #[cfg(target_os="macos")]
-    #[link_name("_opendir$INODE64")]
-    extern "C" fn opendir(dirname: &c_char) -> &mut DIR;
-    #[cfg(not(target_os="macos"))]
+    #[cfg_attr(target_os="macos", link_name("_opendir$INODE64"))]
     extern "C" fn opendir(dirname: &c_char) -> &mut DIR;
 
-    #[cfg(target_os="macos")]
-    #[link_name("_readdir$INODE64")]
-    extern "C" fn readdir(dirp: &mut DIR) -> &mut dirent;
-
-    #[cfg(not(target_os="macos"))]
+    #[cfg_attr(target_os="macos", link_name("_readdir$INODE64"))]
     extern "C" fn readdir(dirp: &mut DIR) -> &mut dirent;
     extern "C" fn closedir(dirp: &mut DIR) -> c_int;
 
     #[cfg(not(target_os="macos"))]
     extern "C" fn readdir64(dirp: &mut DIR) -> &mut dirent64;
 
-    #[cfg(not(target_os="macos"))]
+    #[cfg_attr(target_os="macos", link_name("_realpath$DARWIN_EXTSN"))]
     extern "C" fn realpath(pathname: &c_char, resolved: &mut c_char) -> &mut c_char;
 
     extern "C" fn getcwd(buf: &mut c_char, size: size_t) -> &mut c_char;
 
     extern "C" fn chdir(dir: &c_char) -> c_int;
 
-    #[cfg(target_os="macos")]
-    #[link_name("_realpath$DARWIN_EXTSN")]
-    extern "C" fn realpath(pathname: &c_char, resolved: &mut c_char) -> &mut c_char;
-
     extern "C" fn mkdir(path: &c_char, mode: mode_t) -> c_int;
 
-    #[cfg(target_os="macos")]
-    #[link_name("_stat$INODE64")]
-    extern "C" fn stat(path: &c_char, buf: &mut t_stat) -> c_int;
-    #[cfg(not(target_os="macos"))]
+    #[cfg_attr(target_os="macos", link_name("_stat$INODE64"))]
     extern "C" fn stat(path: &c_char, buf: &mut t_stat) -> c_int;
 
     #[cfg(not(target_os="macos"))]
     extern "C" fn stat64(path: &c_char, buf: &mut t_stat64) -> c_int;
 
-    #[cfg(target_os="macos")]
-    #[link_name("_fstat$INODE64")]
-    extern "C" fn fstat(fildes: c_int, buf: &mut t_stat) -> c_int;
-    #[cfg(not(target_os="macos"))]
+    #[cfg_attr(target_os="macos", link_name("_fstat$INODE64"))]
     extern "C" fn fstat(fildes: c_int, buf: &mut t_stat) -> c_int;
 
     #[cfg(not(target_os="macos"))]

--- a/sysroot/std.alu
+++ b/sysroot/std.alu
@@ -296,7 +296,7 @@ mod internal {
     // error message if the argument is Formattable.
 
     #[cold]
-    #[inline(never)]
+    #[no_inline]
     fn panic_assert(file: &[u8], line: i32, column: i32) -> ! {
         use panicking::internal::panic_impl;
         use fmt::{Formattable, internal::format_arg};
@@ -324,7 +324,7 @@ mod internal {
     }
 
     #[cold]
-    #[inline(never)]
+    #[no_inline]
     fn panic_assert_eq<T>(file: &[u8], line: i32, column: i32, lhs: T, rhs: T) -> ! {
         use panicking::internal::panic_impl;
         use fmt::{Formattable, internal::format_arg};
@@ -350,7 +350,7 @@ mod internal {
     }
 
     #[cold]
-    #[inline(never)]
+    #[no_inline]
     fn panic_assert_ne<T>(file: &[u8], line: i32, column: i32, lhs: T, rhs: T) -> ! {
         use panicking::internal::panic_impl;
         use fmt::{Formattable, internal::format_arg};

--- a/sysroot/std.alu
+++ b/sysroot/std.alu
@@ -296,7 +296,7 @@ mod internal {
     // error message if the argument is Formattable.
 
     #[cold]
-    #[no_inline]
+    #[inline(never)]
     fn panic_assert(file: &[u8], line: i32, column: i32) -> ! {
         use panicking::internal::panic_impl;
         use fmt::{Formattable, internal::format_arg};
@@ -324,7 +324,7 @@ mod internal {
     }
 
     #[cold]
-    #[no_inline]
+    #[inline(never)]
     fn panic_assert_eq<T>(file: &[u8], line: i32, column: i32, lhs: T, rhs: T) -> ! {
         use panicking::internal::panic_impl;
         use fmt::{Formattable, internal::format_arg};
@@ -350,7 +350,7 @@ mod internal {
     }
 
     #[cold]
-    #[no_inline]
+    #[inline(never)]
     fn panic_assert_ne<T>(file: &[u8], line: i32, column: i32, lhs: T, rhs: T) -> ! {
         use panicking::internal::panic_impl;
         use fmt::{Formattable, internal::format_arg};
@@ -375,7 +375,7 @@ mod internal {
         }
     }
 
-    #[force_inline]
+    #[inline(always)]
     fn expect(cond: bool, expected: bool) -> bool {
         intrinsics::codegen_func::<bool>("__builtin_expect", cond, expected)
     }

--- a/sysroot/std/builtins.alu
+++ b/sysroot/std/builtins.alu
@@ -19,19 +19,19 @@ use fmt::{Formatter};
 struct void {}
 impl void {
     /// @ cmp::Equatable::equals
-    #[force_inline]
+    #[inline(always)]
     fn equals(lhs: &void, rhs: &void) -> bool {
         true
     }
 
     /// @ cmp::Comparable::compare
-    #[force_inline]
+    #[inline(always)]
     fn compare(lhs: &void, rhs: &void) -> Ordering {
         Ordering::Equal
     }
 
     /// @ hash::Hashable::hash
-    #[force_inline]
+    #[inline(always)]
     fn hash<H: Hasher<H>>(self: &void, hasher: &mut H) {
     }
 
@@ -44,13 +44,13 @@ impl void {
 struct bool {}
 impl bool {
     /// Returns `true`.
-    #[force_inline]
+    #[inline(always)]
     fn max_value() -> bool {
         true
     }
 
     /// Returns `false`.
-    #[force_inline]
+    #[inline(always)]
     fn min_value() -> bool {
         false
     }
@@ -96,13 +96,13 @@ impl bool {
     }
 
     /// @ cmp::Equatable::equals
-    #[force_inline]
+    #[inline(always)]
     fn equals(lhs: &bool, rhs: &bool) -> bool {
         *lhs == *rhs
     }
 
     /// @ cmp::Comparable::compare
-    #[force_inline]
+    #[inline(always)]
     fn compare(lhs: &bool, rhs: &bool) -> Ordering {
         if *lhs == *rhs {
             Ordering::Equal
@@ -176,13 +176,13 @@ impl u8 {
     mixin internal::IntegerParsable<u8>;
 
     /// Returns the maximum value of `u8`.
-    #[force_inline]
+    #[inline(always)]
     fn max_value() -> u8 {
         0xffu8
     }
 
     /// Returns the minimum value of `u8`.
-    #[force_inline]
+    #[inline(always)]
     fn min_value() -> u8 {
         0u8
     }
@@ -199,13 +199,13 @@ impl u16 {
     mixin internal::IntegerParsable<u16>;
 
     /// Returns the maximum value of `u16`.
-    #[force_inline]
+    #[inline(always)]
     fn max_value() -> u16 {
         0xffffu16
     }
 
     /// Returns the minimum value of `u16`.
-    #[force_inline]
+    #[inline(always)]
     fn min_value() -> u16 {
         0u16
     }
@@ -222,13 +222,13 @@ impl u32 {
     mixin internal::IntegerParsable<u32>;
 
     /// Returns the maximum value of `u32`.
-    #[force_inline]
+    #[inline(always)]
     fn max_value() -> u32 {
         0xffffffffu32
     }
 
     /// Returns the minimum value of `u32`.
-    #[force_inline]
+    #[inline(always)]
     fn min_value() -> u32 {
         0u32
     }
@@ -245,13 +245,13 @@ impl u64 {
     mixin internal::IntegerParsable<u64>;
 
     /// Returns the maximum value of `u64`.
-    #[force_inline]
+    #[inline(always)]
     fn max_value() -> u64 {
         0xffffffffffffffffu64
     }
 
     /// Returns the minimum value of `u64`.
-    #[force_inline]
+    #[inline(always)]
     fn min_value() -> u64 {
         0u64
     }
@@ -268,13 +268,13 @@ impl u128 {
     mixin internal::IntegerParsable<u128>;
 
     /// Returns the maximum value of `u128`.
-    #[force_inline]
+    #[inline(always)]
     fn max_value() -> u128 {
         0xffffffffffffffffffffffffffffffffu128
     }
 
     /// Returns the minimum value of `u128`.
-    #[force_inline]
+    #[inline(always)]
     fn min_value() -> u128 {
         0u128
     }
@@ -297,7 +297,7 @@ impl usize {
     mixin internal::IntegerParsable<usize>;
 
     /// Returns the maximum value of `usize`.
-    #[force_inline]
+    #[inline(always)]
     fn max_value() -> usize {
         #[cfg(target_pointer_width = "32")]
         {
@@ -310,7 +310,7 @@ impl usize {
     }
 
     /// Returns the minimum value of `usize`.
-    #[force_inline]
+    #[inline(always)]
     fn min_value() -> usize {
         #[cfg(target_pointer_width = "32")]
         {
@@ -333,13 +333,13 @@ impl i8 {
     mixin internal::IntegerParsable<i8>;
 
     /// Returns the maximum value of `i8`.
-    #[force_inline]
+    #[inline(always)]
     fn max_value() -> i8 {
         0x7fu8 as i8
     }
 
     /// Returns the minimum value of `i8`.
-    #[force_inline]
+    #[inline(always)]
     fn min_value() -> i8 {
         0x80u8 as i8
     }
@@ -355,13 +355,13 @@ impl i16 {
     mixin internal::IntegerParsable<i16>;
 
     /// Returns the maximum value of `i16`.
-    #[force_inline]
+    #[inline(always)]
     fn max_value() -> i16 {
         0x7fffu16 as i16
     }
 
     /// Returns the minimum value of `i16`.
-    #[force_inline]
+    #[inline(always)]
     fn min_value() -> i16 {
         0x8000u16 as i16
     }
@@ -377,13 +377,13 @@ impl i32 {
     mixin internal::IntegerParsable<i32>;
 
     /// Returns the maximum value of `i32`.
-    #[force_inline]
+    #[inline(always)]
     fn max_value() -> i32 {
         0x7fffffffu32 as i32
     }
 
     /// Returns the minimum value of `i32`.
-    #[force_inline]
+    #[inline(always)]
     fn min_value() -> i32 {
         0x80000000u32 as i32
     }
@@ -399,13 +399,13 @@ impl i64 {
     mixin internal::IntegerParsable<i64>;
 
     /// Returns the maximum value of `i64`.
-    #[force_inline]
+    #[inline(always)]
     fn max_value() -> i64 {
         0x7fffffffffffffffu64 as i64
     }
 
     /// Returns the minimum value of `i64`.
-    #[force_inline]
+    #[inline(always)]
     fn min_value() -> i64 {
         0x8000000000000000u64 as i64
     }
@@ -421,13 +421,13 @@ impl i128 {
     mixin internal::IntegerParsable<i128>;
 
     /// Returns the maximum value of `i128`.
-    #[force_inline]
+    #[inline(always)]
     fn max_value() -> i128 {
         0x7fffffffffffffffffffffffffffffffu128 as i128
     }
 
     /// Returns the minimum value of `i128`.
-    #[force_inline]
+    #[inline(always)]
     fn min_value() -> i128 {
         0x80000000000000000000000000000000u128 as i128
     }
@@ -443,7 +443,7 @@ impl isize {
     mixin internal::IntegerParsable<isize>;
 
     /// Returns the maximum value of `isize`.
-    #[force_inline]
+    #[inline(always)]
     fn max_value() -> isize {
         #[cfg(target_pointer_width = "32")]
         {
@@ -456,7 +456,7 @@ impl isize {
     }
 
     /// Returns the minimum value of `isize`.
-    #[force_inline]
+    #[inline(always)]
     fn min_value() -> isize {
         #[cfg(target_pointer_width = "32")]
         {
@@ -479,110 +479,110 @@ impl f32 {
     mixin internal::FloatOps<f32>;
 
     /// Returns `true` if the number has a negative sign, `false` otherwise.
-    #[force_inline]
+    #[inline(always)]
     fn is_sign_negative(self: f32) -> bool {
         let as_bits: u32 = util::transmute(self);
         as_bits & 0x80000000u32 != 0
     }
 
     /// Returns the maximum value of `f32`.
-    #[force_inline]
+    #[inline(always)]
     fn max_value() -> f32 {
         3.40282347e+38f32
     }
 
     /// Returns the minimum value of `f32`.
-    #[force_inline]
+    #[inline(always)]
     fn min_value() -> f32 {
         -3.40282347e+38f32
     }
 
     /// Returns the smallest positive value of `f32`.
-    #[force_inline]
+    #[inline(always)]
     fn min_positive() -> f32 {
         1.17549435e-38f32
     }
 
     /// Returns the machine epsilon for `f32`.
-    #[force_inline]
+    #[inline(always)]
     fn epsilon() -> f32 {
         1.19209290e-07f32
     }
 
     /// Inverse cosine
-    #[force_inline]
+    #[inline(always)]
     fn acos(self: f32) -> f32 {
         libc::acosf(self)
     }
 
     /// Inverse sine
-    #[force_inline]
+    #[inline(always)]
     fn asin(self: f32) -> f32 {
         libc::asinf(self)
     }
 
     /// Inverse tangent
-    #[force_inline]
+    #[inline(always)]
     fn atan(self: f32) -> f32 {
         libc::atanf(self)
     }
 
     /// Four-quadrant inverse tangent
-    #[force_inline]
+    #[inline(always)]
     fn atan2(self: f32, other: f32) -> f32 {
         libc::atan2f(self, other)
     }
 
     /// Inverse hyperbolic cosine
-    #[force_inline]
+    #[inline(always)]
     fn atanh(self: f32) -> f32 {
         libc::atanhf(self)
     }
 
     /// Cube root
-    #[force_inline]
+    #[inline(always)]
     fn cbrt(self: f32) -> f32 {
         libc::cbrtf(self)
     }
 
     /// Ceiling of number
-    #[force_inline]
+    #[inline(always)]
     fn ceil(self: f32) -> f32 {
         libc::ceilf(self)
     }
 
     /// Cosine
-    #[force_inline]
+    #[inline(always)]
     fn cos(self: f32) -> f32 {
         libc::cosf(self)
     }
 
     /// Hyperbolic cosine
-    #[force_inline]
+    #[inline(always)]
     fn cosh(self: f32) -> f32 {
         libc::coshf(self)
     }
 
     /// Gauss error function
-    #[force_inline]
+    #[inline(always)]
     fn erf(self: f32) -> f32 {
         libc::erff(self)
     }
 
     /// Complementary error function (1 - [erf(self)](erf))
-    #[force_inline]
+    #[inline(always)]
     fn erfc(self: f32) -> f32 {
         libc::erfcf(self)
     }
 
     /// Exponential function (e^`self`)
-    #[force_inline]
+    #[inline(always)]
     fn exp(self: f32) -> f32 {
         libc::expf(self)
     }
 
     /// Floor of number
-    #[force_inline]
+    #[inline(always)]
     fn floor(self: f32) -> f32 {
         libc::floorf(self)
     }
@@ -590,7 +590,7 @@ impl f32 {
     /// Decomposes `self` into a normalized fractional part and an integral power of two.
     ///
     /// Inverse of [ldexp].
-    #[force_inline]
+    #[inline(always)]
     fn frexp(self: f32) -> (f32, i32) {
         let out: i32;
         let val = libc::frexpf(self, &out);
@@ -600,31 +600,31 @@ impl f32 {
     /// Multiplies `self` by 2 raised to the power of `exp`.
     ///
     /// Inverse of [frexp].
-    #[force_inline]
+    #[inline(always)]
     fn ldexp(self: f32, exp: i32) -> f32 {
         libc::ldexpf(self, exp)
     }
 
     /// Natural logarithm
-    #[force_inline]
+    #[inline(always)]
     fn log(self: f32) -> f32 {
         libc::logf(self)
     }
 
     /// Base 2 logarithm
-    #[force_inline]
+    #[inline(always)]
     fn log2(self: f32) -> f32 {
         libc::log2f(self)
     }
 
     /// Base 10 logarithm
-    #[force_inline]
+    #[inline(always)]
     fn log10(self: f32) -> f32 {
         libc::log10f(self)
     }
 
     /// Decompose `self` into a whole and fractional part
-    #[force_inline]
+    #[inline(always)]
     fn modf(self: f32) -> (f32, f32) {
         let out: f32;
         let val = libc::modff(self, &out);
@@ -632,7 +632,7 @@ impl f32 {
     }
 
     /// Power function
-    #[force_inline]
+    #[inline(always)]
     fn pow(self: f32, other: f32) -> f32 {
         libc::powf(self, other)
     }
@@ -640,43 +640,43 @@ impl f32 {
     /// Rounds `self` to the closest integer.
     ///
     /// If the number is halfway between two integers, it is rounded away from zero.
-    #[force_inline]
+    #[inline(always)]
     fn round(self: f32) -> f32 {
         libc::roundf(self)
     }
 
     /// Sine function
-    #[force_inline]
+    #[inline(always)]
     fn sin(self: f32) -> f32 {
         libc::sinf(self)
     }
 
     /// Hyperbolic sine function
-    #[force_inline]
+    #[inline(always)]
     fn sinh(self: f32) -> f32 {
         libc::sinhf(self)
     }
 
     /// Square root
-    #[force_inline]
+    #[inline(always)]
     fn sqrt(self: f32) -> f32 {
         libc::sqrtf(self)
     }
 
     /// Tangent function
-    #[force_inline]
+    #[inline(always)]
     fn tan(self: f32) -> f32 {
         libc::tanf(self)
     }
 
     /// Hyperbolic tangent function
-    #[force_inline]
+    #[inline(always)]
     fn tanh(self: f32) -> f32 {
         libc::tanhf(self)
     }
 
     /// Returns the integer part of `self` (round towards zero).
-    #[force_inline]
+    #[inline(always)]
     fn trunc(self: f32) -> f32 {
         libc::truncf(self)
     }
@@ -692,116 +692,116 @@ impl f64 {
     mixin internal::FloatOps<f64>;
 
     /// @ f32::is_sign_negative
-    #[force_inline]
+    #[inline(always)]
     fn is_sign_negative(self: f64) -> bool {
         let as_bits: u64 = util::transmute(self);
         as_bits & 0x8000000000000000u64 != 0
     }
 
     /// Returns the maximum value of `f64`
-    #[force_inline]
+    #[inline(always)]
     fn max_value() -> f64 {
         1.7976931348623157e+308f64
     }
 
     /// Returns the minimum value of `f64`
-    #[force_inline]
+    #[inline(always)]
     fn min_value() -> f64 {
         -1.7976931348623157e+308f64
     }
 
     /// Returns the smallest positive value of `f64`.
-    #[force_inline]
+    #[inline(always)]
     fn min_positive() -> f64 {
         2.2250738585072014e-308f64
     }
 
     /// Returns the machine epsilon for `f64`.
-    #[force_inline]
+    #[inline(always)]
     fn epsilon() -> f64 {
         2.2204460492503131e-16f64
     }
 
     /// @ f32::acos
-    #[force_inline]
+    #[inline(always)]
     fn acos(self: f64) -> f64 {
         libc::acos(self)
     }
 
     /// @ f32::asin
-    #[force_inline]
+    #[inline(always)]
     fn asin(self: f64) -> f64 {
         libc::asin(self)
     }
 
     /// @ f32::atan
-    #[force_inline]
+    #[inline(always)]
     fn atan(self: f64) -> f64 {
         libc::atan(self)
     }
 
     /// @ f32::atan2
-    #[force_inline]
+    #[inline(always)]
     fn atan2(self: f64, other: f64) -> f64 {
         libc::atan2(self, other)
     }
 
     /// @ f32::atanh
-    #[force_inline]
+    #[inline(always)]
     fn atanh(self: f64) -> f64 {
         libc::atanh(self)
     }
 
     /// @ f32::cbrt
-    #[force_inline]
+    #[inline(always)]
     fn cbrt(self: f64) -> f64 {
         libc::cbrt(self)
     }
 
     /// @ f32::ceil
-    #[force_inline]
+    #[inline(always)]
     fn ceil(self: f64) -> f64 {
         libc::ceil(self)
     }
 
     /// @ f32::cos
-    #[force_inline]
+    #[inline(always)]
     fn cos(self: f64) -> f64 {
         libc::cos(self)
     }
 
     /// @ f32::cosh
-    #[force_inline]
+    #[inline(always)]
     fn cosh(self: f64) -> f64 {
         libc::cosh(self)
     }
 
     /// @ f32::erf
-    #[force_inline]
+    #[inline(always)]
     fn erf(self: f64) -> f64 {
         libc::erf(self)
     }
 
     /// @ f32::erfc
-    #[force_inline]
+    #[inline(always)]
     fn erfc(self: f64) -> f64 {
         libc::erfc(self)
     }
 
     /// @ f32::exp
-    #[force_inline]
+    #[inline(always)]
     fn exp(self: f64) -> f64 {
         libc::exp(self)
     }
 
     /// @ f32::floor
-    #[force_inline]
+    #[inline(always)]
     fn floor(self: f64) -> f64 {
         libc::floor(self)
     }
 
     /// @ f32::frexp
-    #[force_inline]
+    #[inline(always)]
     fn frexp(self: f64) -> (f64, i32) {
         let out: i32;
         let val = libc::frexp(self, &out);
@@ -809,31 +809,31 @@ impl f64 {
     }
 
     /// @ f32::ldexp
-    #[force_inline]
+    #[inline(always)]
     fn ldexp(self: f64, exp: i32) -> f64 {
         libc::ldexp(self, exp)
     }
 
     /// @ f32::log
-    #[force_inline]
+    #[inline(always)]
     fn log(self: f64) -> f64 {
         libc::log(self)
     }
 
     /// @ f32::log2
-    #[force_inline]
+    #[inline(always)]
     fn log2(self: f64) -> f64 {
         libc::log2(self)
     }
 
     /// @ f32::log10
-    #[force_inline]
+    #[inline(always)]
     fn log10(self: f64) -> f64 {
         libc::log10(self)
     }
 
     /// @ f32::modf
-    #[force_inline]
+    #[inline(always)]
     fn modf(self: f64) -> (f64, f64) {
         let out: f64;
         let val = libc::modf(self, &out);
@@ -841,49 +841,49 @@ impl f64 {
     }
 
     /// @ f32::pow
-    #[force_inline]
+    #[inline(always)]
     fn pow(self: f64, other: f64) -> f64 {
         libc::pow(self, other)
     }
 
     /// @ f32::round
-    #[force_inline]
+    #[inline(always)]
     fn round(self: f64) -> f64 {
         libc::round(self)
     }
 
     /// @ f32::sin
-    #[force_inline]
+    #[inline(always)]
     fn sin(self: f64) -> f64 {
         libc::sin(self)
     }
 
     /// @ f32::sinh
-    #[force_inline]
+    #[inline(always)]
     fn sinh(self: f64) -> f64 {
         libc::sinh(self)
     }
 
     /// @ f32::sqrt
-    #[force_inline]
+    #[inline(always)]
     fn sqrt(self: f64) -> f64 {
         libc::sqrt(self)
     }
 
     /// @ f32::tan
-    #[force_inline]
+    #[inline(always)]
     fn tan(self: f64) -> f64 {
         libc::tan(self)
     }
 
     /// @ f32::tanh
-    #[force_inline]
+    #[inline(always)]
     fn tanh(self: f64) -> f64 {
         libc::tanh(self)
     }
 
     /// @ f32::trunc
-    #[force_inline]
+    #[inline(always)]
     fn trunc(self: f64) -> f64 {
         libc::trunc(self)
     }
@@ -897,25 +897,25 @@ impl f64 {
 struct array {}
 impl array<Arr: builtins::Array> {
     /// @ mem::AsSlice::as_slice
-    #[force_inline]
+    #[inline(always)]
     fn as_slice(self: &Arr) -> &[element_of<Arr>] {
         self
     }
 
     /// @ mem::AsSlice::as_slice
-    #[force_inline]
+    #[inline(always)]
     fn as_slice_mut(self: &mut Arr) -> &mut [element_of<Arr>] {
         self
     }
 
     /// Returns a pointer to the first element.
-    #[force_inline]
+    #[inline(always)]
     fn as_ptr(self: &Arr) -> &element_of<Arr> {
         &self[0]
     }
 
     /// Returns a mutable pointer to the first element.
-    #[force_inline]
+    #[inline(always)]
     fn as_ptr_mut(self: &mut Arr) -> &mut element_of<Arr> {
         &self[0]
     }
@@ -935,7 +935,7 @@ impl array<Arr: builtins::Array> {
     /// assert_eq!(b.len(), 0);
     /// assert_eq!(c.len(), 10);
     /// ```
-    #[force_inline]
+    #[inline(always)]
     fn len(self: &Arr) -> usize {
         intrinsics::array_length_of::<Arr>()
     }
@@ -1222,11 +1222,11 @@ mod internal {
     /// equality and comparison operators.
     protocol BuiltinComparable<Self: builtins::Numeric> {
         /// @ cmp::Equatable::equals
-        #[force_inline] fn equals(lhs: &Self, rhs: &Self) -> bool { *lhs == *rhs }
+        #[inline(always)] fn equals(lhs: &Self, rhs: &Self) -> bool { *lhs == *rhs }
         /// @ cmp::Equatable::not_equals
-        #[force_inline] fn not_equals(lhs: &Self, rhs: &Self) -> bool { *lhs != *rhs }
+        #[inline(always)] fn not_equals(lhs: &Self, rhs: &Self) -> bool { *lhs != *rhs }
         /// @ cmp::Comparable::compare
-        #[force_inline]
+        #[inline(always)]
         fn compare(lhs: &Self, rhs: &Self) -> Ordering {
             if *lhs < *rhs {
                 Ordering::Less
@@ -1238,13 +1238,13 @@ mod internal {
         }
 
         /// @ cmp::Comparable::less_than
-        #[force_inline] fn less_than(lhs: &Self, rhs: &Self) -> bool { *lhs < *rhs }
+        #[inline(always)] fn less_than(lhs: &Self, rhs: &Self) -> bool { *lhs < *rhs }
         /// @ cmp::Comparable::less_than_or_equal
-        #[force_inline] fn less_than_or_equal(lhs: &Self, rhs: &Self) -> bool { *lhs <= *rhs }
+        #[inline(always)] fn less_than_or_equal(lhs: &Self, rhs: &Self) -> bool { *lhs <= *rhs }
         /// @ cmp::Comparable::greater_than
-        #[force_inline] fn greater_than(lhs: &Self, rhs: &Self) -> bool { *lhs > *rhs }
+        #[inline(always)] fn greater_than(lhs: &Self, rhs: &Self) -> bool { *lhs > *rhs }
         /// @ cmp::Comparable::greater_than_or_equal
-        #[force_inline] fn greater_than_or_equal(lhs: &Self, rhs: &Self) -> bool { *lhs >= *rhs }
+        #[inline(always)] fn greater_than_or_equal(lhs: &Self, rhs: &Self) -> bool { *lhs >= *rhs }
     }
 
     /// Mixin for parsing integers from strings.

--- a/sysroot/std/cmp.alu
+++ b/sysroot/std/cmp.alu
@@ -290,9 +290,6 @@ fn is_sorted<T: Comparable<T>>(arr: &[T]) -> bool {
 /// assert_eq!(arr[..], &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 /// ```
 fn sort_by<T, F: CompareFunction<T>>(arr: &mut [T], f: F) {
-    if arr.len() <= 1 {
-        return;
-    }
     let max_depth = collections::heap::internal::log2_fast(arr.len()) * 2;
     internal::introsort_by(arr, max_depth, f);
 }
@@ -544,24 +541,30 @@ mod internal {
             sort3(&arr[1], &arr[mid - 1], &arr[arr.len() - 2], f);
             sort3(&arr[2], &arr[mid + 1], &arr[arr.len() - 3], f);
             sort3(&arr[mid - 1], &arr[mid], &arr[mid + 1], f);
-            std::mem::swap(&arr[arr.len() - 1], &arr[mid]);
         } else {
             // Median-of-three for smaller slices
-            sort3(&arr[0], &arr[arr.len() - 1], &arr[mid], f);
+            sort3(&arr[0], &arr[mid], &arr[arr.len() - 1], f);
         }
 
-        let pivot = arr[arr.len() - 1];
+        let pivot = arr[mid];
         let i = 0usize;
-        let j = 0usize;
-        while j < arr.len() - 1 {
-            if f(&arr[j], &pivot) == Ordering::Less {
-                swap(&arr[i], &arr[j]);
+        let j = arr.len() - 1;
+
+        loop {
+            while f(&arr[i], &pivot) == Ordering::Less {
                 i += 1;
             }
-            j += 1;
+            while f(&arr[j], &pivot) == Ordering::Greater {
+                j -= 1;
+            }
+            if i >= j {
+                return j;
+            }
+
+            swap(&arr[i], &arr[j]);
+            i += 1;
+            j -= 1;
         }
-        swap(&arr[i], &arr[arr.len() - 1]);
-        i
     }
 
     fn insertion_sort_by<T, F: CompareFunction<T>>(arr: &mut [T], f: F) {
@@ -619,14 +622,14 @@ mod internal {
 
     fn introsort_by<T, F: CompareFunction<T>>(arr: &mut [T], max_depth: usize, f: F) {
         if arr.len() < INTROSORT_MIN_SIZE {
-            internal::insertion_sort_by(arr, f);
+            insertion_sort_by(arr, f);
         } else if max_depth == 0 {
             // Fall back to heapsort
             collections::heap::heapify_by(arr, f);
             collections::heap::sort_heap_by(arr, f);
         } else {
             let p = partition_by(arr, f);
-            introsort_by(arr[..p], max_depth - 1,  f);
+            introsort_by(arr[..p+1], max_depth - 1,  f);
             introsort_by(arr[p+1..], max_depth - 1, f);
         }
     }

--- a/sysroot/std/cmp.alu
+++ b/sysroot/std/cmp.alu
@@ -481,37 +481,37 @@ mod internal {
     const INTROSORT_MIN_SIZE: usize = 24;
     const MERGESORT_MIN_SIZE: usize = 32;
 
-    #[force_inline]
+    #[inline(always)]
     #[lang(operator_eq)]
     fn operator_eq<T: Equatable<T>>(lhs: &T, rhs: &T) -> bool {
         lhs.equals(rhs)
     }
 
-    #[force_inline]
+    #[inline(always)]
     #[lang(operator_neq)]
     fn operator_neq<T: Equatable<T>>(lhs: &T, rhs: &T) -> bool {
         lhs.not_equals(rhs)
     }
 
-    #[force_inline]
+    #[inline(always)]
     #[lang(operator_lt)]
     fn operator_lt<T: Comparable<T>>(lhs: &T, rhs: &T) -> bool {
         lhs.less_than(rhs)
     }
 
-    #[force_inline]
+    #[inline(always)]
     #[lang(operator_lte)]
     fn operator_lte<T: Comparable<T>>(lhs: &T, rhs: &T) -> bool {
         lhs.less_than_or_equal(rhs)
     }
 
-    #[force_inline]
+    #[inline(always)]
     #[lang(operator_gt)]
     fn operator_gt<T: Comparable<T>>(lhs: &T, rhs: &T) -> bool {
         lhs.greater_than(rhs)
     }
 
-    #[force_inline]
+    #[inline(always)]
     #[lang(operator_gte)]
     fn operator_gte<T: Comparable<T>>(lhs: &T, rhs: &T) -> bool {
         lhs.greater_than_or_equal(rhs)

--- a/sysroot/std/collections/deque.alu
+++ b/sysroot/std/collections/deque.alu
@@ -76,7 +76,7 @@ impl Deque<T> {
     }
 
     #[cold]
-    #[no_inline]
+    #[inline(never)]
     fn _resize(self: &mut Deque<T>, new_size: usize) {
         debug_assert!((self.len() == 0 && new_size == 0) || (new_size > self.len()));
 

--- a/sysroot/std/collections/deque.alu
+++ b/sysroot/std/collections/deque.alu
@@ -192,7 +192,7 @@ impl Deque<T> {
         }
     }
 
-    /// Returns an iterator over the elements of the deque.
+    /// @ iter::Iterable::iter
     fn iter(self: &Deque<T>) -> DequeIterator<T> {
         // Just pass a shallow copy of self and use pop_front and pop to iterate.
         // This works because Deque never shrinks the buffer when popping elements.
@@ -201,7 +201,7 @@ impl Deque<T> {
         DequeIterator { _inner: *self }
     }
 
-    /// Returns a iterator over the pointers to the elements of the deque.
+    /// @ iter::IterableRef::iter_ref
     fn iter_ref(self: &Deque<T>) -> DequeRefIterator<&T> {
         DequeRefIterator::<&T> {
             _data: self._data,
@@ -210,7 +210,7 @@ impl Deque<T> {
         }
     }
 
-    /// Returns a iterator over the mutable pointers to the elements of the deque.
+    /// @ iter::IterableMut::iter_mut
     fn iter_mut(self: &mut Deque<T>) -> DequeRefIterator<&mut T> {
         DequeRefIterator::<&mut T> {
             _data: self._data,

--- a/sysroot/std/collections/hashmap.alu
+++ b/sysroot/std/collections/hashmap.alu
@@ -118,7 +118,7 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
     /// map.rehash(1); // panics
     /// ```
     #[cold]
-    #[no_inline]
+    #[inline(never)]
     fn rehash(self: &mut HashMap<K, V, H>, new_capacity: usize) {
         assert!(self._length <= new_capacity);
 

--- a/sysroot/std/collections/hashmap.alu
+++ b/sysroot/std/collections/hashmap.alu
@@ -232,7 +232,7 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
         self._length = 0;
     }
 
-    /// Returns an iterator over the elements of the array.
+    /// @ iter::Iterable::iter
     fn iter(self: &HashMap<K, V, H>) -> HashMapIterator<K, V> {
         HashMapIterator::<K, V> {
             inner: self._buckets.iter_ref(),
@@ -240,7 +240,7 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
         }
     }
 
-    /// Returns an iterator of pointers to elements of the array.
+    /// @ iter::IterableRef::iter_ref
     fn iter_ref(self: &HashMap<K, V, H>) -> HashMapRefIterator<K, V> {
         HashMapRefIterator::<K, V> {
             inner: self._buckets.iter_ref(),
@@ -248,7 +248,7 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
         }
     }
 
-    /// Returns an iterator of mutable pointers to elements of the array.
+    /// @ iter::IterableMut::iter_mut
     fn iter_mut(self: &mut HashMap<K, V, H>) -> HashMapMutIterator<K, V> {
         HashMapMutIterator::<K, V> {
             inner: self._buckets.iter_mut(),

--- a/sysroot/std/collections/heap.alu
+++ b/sysroot/std/collections/heap.alu
@@ -399,6 +399,9 @@ impl BinaryHeap<T: Comparable<T>> {
     ///
     /// The iterator will return the elements in arbitrary order (satisfying the
     /// heap property).
+    ///
+    /// See [iter_drain] for an iterator that removes the elements from the heap, but in
+    /// descending order.
     fn iter(self: &BinaryHeap<T>) -> mem::SliceIterator<&T> {
         self._data.iter()
     }
@@ -407,6 +410,9 @@ impl BinaryHeap<T: Comparable<T>> {
     ///
     /// The iterator will return the elements in arbitrary order (satisfying the
     /// heap property).
+    ///
+    /// See [iter_drain] for an iterator that removes the elements from the heap, but in
+    /// descending order.
     fn iter_ref(self: &BinaryHeap<T>) -> mem::SliceRefIterator<&T> {
         self._data.iter_ref()
     }

--- a/sysroot/std/collections/vector.alu
+++ b/sysroot/std/collections/vector.alu
@@ -281,30 +281,19 @@ impl Vector<T> {
         self._length -= off;
     }
 
-    /// Returns an iterator over the vector.
+    /// @ iter::Iterable::iter
     #[inline]
     fn iter(self: &Vector<T>) -> mem::SliceIterator<&T> {
         self.as_slice().iter()
     }
 
-    /// Returns an iterator over the pointers to the elements.
+    /// @ iter::IterableRef::iter_ref
     #[inline]
     fn iter_ref(self: &Vector<T>) -> mem::SliceRefIterator<&T> {
         self.as_slice().iter_ref()
     }
 
-    /// Returns an iterator over the mutable pointers to the elements.
-    ///
-    /// ## Example
-    /// ```
-    /// use std::collections::Vector;
-    ///
-    /// let vec = Vector::from_slice(&[1, 2, 3]);
-    /// for elem in vec.iter_mut() {
-    ///     *elem *= 2;
-    /// }
-    /// assert_eq!(vec[..], &[2, 4, 6]);
-    /// ```
+    /// @ iter::IterableMut::iter_mut
     #[inline]
     fn iter_mut(self: &mut Vector<T>) -> mem::SliceRefIterator<&mut T> {
         self.as_slice_mut().iter_mut()

--- a/sysroot/std/io.alu
+++ b/sysroot/std/io.alu
@@ -538,7 +538,7 @@ impl BufferedWriter<W: Writable<W>> {
     }
 
     #[cold]
-    #[no_inline]
+    #[inline(never)]
     fn write_full(self: &mut BufferedWriter<W>, buf: &[u8]) -> Result<usize> {
         if buf.len() > self.buf.len() - self.pos {
             self._flush_buffer()?;
@@ -602,7 +602,7 @@ impl BufferedWriter<W: Writable<W>> {
     }
 
     #[cold]
-    #[no_inline]
+    #[inline(never)]
     fn _write_all_full(self: &mut BufferedWriter<W>, buf: &[u8]) -> Result<()> {
         if buf.len() > self.buf.len() - self.pos {
             self._flush_buffer()?;

--- a/sysroot/std/io.alu
+++ b/sysroot/std/io.alu
@@ -15,10 +15,10 @@ type Result<T> = std::result::Result<T, Error>;
 
 /// Buffer for formatted standard I/O.
 ///
-/// We use a single small thread local buffer for convenience stdio formatting macros.
-/// This buffer has limited a purpose (if you need a larger buffer, use [io::StdioStream]
-/// directly). As many formatters write individual characters, doing a syscall for every
-/// one would be a performance killer.
+/// A single thread local buffer is used for convenience stdio formatting macros. This
+/// buffer has limited a purpose (if you need a larger buffer, use [io::StdioStream] directly).
+/// As many formatters write individual characters, doing a syscall for every one
+/// would be a performance killer.
 #[thread_local] static FMT_BUF: [u8; 256];
 
 /// Prints a formatted string to standard output.
@@ -641,7 +641,7 @@ impl BufferedWriter<W: Writable<W>> {
     mixin fmt::Formatter<BufferedWriter<W>>;
 }
 
-
+/// Default buffer size for I/O methods that allocate a buffer.
 const DEFAULT_BUFFER_SIZE: usize = 8192;
 
 // Extension methods

--- a/sysroot/std/io/unix.alu
+++ b/sysroot/std/io/unix.alu
@@ -172,8 +172,7 @@ impl FileDescriptor {
     /// Sets the file descriptor blocking mode.
     fn set_nonblocking(self: &mut FileDescriptor, nonblocking: bool) -> Result<()> {
         #[cfg(target_os = "linux")] {
-            let nonblocking =  if nonblocking { 1 as libc::c_int } else { 0 as libc::c_int };
-            errno_try!(libc::ioctl(self.value, libc::FIONBIO, &nonblocking));
+            errno_try!(libc::ioctl(self.value, libc::FIONBIO, &(nonblocking as libc::c_int)));
         }
 
         #[cfg(not(target_os = "linux"))] {

--- a/sysroot/std/iter.alu
+++ b/sysroot/std/iter.alu
@@ -70,18 +70,24 @@ protocol DoubleEndedIteratorExt<Self: DoubleEndedIterator<Self, T>, T> {
 /// the `iter` method.
 protocol Iterable<Self, It: Iterator<It, T>, T> {
     /// Returns an iterator over the elements of this iterable.
+    ///
+    /// See [Iterable] for details.
     fn iter(self: &Self) -> It;
 }
 
 /// Types that can produce an iterator over pointers to their elements.
 protocol IterableRef<Self, It: Iterator<It, &T>, T> {
-    /// Returns an iterator over the pointers of the items of the collection.
+    /// Returns an iterator over the pointers of the items of this iterable.
+    ///
+    /// See [IterableRef] for details.
     fn iter_ref(self: &Self) -> It;
 }
 
 /// Types that can produce an iterator over mutable pointers to their elements.
 protocol IterableMut<Self, It: Iterator<It, &mut T>, T> {
     /// Returns an iterator over mutable pointers to the elements of the collection.
+    ///
+    /// See [IterableMut] for details.
     fn iter_mut(self: &mut Self) -> It;
 }
 
@@ -225,6 +231,26 @@ impl FilterMapIterator<It: Iterator<It, T>, F: Fn(T) -> Option<U>, T, U> {
 
     mixin Iterator<FilterMapIterator<It, F, T, U>, U>;
     mixin IteratorExt<FilterMapIterator<It, F, T, U>, U>;
+}
+
+
+impl FilterMapIterator<It: DoubleEndedIterator<It, T>, F: Fn(T) -> Option<U>, T, U> {
+    /// @ DoubleEndedIterator::next_back
+    fn next_back(self: &mut FilterMapIterator<It, F, T, U>) -> Option<U> {
+        use option::try;
+
+        loop {
+            let value = self.it.next_back()?;
+            let mapped = self.fun(value);
+
+            if mapped.is_some() {
+                return mapped
+            }
+        }
+    }
+
+    mixin DoubleEndedIterator<FilterMapIterator<It, F, T, U>, U>;
+    mixin DoubleEndedIteratorExt<FilterMapIterator<It, F, T, U>, U>;
 }
 
 /// Filter iterator.
@@ -1887,6 +1913,23 @@ mod tests {
         assert_eq!(range.next(), Option::some(0));
         assert_eq!(range.next(), Option::some(4));
         assert_eq!(range.next(), Option::some(8));
+        assert_eq!(range.next(), Option::none());
+    }
+
+    #[test]
+    fn test_filter_map_rev() {
+        let range = (0..5).filter_map(|x: i32| -> Option<i32> {
+            if x % 2 == 0 {
+                Option::some(x * 2)
+            } else {
+                Option::none()
+            }
+        }).rev();
+        assert_eq!(range.size_hint(), Option::none());
+
+        assert_eq!(range.next(), Option::some(8));
+        assert_eq!(range.next(), Option::some(4));
+        assert_eq!(range.next(), Option::some(0));
         assert_eq!(range.next(), Option::none());
     }
 

--- a/sysroot/std/iter.alu
+++ b/sysroot/std/iter.alu
@@ -17,7 +17,7 @@
 //! consumable objects that can only be used to iterate once. Iterable types are ones that can
 //! produce an iterator when needed.
 //!
-//! Iterators can also be combined to create more complex types of iterators. See [IteratorExt] protocol
+//! Iterators can also be combined to create more complex types of iterators. See [IteratorExt] mixin
 //! for a reference of methods that can be used to combine iterators.
 
 use builtins::Integer;
@@ -25,31 +25,121 @@ use option::Option;
 
 /// Iterators.
 ///
-/// Types that implement `Iterator` can be used in a for-loop. Types that implement `Iterator` should
-/// also mix in the [IteratorExt] protocol so that the combinator methods can be used.
+/// See [module-level documentation](std::iter) for more details.
+///
+/// # Implementing an iterator
+///
+/// Types that have [Iterator] semantics should implement [Iterator::next] at a minimum. When the iterator can
+/// cheaply determine the number of remaining elements, it should also implement [Iterator::size_hint]. This
+/// enables the collections constructed from iterators to efficiently reserve space for the elements and
+/// avoid reallocations. If [Iterator::size_hint] returns a value, it should be exact.
+///
+/// All types implementing [Iterator] should also mix in [IteratorExt], which provides a number of useful
+/// extension methods.
+///
+/// See also [DoubleEndedIterator] for iterators that can be iterated in reverse order.
+///
+/// ## Example
+/// ```
+/// struct Countdown { counter: i32 }
+///
+/// impl Countdown {
+///     use std::cmp::max;
+///     use std::iter::{Iterator, IteratorExt};
+///
+///     fn next(self: &mut Countdown) -> Option<i32> {
+///         if self.counter <= 0 {
+///             Option::none()
+///         } else {
+///             let ret = Option::some(self.counter);
+///             self.counter -= 1;
+///             ret
+///         }
+///     }
+///
+///     fn size_hint(self: &Countdown) -> Option<usize> {
+///         Option::some(max(0, self.counter) as usize)
+///     }
+///
+///     mixin Iterator<Countdown, i32>;
+///     mixin IteratorExt<Countdown, i32>;
+/// }
+///
+/// // use `(1..=5).rev()` in real code
+/// let countdown = Countdown { counter: 5 };
+///
+/// for i in countdown {
+///     println!("{}", i);
+/// }
+/// println!("Ignition and Liftoff!");
+/// ```
 protocol Iterator<Self, T> {
     /// Returns the next item, if any.
     ///
-    /// If the iterator has reached the end, it returns none.
+    /// If the iterator has reached the end, it returns `Option::none()`.
+    ///
+    /// See [Iterator] for more information.
     fn next(self: &mut Self) -> Option<T>;
 
     /// Returns the number of remaining elements, if available.
     ///
-    /// This is used for efficiently pre-allocating storage in collections
-    /// that are created from iterators to avoid copies.
-    ///
-    /// It the number of remaining elements is unknown, the method should
-    /// return `Option::none()`.
+    /// See [Iterator] for more information.
     fn size_hint(self: &Self) -> Option<usize> {
         Option::none()
     }
 }
 
 /// Iterators that can be consumed from both ends.
+///
+/// # Implementing a double-ended iterator
+///
+/// Iterators that can be iterated from both ends efficiently should implement this protocol.
+/// [DoubleEndedIterator::next_back] is the method that is used to iterate in reverse order. The
+/// convention is that [Iterator::next] and [DoubleEndedIterator::next_back] "meet in the middle",
+/// so that each element is visited once regardless of the direction of iteration.
+///
+/// All types implementing [DoubleEndedIterator] should also mix in [DoubleEndedIteratorExt], which provides
+/// relevant extension methods, notably [DoubleEndedIteratorExt::rev], which reverses the direction of
+/// iteration.
+///
+/// ## Example
+/// ```
+/// struct Range { lower: i32, upper: i32 }
+///
+/// impl Range {
+///     use std::iter::{Iterator, IteratorExt, DoubleEndedIterator, DoubleEndedIteratorExt};
+///
+///     fn next(self: &mut Range) -> Option<i32> {
+///         if self.lower < self.upper {
+///             let result = self.lower;
+///             self.lower += 1;
+///             Option::some(result)
+///         } else {
+///             Option::none()
+///         }
+///     }
+///
+///     fn next_back(self: &mut Range) -> Option<i32> {
+///         if self.lower < self.upper {
+///             self.upper -= 1;
+///             Option::some(self.upper)
+///         } else {
+///             Option::none()
+///         }
+///     }
+///
+///     mixin Iterator<Range, i32>;
+///     mixin IteratorExt<Range, i32>;
+///     mixin DoubleEndedIterator<Range, i32>;
+///     mixin DoubleEndedIteratorExt<Range, i32>;
+/// }
+/// ```
 protocol DoubleEndedIterator<Self: Iterator<Self, T>, T> {
     /// Returns the next item from the back, if any.
     ///
     /// If the iterator has reached the beginning, it returns none.
+    ///
+    /// See [DoubleEndedIterator] for more information.
     fn next_back(self: &mut Self) -> Option<T>;
 }
 
@@ -60,7 +150,7 @@ protocol DoubleEndedIteratorExt<Self: DoubleEndedIterator<Self, T>, T> {
     /// `rev` returns a wrapper over an iterator that has `next` and `next_back` methods
     /// reversed.
     fn rev(self: &mut Self) -> RevIterator<Self, T> {
-        RevIterator { it: self }
+        RevIterator { _it: self }
     }
 }
 
@@ -95,23 +185,23 @@ protocol IterableMut<Self, It: Iterator<It, &mut T>, T> {
 ///
 /// See [DoubleEndedIteratorExt::rev].
 struct RevIterator<It: DoubleEndedIterator<It, T>, T> {
-    it: &mut It
+    _it: &mut It
 }
 
 impl RevIterator<It: DoubleEndedIterator<It, T>, T> {
     /// @ Iterator::next
     fn next(self: &mut RevIterator<It, T>) -> Option<T> {
-        self.it.next_back()
+        self._it.next_back()
     }
 
     /// @ DoubleEndedIterator::next_back
     fn next_back(self: &mut RevIterator<It, T>) -> Option<T> {
-        self.it.next()
+        self._it.next()
     }
 
     /// @ Iterator::size_hint
     fn size_hint(self: &RevIterator<It, T>) -> Option<usize> {
-        self.it.size_hint()
+        self._it.size_hint()
     }
 
     mixin Iterator<RevIterator<It, T>, T>;
@@ -124,19 +214,19 @@ impl RevIterator<It: DoubleEndedIterator<It, T>, T> {
 ///
 /// See [IteratorExt::map].
 struct MapIterator<It: Iterator<It, T>, F: Fn(T) -> U, T, U> {
-    it: &mut It,
-    fun: F,
+    _it: &mut It,
+    _fun: F,
 }
 
 impl MapIterator<It: Iterator<It, T>, F: Fn(T) -> U, T, U> {
     /// @ Iterator::next
     fn next(self: &mut MapIterator<It, F, T, U>) -> Option<U> {
-        self.it.next().map(self.fun)
+        self._it.next().map(self._fun)
     }
 
     /// @ Iterator::size_hint
     fn size_hint(self: &MapIterator<It, F, T, U>) -> Option<usize> {
-        self.it.size_hint()
+        self._it.size_hint()
     }
 
     mixin Iterator<MapIterator<It, F, T, U>, U>;
@@ -146,7 +236,7 @@ impl MapIterator<It: Iterator<It, T>, F: Fn(T) -> U, T, U> {
 impl MapIterator<It: DoubleEndedIterator<It, T>, F: Fn(T) -> U, T, U> {
     /// @ DoubleEndedIterator::next_back
     fn next_back(self: &mut MapIterator<It, F, T, U>) -> Option<U> {
-        self.it.next_back().map(self.fun)
+        self._it.next_back().map(self._fun)
     }
 
     mixin DoubleEndedIterator<MapIterator<It, F, T, U>, U>;
@@ -157,15 +247,15 @@ impl MapIterator<It: DoubleEndedIterator<It, T>, F: Fn(T) -> U, T, U> {
 ///
 /// See [IteratorExt::take_while].
 struct TakeWhileIterator<It: Iterator<It, T>, F: Fn(T) -> bool, T> {
-    it: &mut It,
-    fun: F,
+    _it: &mut It,
+    _fun: F,
 }
 
 impl TakeWhileIterator<It: Iterator<It, T>, F: Fn(T) -> bool, T> {
     /// @ Iterator::next
     fn next(self: &mut TakeWhileIterator<It, F, T>) -> Option<T> {
-        self.it.next().and_then(|=self, x: T| -> Option<T> {
-            if self.fun(x) {
+        self._it.next().and_then(|=self, x: T| -> Option<T> {
+            if self._fun(x) {
                 Option::some(x)
             } else {
                 Option::none()
@@ -181,22 +271,22 @@ impl TakeWhileIterator<It: Iterator<It, T>, F: Fn(T) -> bool, T> {
 ///
 /// See [IteratorExt::skip_while].
 struct SkipWhileIterator<It: Iterator<It, T>, F: Fn(T) -> bool, T> {
-    it: &mut It,
-    fun: F,
-    finished: bool,
+    _it: &mut It,
+    _fun: F,
+    _finished: bool,
 }
 
 impl SkipWhileIterator<It: Iterator<It, T>, F: Fn(T) -> bool, T> {
     /// @ Iterator::next
     fn next(self: &mut SkipWhileIterator<It, F, T>) -> Option<T> {
         loop {
-            let v = self.it.next();
-            if self.finished || v.is_none() {
+            let v = self._it.next();
+            if self._finished || v.is_none() {
                 return v;
-            } else if self.fun(v.unwrap()) {
+            } else if self._fun(v.unwrap()) {
                 continue
             } else {
-                self.finished = true;
+                self._finished = true;
                 return v
             }
         }
@@ -210,8 +300,8 @@ impl SkipWhileIterator<It: Iterator<It, T>, F: Fn(T) -> bool, T> {
 ///
 /// See [IteratorExt::filter_map].
 struct FilterMapIterator<It: Iterator<It, T>, F: Fn(T) -> Option<U>, T, U> {
-    it: &mut It,
-    fun: F,
+    _it: &mut It,
+    _fun: F,
 }
 
 impl FilterMapIterator<It: Iterator<It, T>, F: Fn(T) -> Option<U>, T, U> {
@@ -220,8 +310,8 @@ impl FilterMapIterator<It: Iterator<It, T>, F: Fn(T) -> Option<U>, T, U> {
         use option::try;
 
         loop {
-            let value = self.it.next()?;
-            let mapped = self.fun(value);
+            let value = self._it.next()?;
+            let mapped = self._fun(value);
 
             if mapped.is_some() {
                 return mapped
@@ -240,8 +330,8 @@ impl FilterMapIterator<It: DoubleEndedIterator<It, T>, F: Fn(T) -> Option<U>, T,
         use option::try;
 
         loop {
-            let value = self.it.next_back()?;
-            let mapped = self.fun(value);
+            let value = self._it.next_back()?;
+            let mapped = self._fun(value);
 
             if mapped.is_some() {
                 return mapped
@@ -257,8 +347,8 @@ impl FilterMapIterator<It: DoubleEndedIterator<It, T>, F: Fn(T) -> Option<U>, T,
 ///
 /// See [IteratorExt::filter].
 struct FilterIterator<It: Iterator<It, T>, F: Fn(T) -> bool, T> {
-    it: &mut It,
-    fun: F,
+    _it: &mut It,
+    _fun: F,
 }
 
 impl FilterIterator<It: Iterator<It, T>, F: Fn(T) -> bool, T> {
@@ -267,8 +357,8 @@ impl FilterIterator<It: Iterator<It, T>, F: Fn(T) -> bool, T> {
         use option::try;
 
         loop {
-            let value = self.it.next()?;
-            if self.fun(value) {
+            let value = self._it.next()?;
+            if self._fun(value) {
                 return Option::some(value)
             }
         }
@@ -284,8 +374,8 @@ impl FilterIterator<It: DoubleEndedIterator<It, T>, F: Fn(T) -> bool, T> {
         use option::try;
 
         loop {
-            let value = self.it.next_back()?;
-            if self.fun(value) {
+            let value = self._it.next_back()?;
+            if self._fun(value) {
                 return Option::some(value)
             }
         }
@@ -299,30 +389,30 @@ impl FilterIterator<It: DoubleEndedIterator<It, T>, F: Fn(T) -> bool, T> {
 ///
 /// See [IteratorExt::skip].
 struct SkipIterator<It: Iterator<It, T>, T> {
-    it: &mut It,
-    n: usize,
+    _it: &mut It,
+    _n: usize,
 }
 
 impl SkipIterator<It: Iterator<It, T>, T> {
     /// @ Iterator::next
     fn next(self: &mut SkipIterator<It, T>) -> Option<T> {
-        while self.n > 0 {
-            self.n -= 1;
-            if self.it.next().is_none() {
+        while self._n > 0 {
+            self._n -= 1;
+            if self._it.next().is_none() {
                 return Option::none();
             }
         }
 
-        self.it.next()
+        self._it.next()
     }
 
     /// @ Iterator::size_hint
     fn size_hint(self: &SkipIterator<It, T>) -> Option<usize> {
-        self.it.size_hint().map(|=self, v: usize| -> usize {
-            if self.n > v {
+        self._it.size_hint().map(|=self, v: usize| -> usize {
+            if self._n > v {
                 0
             } else {
-                v - self.n
+                v - self._n
             }
         })
     }
@@ -335,9 +425,9 @@ impl SkipIterator<It: Iterator<It, T>, T> {
 ///
 /// See [IteratorExt::step_by].
 struct StepByIterator<It: Iterator<It, T>, T> {
-    it: &mut It,
-    n: usize,
-    index: usize,
+    _it: &mut It,
+    _n: usize,
+    _index: usize,
 }
 
 impl StepByIterator<It: Iterator<It, T>, T> {
@@ -345,20 +435,20 @@ impl StepByIterator<It: Iterator<It, T>, T> {
     fn next(self: &mut StepByIterator<It, T>) -> Option<T> {
         use option::try;
         loop {
-            self.index = (self.index + 1) % self.n;
-            if self.index > 0 {
-                self.it.next()?;
+            self._index = (self._index + 1) % self._n;
+            if self._index > 0 {
+                self._it.next()?;
             } else {
                 break;
             }
         }
-        self.it.next()
+        self._it.next()
     }
 
     /// @ Iterator::size_hint
     fn size_hint(self: &StepByIterator<It, T>) -> Option<usize> {
-        self.it.size_hint().map(|=self, v: usize| -> usize {
-            (v + self.index) / self.n
+        self._it.size_hint().map(|=self, v: usize| -> usize {
+            (v + self._index) / self._n
         })
     }
 
@@ -370,28 +460,28 @@ impl StepByIterator<It: Iterator<It, T>, T> {
 ///
 /// See [IteratorExt::fuse].
 struct FusedIterator<It: Iterator<It, T>, T> {
-    done: bool,
-    it: &mut It,
+    _done: bool,
+    _it: &mut It,
 }
 
 impl FusedIterator<It: Iterator<It, T>, T> {
     /// @ Iterator::next
     fn next(self: &mut FusedIterator<It, T>) -> Option<T> {
-        if self.done {
+        if self._done {
             Option::none()
         } else {
-            let v = self.it.next();
-            self.done = v.is_none();
+            let v = self._it.next();
+            self._done = v.is_none();
             v
         }
     }
 
     /// @ Iterator::size_hint
     fn size_hint(self: &FusedIterator<It, T>) -> Option<usize> {
-        if self.done {
+        if self._done {
             Option::some(0usize)
         } else {
-            self.it.size_hint()
+            self._it.size_hint()
         }
     }
 
@@ -402,11 +492,11 @@ impl FusedIterator<It: Iterator<It, T>, T> {
 impl FusedIterator<It: DoubleEndedIterator<It, T>, T> {
     /// @ DoubleEndedIterator::next_back
     fn next_back(self: &mut FusedIterator<It, T>) -> Option<T> {
-        if self.done {
+        if self._done {
             Option::none()
         } else {
-            let v = self.it.next_back();
-            self.done = v.is_none();
+            let v = self._it.next_back();
+            self._done = v.is_none();
             v
         }
     }
@@ -419,25 +509,25 @@ impl FusedIterator<It: DoubleEndedIterator<It, T>, T> {
 ///
 /// See [IteratorExt::take].
 struct TakeIterator<It: Iterator<It, T>, T> {
-    it: &mut It,
-    n: usize,
+    _it: &mut It,
+    _n: usize,
 }
 
 impl TakeIterator<It: Iterator<It, T>, T> {
     /// @ Iterator::next
     fn next(self: &mut TakeIterator<It, T>) -> Option<T> {
-        if self.n == 0 {
+        if self._n == 0 {
             return Option::none();
         }
 
-        self.n -= 1;
-        self.it.next()
+        self._n -= 1;
+        self._it.next()
     }
 
     /// @ Iterator::size_hint
     fn size_hint(self: &TakeIterator<It, T>) -> Option<usize> {
-        self.it.size_hint().map(|=self, v: usize| -> usize {
-            cmp::min(v, self.n)
+        self._it.size_hint().map(|=self, v: usize| -> usize {
+            cmp::min(v, self._n)
         })
     }
 
@@ -449,8 +539,8 @@ impl TakeIterator<It: Iterator<It, T>, T> {
 ///
 /// See [IteratorExt::enumerate].
 struct EnumerateIterator<It: Iterator<It, T>, T> {
-    it: &mut It,
-    n: usize,
+    _it: &mut It,
+    _n: usize,
 }
 
 impl EnumerateIterator<It: Iterator<It, T>, T> {
@@ -458,15 +548,15 @@ impl EnumerateIterator<It: Iterator<It, T>, T> {
     fn next(self: &mut EnumerateIterator<It, T>) -> Option<(usize, T)> {
         use option::try;
 
-        let val = self.it.next()?;
-        let res = (self.n, val);
-        self.n += 1;
+        let val = self._it.next()?;
+        let res = (self._n, val);
+        self._n += 1;
         Option::some(res)
     }
 
     /// @ Iterator::size_hint
     fn size_hint(self: &EnumerateIterator<It, T>) -> Option<usize> {
-        self.it.size_hint()
+        self._it.size_hint()
     }
 
     mixin Iterator<EnumerateIterator<It, T>, (usize, T)>;
@@ -477,20 +567,20 @@ impl EnumerateIterator<It: Iterator<It, T>, T> {
 ///
 /// See [IteratorExt::chain].
 struct ChainIterator<It1: Iterator<It1, T>, It2: Iterator<It2, T>, T> {
-    it1: FusedIterator<It1, T>,
-    it2: FusedIterator<It2, T>,
+    _it1: FusedIterator<It1, T>,
+    _it2: FusedIterator<It2, T>,
 }
 
 impl ChainIterator<It1: Iterator<It1, T>, It2: Iterator<It2, T>, T> {
     /// @ Iterator::next
     fn next(self: &mut ChainIterator<It1, It2, T>) -> Option<T> {
-        self.it1.next().or_else(|=self| -> Option<T> { self.it2.next() })
+        self._it1.next().or_else(|=self| -> Option<T> { self._it2.next() })
     }
 
     /// @ Iterator::size_hint
     fn size_hint(self: &ChainIterator<It1, It2, T>) -> Option<usize> {
-        self.it1.size_hint()
-            .zip(self.it2.size_hint())
+        self._it1.size_hint()
+            .zip(self._it2.size_hint())
             .map(|v: (usize, usize)| -> usize {
                 v.0 + v.1
             })
@@ -503,11 +593,11 @@ impl ChainIterator<It1: Iterator<It1, T>, It2: Iterator<It2, T>, T> {
 impl ChainIterator<It1: DoubleEndedIterator<It1, T>, It2: DoubleEndedIterator<It2, T>, T> {
     /// @ DoubleEndedIterator::next_back
     fn next_back(self: &mut ChainIterator<It1, It2, T>) -> Option<T> {
-        let v = self.it2.next_back();
+        let v = self._it2.next_back();
         if v.is_some() {
             v
         } else {
-            self.it1.next_back()
+            self._it1.next_back()
         }
     }
 
@@ -519,33 +609,33 @@ impl ChainIterator<It1: DoubleEndedIterator<It1, T>, It2: DoubleEndedIterator<It
 ///
 /// See [IteratorExt::merge_sorted].
 struct MergeIterator<It1: Iterator<It1, T>, It2: Iterator<It2, T>, T: cmp::Comparable<T>> {
-    it1: Option<PeekableIterator<It1, T>>,
-    it2: Option<PeekableIterator<It2, T>>,
+    _it1: Option<PeekableIterator<It1, T>>,
+    _it2: Option<PeekableIterator<It2, T>>,
 }
 
 impl MergeIterator<It1: Iterator<It1, T>, It2: Iterator<It2, T>, T: cmp::Comparable<T>> {
     /// @ Iterator::next
     fn next(self: &mut MergeIterator<It1, It2, T>) -> Option<T> {
-        if self.it1.is_none() {
-            return self.it2.as_mut_ptr().unwrap().next();
-        } else if self.it2.is_none() {
-            return self.it1.as_mut_ptr().unwrap().next();
+        if self._it1.is_none() {
+            return self._it2.as_mut_ptr().unwrap().next();
+        } else if self._it2.is_none() {
+            return self._it1.as_mut_ptr().unwrap().next();
         }
 
-        let it1 = self.it1.as_mut_ptr().unwrap();
-        let it2 = self.it2.as_mut_ptr().unwrap();
+        let it1 = self._it1.as_mut_ptr().unwrap();
+        let it2 = self._it2.as_mut_ptr().unwrap();
 
         let v1 = it1.peek();
         let v2 = it2.peek();
 
         if v1.is_none() {
             it1.next();
-            self.it1 = Option::none();
+            self._it1 = Option::none();
 
             it2.next()
         } else if v2.is_none() {
             it2.next();
-            self.it2 = Option::none();
+            self._it2 = Option::none();
 
             it1.next()
         } else if v1.unwrap() <= v2.unwrap() {
@@ -557,13 +647,13 @@ impl MergeIterator<It1: Iterator<It1, T>, It2: Iterator<It2, T>, T: cmp::Compara
 
     /// @ Iterator::size_hint
     fn size_hint(self: &MergeIterator<It1, It2, T>) -> Option<usize> {
-        if self.it1.is_none() {
-            self.it2.as_ptr().unwrap().size_hint()
-        } else if self.it2.is_none() {
-            self.it1.as_ptr().unwrap().size_hint()
+        if self._it1.is_none() {
+            self._it2.as_ptr().unwrap().size_hint()
+        } else if self._it2.is_none() {
+            self._it1.as_ptr().unwrap().size_hint()
         } else {
-            self.it1.as_ptr().unwrap().size_hint()
-                .zip(self.it2.as_ptr().unwrap().size_hint())
+            self._it1.as_ptr().unwrap().size_hint()
+                .zip(self._it2.as_ptr().unwrap().size_hint())
                 .map(|v: (usize, usize)| -> usize {
                     v.0 + v.1
                 })
@@ -578,26 +668,26 @@ impl MergeIterator<It1: Iterator<It1, T>, It2: Iterator<It2, T>, T: cmp::Compara
 impl MergeIterator<It1: DoubleEndedIterator<It1, T>, It2: DoubleEndedIterator<It2, T>, T: cmp::Comparable<T>> {
     /// @ DoubleEndedIterator::next_back
     fn next_back(self: &mut MergeIterator<It1, It2, T>) -> Option<T> {
-        if self.it1.is_none() {
-            return self.it2.as_mut_ptr().unwrap().next_back();
-        } else if self.it2.is_none() {
-            return self.it1.as_mut_ptr().unwrap().next_back();
+        if self._it1.is_none() {
+            return self._it2.as_mut_ptr().unwrap().next_back();
+        } else if self._it2.is_none() {
+            return self._it1.as_mut_ptr().unwrap().next_back();
         }
 
-        let it1 = self.it1.as_mut_ptr().unwrap();
-        let it2 = self.it2.as_mut_ptr().unwrap();
+        let it1 = self._it1.as_mut_ptr().unwrap();
+        let it2 = self._it2.as_mut_ptr().unwrap();
 
         let v1 = it1.peek_back();
         let v2 = it2.peek_back();
 
         if v1.is_none() {
             it1.next_back();
-            self.it1 = Option::none();
+            self._it1 = Option::none();
 
             it2.next_back()
         } else if v2.is_none() {
             it2.next_back();
-            self.it2 = Option::none();
+            self._it2 = Option::none();
 
             it1.next_back()
         } else if v1.unwrap() > v2.unwrap() {
@@ -617,23 +707,23 @@ impl MergeIterator<It1: DoubleEndedIterator<It1, T>, It2: DoubleEndedIterator<It
 ///
 /// See [IteratorExt::inspect].
 struct InspectIterator<It: Iterator<It, T>, F: Fn(T), T> {
-    it: &mut It,
-    func: F,
+    _it: &mut It,
+    _func: F,
 }
 
 impl InspectIterator<It: Iterator<It, T>, F: Fn(T), T> {
     /// @ Iterator::next
     fn next(self: &mut InspectIterator<It, F, T>) -> Option<T> {
-        let v = self.it.next();
+        let v = self._it.next();
         if v.is_some() {
-            self.func(v.unwrap());
+            self._func(v.unwrap());
         }
         v
     }
 
     /// @ Iterator::size_hint
     fn size_hint(self: &InspectIterator<It, F, T>) -> Option<usize> {
-        self.it.size_hint()
+        self._it.size_hint()
     }
 
     mixin Iterator<InspectIterator<It, F, T>, T>;
@@ -644,7 +734,7 @@ impl InspectIterator<It: Iterator<It, T>, F: Fn(T), T> {
 ///
 /// See [IteratorExt::group_by].
 struct Grouping<It: Iterator<It, T>, F: Fn(T) -> K, T, K: cmp::Equatable<K>> {
-    parent: &mut GroupByIterator<It, F, T, K>,
+    _parent: &mut GroupByIterator<It, F, T, K>,
     key: K
 }
 
@@ -653,17 +743,17 @@ impl Grouping<It: Iterator<It, T>, F: Fn(T) -> K, T, K: cmp::Equatable<K>> {
     fn next(self: &mut Grouping<It, F, T, K>) -> Option<T> {
         use option::try;
 
-        let v = self.parent.it.peek();
+        let v = self._parent._it.peek();
         if v.is_none() {
-            self.parent.last_group = Option::none();
-            return self.parent.it.next();
+            self._parent._last_group = Option::none();
+            return self._parent._it.next();
         }
 
-        if self.key != self.parent.func(v.unwrap()) {
-            self.parent.last_group = Option::none();
+        if self.key != self._parent._func(v.unwrap()) {
+            self._parent._last_group = Option::none();
             Option::none()
         } else {
-            self.parent.it.next()
+            self._parent._it.next()
         }
     }
 
@@ -675,32 +765,32 @@ impl Grouping<It: Iterator<It, T>, F: Fn(T) -> K, T, K: cmp::Equatable<K>> {
 ///
 /// See [IteratorExt::group_by].
 struct GroupByIterator<It: Iterator<It, T>, F: Fn(T) -> K, T, K: cmp::Equatable<K>> {
-    it: PeekableIterator<It, T>,
-    last_group: Option<Grouping<It, F, T, K>>,
-    func: F
+    _it: PeekableIterator<It, T>,
+    _last_group: Option<Grouping<It, F, T, K>>,
+    _func: F
 }
 
 impl GroupByIterator<It: Iterator<It, T>, F: Fn(T) -> K, T, K: cmp::Equatable<K>> {
     /// @ Iterator::next
     fn next(self: &mut GroupByIterator<It, F, T, K>) -> Option<Grouping<It, F, T, K>> {
-        let needs_drain = self.last_group.move();
+        let needs_drain = self._last_group.move();
         if needs_drain.is_some() {
             for _ in needs_drain.unwrap() {
             }
         }
 
-        let v = self.it.peek();
+        let v = self._it.peek();
         if v.is_none() {
-            self.it.next();
+            self._it.next();
             return Option::none();
         }
 
-        self.last_group = Option::some(Grouping::<It, F, T, K> {
-            parent: self,
-            key: self.func(v.unwrap())
+        self._last_group = Option::some(Grouping::<It, F, T, K> {
+            _parent: self,
+            key: self._func(v.unwrap())
         });
 
-        self.last_group
+        self._last_group
     }
 
     mixin Iterator<GroupByIterator<It, F, T, K>, Grouping<It, F, T, K>>;
@@ -711,18 +801,18 @@ impl GroupByIterator<It: Iterator<It, T>, F: Fn(T) -> K, T, K: cmp::Equatable<K>
 ///
 /// See [IteratorExt::chunks].
 struct Chunk<It: Iterator<It, T>, T> {
-    it: &mut TakeIterator<PeekableIterator<It, T>, T>,
+    _it: &mut TakeIterator<PeekableIterator<It, T>, T>,
 }
 
 impl Chunk<It: Iterator<It, T>, T> {
     /// @ Iterator::next
     fn next(self: &mut Chunk<It, T>) -> Option<T> {
-        self.it.next()
+        self._it.next()
     }
 
     /// @ Iterator::size_hint
     fn size_hint(self: &Chunk<It, T>) -> Option<usize> {
-        self.it.size_hint()
+        self._it.size_hint()
     }
 
     mixin Iterator<Chunk<It, T>, T>;
@@ -733,30 +823,30 @@ impl Chunk<It: Iterator<It, T>, T> {
 ///
 /// See [IteratorExt::chunks].
 struct ChunksIterator<It: Iterator<It, T>, T> {
-    chunk_size: usize,
-    it: PeekableIterator<It, T>,
-    last_chunk: Option<TakeIterator<PeekableIterator<It, T>, T>>,
+    _chunk_size: usize,
+    _it: PeekableIterator<It, T>,
+    _last_chunk: Option<TakeIterator<PeekableIterator<It, T>, T>>,
 }
 
 impl ChunksIterator<It: Iterator<It, T>, T> {
     /// @ Iterator::next
     fn next(self: &mut ChunksIterator<It, T>) -> Option<Chunk<It, T>> {
-        let needs_drain = self.last_chunk.move();
+        let needs_drain = self._last_chunk.move();
         if needs_drain.is_some() {
             for _ in needs_drain.unwrap() {
             }
-            self.last_chunk = Option::none();
+            self._last_chunk = Option::none();
         }
 
-        let v = self.it.peek();
+        let v = self._it.peek();
         if v.is_none() {
-            self.it.next();
+            self._it.next();
             return Option::none();
         }
 
-        self.last_chunk = Option::some(self.it.take(self.chunk_size));
+        self._last_chunk = Option::some(self._it.take(self._chunk_size));
         let result = Chunk {
-            it: self.last_chunk.as_mut_ptr().unwrap()
+            _it: self._last_chunk.as_mut_ptr().unwrap()
         };
 
         Option::some(result)
@@ -764,9 +854,9 @@ impl ChunksIterator<It: Iterator<It, T>, T> {
 
     /// @ Iterator::size_hint
     fn size_hint(self: &ChunksIterator<It, T>) -> Option<usize> {
-        self.it.size_hint().map(|=self, s: usize| -> usize {
-            let full_size = (s + self.chunk_size - 1) / self.chunk_size;
-            if self.last_chunk.is_some() {
+        self._it.size_hint().map(|=self, s: usize| -> usize {
+            let full_size = (s + self._chunk_size - 1) / self._chunk_size;
+            if self._last_chunk.is_some() {
                 full_size - 1
             } else {
                 full_size
@@ -782,26 +872,26 @@ impl ChunksIterator<It: Iterator<It, T>, T> {
 ///
 /// See [IteratorExt::peekable].
 struct PeekableIterator<It: Iterator<It, T>, T> {
-    it: &mut It,
-    peeked: Option<T>,
-    peeked_back: when It: DoubleEndedIterator<It, T> { Option<T> } else { () },
+    _it: &mut It,
+    _peeked: Option<T>,
+    _peeked_back: when It: DoubleEndedIterator<It, T> { Option<T> } else { () },
 }
 
 impl PeekableIterator<It: Iterator<It, T>, T> {
     /// @ Iterator::next
     fn next(self: &mut PeekableIterator<It, T>) -> Option<T> {
-        if self.peeked.is_some() {
-            self.peeked.move()
+        if self._peeked.is_some() {
+            self._peeked.move()
         } else {
             when It: DoubleEndedIterator<It, T> {
-                let next = self.it.next();
+                let next = self._it.next();
                 if next.is_none() {
-                    self.peeked_back.move()
+                    self._peeked_back.move()
                 } else {
                     next
                 }
             } else {
-                self.it.next()
+                self._it.next()
             }
         }
     }
@@ -809,33 +899,33 @@ impl PeekableIterator<It: Iterator<It, T>, T> {
     /// Return the next element in the iterator without consuming it.
     fn peek(self: &mut PeekableIterator<It, T>) -> Option<T> {
         when It: DoubleEndedIterator<It, T> {
-            if self.peeked.is_none() {
-                self.peeked = self.it.next();
-                if self.peeked.is_some(){
-                    self.peeked
+            if self._peeked.is_none() {
+                self._peeked = self._it.next();
+                if self._peeked.is_some(){
+                    self._peeked
                 } else {
-                    self.peeked_back
+                    self._peeked_back
                 }
             } else {
-                self.peeked
+                self._peeked
             }
         } else {
-            if self.peeked.is_none() {
-                self.peeked = self.it.next();
+            if self._peeked.is_none() {
+                self._peeked = self._it.next();
             }
-            self.peeked
+            self._peeked
         }
     }
 
     /// @ Iterator::size_hint
     fn size_hint(self: &PeekableIterator<It, T>) -> Option<usize> {
-        self.it.size_hint().map(|=self, x: usize| -> usize {
+        self._it.size_hint().map(|=self, x: usize| -> usize {
             when It: DoubleEndedIterator<It, T> {
                 x
-                + (if self.peeked.is_some() { 1 } else { 0 })
-                + (if self.peeked_back.is_some() { 1 } else { 0 })
+                + (self._peeked.is_some() as usize)
+                + (self._peeked_back.is_some() as usize)
             } else {
-                if self.peeked.is_some() {
+                if self._peeked.is_some() {
                     x + 1
                 } else {
                     x
@@ -851,12 +941,12 @@ impl PeekableIterator<It: Iterator<It, T>, T> {
 impl PeekableIterator<It: DoubleEndedIterator<It, T>, T> {
     /// @ DoubleEndedIterator::next_back
     fn next_back(self: &mut PeekableIterator<It, T>) -> Option<T> {
-        if self.peeked_back.is_some() {
-            self.peeked_back.move()
+        if self._peeked_back.is_some() {
+            self._peeked_back.move()
         } else {
-            let next_back = self.it.next_back();
+            let next_back = self._it.next_back();
             if next_back.is_none() {
-                self.peeked.move()
+                self._peeked.move()
             } else {
                 next_back
             }
@@ -865,15 +955,15 @@ impl PeekableIterator<It: DoubleEndedIterator<It, T>, T> {
 
     /// Return the next element from the back in the iterator without consuming it.
     fn peek_back(self: &mut PeekableIterator<It, T>) -> Option<T> {
-        if self.peeked_back.is_none() {
-            self.peeked_back = self.it.next_back();
-            if self.peeked_back.is_some(){
-                self.peeked_back
+        if self._peeked_back.is_none() {
+            self._peeked_back = self._it.next_back();
+            if self._peeked_back.is_some(){
+                self._peeked_back
             } else {
-                self.peeked
+                self._peeked
             }
         } else {
-            self.peeked_back
+            self._peeked_back
         }
     }
 
@@ -885,20 +975,20 @@ impl PeekableIterator<It: DoubleEndedIterator<It, T>, T> {
 ///
 /// See [IteratorExt::zip].
 struct ZipIterator<It1: Iterator<It1, T1>, It2: Iterator<It2, T2>, T1, T2> {
-    it1: &mut It1,
-    it2: &mut It2,
+    _it1: &mut It1,
+    _it2: &mut It2,
 }
 
 impl ZipIterator<It1: Iterator<It1, T1>, It2: Iterator<It2, T2>, T1, T2> {
     /// @ Iterator::next
     fn next(self: &mut ZipIterator<It1, It2, T1, T2>) -> Option<(T1, T2)> {
-        self.it1.next().zip(self.it2.next())
+        self._it1.next().zip(self._it2.next())
     }
 
     /// @ Iterator::size_hint
     fn size_hint(self: &ZipIterator<It1, It2, T1, T2>,) -> Option<usize> {
-        self.it1.size_hint()
-            .zip(self.it2.size_hint())
+        self._it1.size_hint()
+            .zip(self._it2.size_hint())
             .map(|v: (usize, usize)| -> usize {
                 std::cmp::min(v.0, v.1)
             })
@@ -912,9 +1002,9 @@ impl ZipIterator<It1: Iterator<It1, T1>, It2: Iterator<It2, T2>, T1, T2> {
 ///
 /// See [IteratorExt::flatten].
 struct FlattenIterator<It: Iterator<It, T>, T, Ret> {
-    it: &mut It,
-    elem: Option<T>,
-    elem_iter: typeof((null as &mut T).iter()) // maybe uninitialised
+    _it: &mut It,
+    _elem: Option<T>,
+    _elem_iter: typeof((null as &mut T).iter()) // maybe uninitialised
 }
 
 impl FlattenIterator<It: Iterator<It, T>, T, Ret> {
@@ -923,20 +1013,20 @@ impl FlattenIterator<It: Iterator<It, T>, T, Ret> {
         use option::try;
 
         loop {
-            if self.elem.is_none() {
+            if self._elem.is_none() {
                 // We store the element, as the iterator may require a stable pointer to it.
-                self.elem = Option::some(self.it.next()?);
-                self.elem_iter = self.elem
+                self._elem = Option::some(self._it.next()?);
+                self._elem_iter = self._elem
                     .as_mut_ptr()
                     .unwrap()
                     .iter();
             }
 
-            let v = self.elem_iter.next();
+            let v = self._elem_iter.next();
             if v.is_some() {
                 return v;
             } else {
-                self.elem = Option::none()
+                self._elem = Option::none()
             }
         }
     }
@@ -994,8 +1084,8 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// exhausted. This method "caps it off" after they are first exhausted.
     fn fuse(self: &mut Self) -> FusedIterator<Self, T> {
         FusedIterator {
-            done: false,
-            it: self
+            _done: false,
+            _it: self
         }
     }
 
@@ -1013,8 +1103,8 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// ```
     fn chain<Other: Iterator<Other, T>>(self: &mut Self, other: &mut Other) -> ChainIterator<Self, Other, T> {
         ChainIterator {
-            it1: FusedIterator { done: false, it: self },
-            it2: FusedIterator { done: false, it: other }
+            _it1: FusedIterator { _done: false, _it: self },
+            _it2: FusedIterator { _done: false, _it: other }
         }
     }
 
@@ -1037,8 +1127,8 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// ```
     fn merge_sorted<Other: Iterator<Other, T>>(self: &mut Self, other: &mut Other) -> MergeIterator<Self, Other, T> {
         MergeIterator {
-            it1: Option::some(self.peekable()),
-            it2: Option::some(other.peekable())
+            _it1: Option::some(self.peekable()),
+            _it2: Option::some(other.peekable())
         }
     }
 
@@ -1059,8 +1149,8 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// ```
     fn skip(self: &mut Self, n: usize) -> SkipIterator<Self, T> {
         SkipIterator {
-            it: self,
-            n: n,
+            _it: self,
+            _n: n,
         }
     }
 
@@ -1081,9 +1171,9 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
         assert!(n > 0);
 
         StepByIterator {
-            it: self,
-            index: n - 1,
-            n: n,
+            _it: self,
+            _index: n - 1,
+            _n: n,
         }
     }
 
@@ -1100,8 +1190,8 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// ```
     fn take(self: &mut Self, n: usize) -> TakeIterator<Self, T> {
         TakeIterator {
-            it: self,
-            n: n,
+            _it: self,
+            _n: n,
         }
     }
 
@@ -1121,8 +1211,8 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// ```
     fn enumerate(self: &mut Self) -> EnumerateIterator<Self, T> {
         EnumerateIterator {
-            it: self,
-            n: 0,
+            _it: self,
+            _n: 0,
         }
     }
 
@@ -1206,8 +1296,8 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// ```
     fn inspect<F: Fn(T)>(it: &mut Self, func: F) -> InspectIterator<Self, F, T> {
         InspectIterator {
-            it: it,
-            func: func,
+            _it: it,
+            _func: func,
         }
     }
 
@@ -1224,7 +1314,7 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// assert_eq!(range.next(), Option::none());
     /// ```
     fn take_while<F: Fn(T) -> bool>(iter: &mut Self, fun: F) -> TakeWhileIterator<Self, F, T> {
-        TakeWhileIterator { it: iter, fun: fun }
+        TakeWhileIterator { _it: iter, _fun: fun }
     }
 
     /// Returns an iterator that skips the elements while a predicate is true.
@@ -1238,7 +1328,7 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// assert_eq!(range.next(), Option::none());
     /// ```
     fn skip_while<F: Fn(T) -> bool>(iter: &mut Self, fun: F) -> SkipWhileIterator<Self, F, T> {
-        SkipWhileIterator { it: iter, fun: fun, finished: false }
+        SkipWhileIterator { _it: iter, _fun: fun, _finished: false }
     }
 
     /// Returns an iterator that transforms the elements of this iterator.
@@ -1255,7 +1345,7 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// assert_eq!(range.next(), Option::none());
     /// ```
     fn map<U, F: Fn(T) -> U>(iter: &mut Self, fun: F) -> MapIterator<Self, F, T, U> {
-        MapIterator { it: iter, fun: fun }
+        MapIterator { _it: iter, _fun: fun }
     }
 
     /// Executes a function on each element of this iterator.
@@ -1299,7 +1389,7 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// assert_eq!(range.next(), Option::none());
     /// ```
     fn filter<F: Fn(T) -> bool>(iter: &mut Self, fun: F) -> FilterIterator<Self, F, T> {
-        FilterIterator { it: iter, fun: fun }
+        FilterIterator { _it: iter, _fun: fun }
     }
 
     /// Returns the first item matching the predicate.
@@ -1366,7 +1456,7 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// assert_eq!(range.next(), Option::some(500));
     /// ```
     fn filter_map<U, F: Fn(T) -> Option<U>>(iter: &mut Self, fun: F) -> FilterMapIterator<Self, F, T, U> {
-        FilterMapIterator { it: iter, fun: fun }
+        FilterMapIterator { _it: iter, _fun: fun }
     }
 
 
@@ -1393,9 +1483,9 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
         assert!(chunk_size > 0);
 
         ChunksIterator {
-            it: self.peekable(),
-            last_chunk: Option::none(),
-            chunk_size: chunk_size,
+            _it: self.peekable(),
+            _last_chunk: Option::none(),
+            _chunk_size: chunk_size,
         }
     }
 
@@ -1567,9 +1657,9 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// [Iterator::next] will return the same value.
     fn peekable(self: &mut Self) -> PeekableIterator<Self, T> {
         PeekableIterator {
-            it: self,
-            peeked: Option::none(),
-            peeked_back: when Self: DoubleEndedIterator<Self, T> {
+            _it: self,
+            _peeked: Option::none(),
+            _peeked_back: when Self: DoubleEndedIterator<Self, T> {
                 Option::none()
             } else {
                 ()
@@ -1603,9 +1693,9 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// ```
     fn group_by<F: Fn(T) -> K, K: cmp::Equatable<K>>(self: &mut Self, func: F) -> GroupByIterator<Self, F, T, K> {
         GroupByIterator {
-            it: self.peekable(),
-            last_group: Option::none(),
-            func: func
+            _it: self.peekable(),
+            _last_group: Option::none(),
+            _func: func
         }
     }
 
@@ -1626,8 +1716,8 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// ```
     fn zip<Other>(self: &mut Self, other: &mut Other) -> ZipIterator<Self, Other, T, iterator_yield_t<Other>> {
         ZipIterator {
-            it1: self,
-            it2: other,
+            _it1: self,
+            _it2: other,
         }
     }
 
@@ -1644,9 +1734,9 @@ protocol IteratorExt<Self: Iterator<Self, T>, T> {
     /// ```
     fn flatten(self: &mut Self) -> FlattenIterator<Self, T, iterable_yield_t<T>> {
         FlattenIterator {
-            it: self,
-            elem: Option::none(),
-            elem_iter: mem::uninitialized()
+            _it: self,
+            _elem: Option::none(),
+            _elem_iter: mem::uninitialized()
         }
     }
 }
@@ -1685,13 +1775,13 @@ impl EmptyIterator<T> {
 ///
 /// See [from_fn] for details.
 struct FromFnIterator<F: Fn() -> Option<T>, T> {
-    func: F,
+    _func: F,
 }
 
 impl FromFnIterator<F: Fn() -> Option<T>, T> {
     /// @ Iterator::next
     fn next(self: &mut FromFnIterator<F, T>) -> Option<T> {
-        self.func()
+        self._func()
     }
 
     mixin Iterator<FromFnIterator<F, T>, T>;
@@ -1729,25 +1819,25 @@ fn empty<T>() -> EmptyIterator<T> {
 /// println!("{}", sqrt2); // Prints approximately 1.4142135623730951
 /// ```
 fn from_fn<F: Fn() -> Option<T>, T>(func: F) -> FromFnIterator<F, T> {
-    FromFnIterator::<F, T> { func: func }
+    FromFnIterator::<F, T> { _func: func }
 }
 
 /// Iterator that repeats a value infinitely.
 ///
 /// See [repeat] for more details.
 struct RepeatIterator<T> {
-    value: T
+    _value: T
 }
 
 impl RepeatIterator<T> {
     /// @ Iterator::next
     fn next(self: &mut RepeatIterator<T>) -> Option<T> {
-        Option::some(self.value)
+        Option::some(self._value)
     }
 
     /// @ DoubleEndedIterator::next_back
     fn next_back(self: &mut RepeatIterator<T>) -> Option<T> {
-        Option::some(self.value)
+        Option::some(self._value)
     }
 
     /// @ Iterator::size_hint
@@ -1771,30 +1861,30 @@ impl RepeatIterator<T> {
 /// // ...
 /// ```
 fn repeat<T>(value: T) -> RepeatIterator<T> {
-    RepeatIterator { value: value }
+    RepeatIterator { _value: value }
 }
 
 /// Iterator that yields a single value
 ///
 /// See [once] for more details.
 struct OnceIterator<T> {
-    value: Option<T>
+    _value: Option<T>
 }
 
 impl OnceIterator<T> {
     /// @ Iterator::next
     fn next(self: &mut OnceIterator<T>) -> Option<T> {
-        self.value.move()
+        self._value.move()
     }
 
     /// @ DoubleEndedIterator::next_back
     fn next_back(self: &mut OnceIterator<T>) -> Option<T> {
-        self.value.move()
+        self._value.move()
     }
 
     /// @ Iterator::size_hint
     fn size_hint(self: &OnceIterator<T>) -> Option<usize> {
-        if self.value.is_some() {
+        if self._value.is_some() {
             Option::some(1usize)
         } else {
             Option::some(0usize)
@@ -1815,7 +1905,7 @@ impl OnceIterator<T> {
 /// assert_eq!(iter.next(), Option::none());
 /// ```
 fn once<T>(value: T) -> OnceIterator<T> {
-    OnceIterator { value: Option::some(value) }
+    OnceIterator { _value: Option::some(value) }
 }
 
 #[docs(no_index)]

--- a/sysroot/std/mem.alu
+++ b/sysroot/std/mem.alu
@@ -115,7 +115,7 @@ impl slice {
     use libc::memcmp;
 
     /// Empty slice
-    #[force_inline]
+    #[inline(always)]
     fn empty<Ptr: Pointer>() -> slice<Ptr> {
         slice::<Ptr> { _ptr: null, _len: 0 }
     }
@@ -132,14 +132,14 @@ impl slice {
     /// let slice = slice::from_raw(ptr, 2);
     /// assert_eq!(slice, &[1, 2]);
     /// ```
-    #[force_inline]
+    #[inline(always)]
     #[lang(slice_new)]
     fn from_raw<Ptr: Pointer>(ptr: Ptr, len: usize) -> slice<Ptr> {
         slice::<Ptr> { _ptr: ptr, _len: len }
     }
 
     /// Returns the length of the slice
-    #[force_inline]
+    #[inline(always)]
     fn len<Ptr: Pointer>(self: slice<Ptr>) -> usize {
         self._len
     }
@@ -149,7 +149,7 @@ impl slice {
     /// Unlike `&slice[0]`, this is not range-checked, so it will not panic
     /// if the slice is empty, but may return `null`, a dangling or an otherwise
     /// invalid pointer.
-    #[force_inline]
+    #[inline(always)]
     fn as_ptr<Ptr: Pointer>(self: slice<Ptr>) -> Ptr {
         self._ptr
     }
@@ -240,19 +240,19 @@ impl slice {
     }
 
     /// @ std::iter::Iterable::iter
-    #[force_inline]
+    #[inline(always)]
     fn iter<Ptr: Pointer>(self: slice<Ptr>) -> SliceIterator<Ptr> {
         SliceIterator { inner: self }
     }
 
     /// @ std::iter::IterableRef::iter_ref
-    #[force_inline]
+    #[inline(always)]
     fn iter_ref<Ptr: Pointer>(self: slice<Ptr>) -> SliceRefIterator<&builtins::deref_of<Ptr>> {
         SliceRefIterator { inner: self as slice<&builtins::deref_of<Ptr>> }
     }
 
     /// @ std::iter::IterableMut::iter_mut
-    #[force_inline]
+    #[inline(always)]
     fn iter_mut<T>(self: &mut [T]) -> SliceRefIterator<&mut T> {
         SliceRefIterator { inner: self }
     }
@@ -360,7 +360,7 @@ struct SliceIterator<Ptr: builtins::Pointer> {
 
 impl SliceIterator<Ptr: builtins::Pointer> {
     /// @ iter::Iterator::next
-    #[force_inline]
+    #[inline(always)]
     fn next(self: &mut SliceIterator<Ptr>) -> Option<builtins::deref_of<Ptr>> {
         if self.inner.len() > 0 {
             let result = Option::some(*self.inner._ptr);
@@ -373,7 +373,7 @@ impl SliceIterator<Ptr: builtins::Pointer> {
     }
 
     /// @ iter::DoubleEndedIterator::next_back
-    #[force_inline]
+    #[inline(always)]
     fn next_back(self: &mut SliceIterator<Ptr>) -> Option<builtins::deref_of<Ptr>> {
         if self.inner.len() > 0 {
             let result = Option::some(self.inner[self.inner.len() - 1]);
@@ -402,7 +402,7 @@ struct SliceRefIterator<Ptr: builtins::Pointer> {
 
 impl SliceRefIterator<Ptr: builtins::Pointer> {
     /// @ iter::Iterator::next
-    #[force_inline]
+    #[inline(always)]
     fn next(self: &mut SliceRefIterator<Ptr>) -> Option<Ptr> {
         if self.inner.len() > 0 {
             let result = Option::some(self.inner._ptr);
@@ -415,7 +415,7 @@ impl SliceRefIterator<Ptr: builtins::Pointer> {
     }
 
     /// @ iter::DoubleEndedIterator::next_back
-    #[force_inline]
+    #[inline(always)]
     fn next_back(self: &mut SliceRefIterator<Ptr>) -> Option<Ptr> {
         if self.inner.len() > 0 {
             let result = Option::some(&self.inner[self.inner.len() - 1]);
@@ -478,7 +478,7 @@ mod internal {
     ///
     /// Compiler will convert `slice[i]` to `*slice_index(slice, i)`.
     /// Slice indexing is bounds-checked in debug mode.
-    #[force_inline]
+    #[inline(always)]
     #[lang(slice_index)]
     fn slice_index<Ptr: Pointer>(a: slice<Ptr>, idx: usize) -> Ptr {
         bounds_check!(idx < a.len(), "index out of bounds: the len is {} but the index is {}", a.len(), idx);
@@ -490,7 +490,7 @@ mod internal {
     ///
     /// Compiler will convert `slice[ran..ge]` to `slice_index(slice, ran..ge)`.
     /// It is generic over all range types (`..`, `ran..`, `..ge` and `ran..ge`)
-    #[force_inline]
+    #[inline(always)]
     #[lang(slice_range_index)]
     fn slice_range_index<Ptr: Pointer, T: RangeOf<usize>>(a: slice<Ptr>, range: T) -> slice<Ptr> {
         when T: range::Range<usize> {
@@ -562,13 +562,13 @@ mod internal {
     ///
     /// This is necessary, since they are completely
     /// different types.
-    #[force_inline]
+    #[inline(always)]
     #[lang(slice_const_coerce)]
     fn slice_const_coerce<T>(a: slice<&mut T>) -> slice<&T> {
         slice::from_raw::<&T>(a._ptr, a.len())
     }
 
-    #[force_inline]
+    #[inline(always)]
     #[lang(slice_const_cast)]
     fn slice_const_cast<T>(a: slice<&T>) -> slice<&mut T> {
         slice::from_raw::<&mut T>(a._ptr as &mut T, a.len())
@@ -655,7 +655,7 @@ fn free<T>(a: &mut T) {
 /// assert_eq!(size_of::<u32>(), 4);
 /// assert_eq!(size_of::<u64>(), 8);
 /// ```
-#[force_inline]
+#[inline(always)]
 fn size_of<T>() -> usize {
     intrinsics::size_of::<T>()
 }
@@ -672,7 +672,7 @@ fn size_of<T>() -> usize {
 /// assert_eq!(align_of::<u32>(), 4);
 /// assert_eq!(align_of::<u64>(), 8);
 /// ```
-#[force_inline]
+#[inline(always)]
 fn align_of<T>() -> usize {
     intrinsics::align_of::<T>()
 }
@@ -768,7 +768,7 @@ fn zeroed<T>() -> T {
 ///     println!("negative");
 /// }
 /// ```
-#[force_inline]
+#[inline(always)]
 fn uninitialized<T>() -> T {
     let ret: T;
     ret

--- a/sysroot/std/option.alu
+++ b/sysroot/std/option.alu
@@ -88,7 +88,7 @@ impl Option<T> {
     /// assert!(opt.is_some());
     /// assert_eq!(opt.unwrap(), 42);
     /// ```
-    #[force_inline]
+    #[inline(always)]
     fn some(inner: T) -> Option<T> {
         Option::<T> {
             _is_some: true,
@@ -104,7 +104,7 @@ impl Option<T> {
     ///
     /// assert!(opt.is_none());
     /// ```
-    #[force_inline]
+    #[inline(always)]
     fn none() -> Option<T> {
         Option::<T> {
             _is_some: false,
@@ -113,13 +113,13 @@ impl Option<T> {
     }
 
     /// Returns `true` if the option is populated, `false` otherwise.
-    #[force_inline]
+    #[inline(always)]
     fn is_some(self: &Option<T>) -> bool {
         self._is_some
     }
 
     /// Returns `true` if the option is empty, `false` otherwise.
-    #[force_inline]
+    #[inline(always)]
     fn is_none(self: &Option<T>) -> bool {
         !self._is_some
     }
@@ -135,7 +135,7 @@ impl Option<T> {
     ///
     /// opt.unwrap(); // panics
     /// ```
-    #[force_inline]
+    #[inline(always)]
     fn unwrap(self: Option<T>) -> T {
         if self.is_some() {
             self._inner
@@ -528,7 +528,7 @@ impl Option {
 #[docs(no_index)]
 mod internal {
     #[cold]
-    #[no_inline]
+    #[inline(never)]
     fn unwrap_panic() -> ! {
         panic!("called `Option::unwrap()` on a `None` value")
     }

--- a/sysroot/std/option.alu
+++ b/sysroot/std/option.alu
@@ -423,7 +423,7 @@ impl Option<T> {
 
     /// @ iter::Iterable::iter
     fn iter(self: &Option<T>) -> iter::OnceIterator<T> {
-        iter::OnceIterator { value: *self }
+        iter::OnceIterator { _value: *self }
     }
 
     /// @ mem::Movable::move

--- a/sysroot/std/panicking.alu
+++ b/sysroot/std/panicking.alu
@@ -101,7 +101,7 @@ mod internal {
     }
 
     #[cold]
-    #[no_inline]
+    #[inline(never)]
     fn panic_impl(
         file: &[u8],
         line: i32,

--- a/sysroot/std/process/unix.alu
+++ b/sysroot/std/process/unix.alu
@@ -81,6 +81,7 @@ fn current_dir() -> Result<fs::PathBuf> {
     use ffi::CString;
 
     let buf: StringBuf = StringBuf::with_capacity(512);
+    defer buf.free();
 
     loop {
         let spare_capacity = buf.spare_capacity();
@@ -94,19 +95,18 @@ fn current_dir() -> Result<fs::PathBuf> {
             let as_errno = error.as_errno();
 
             if as_errno == Option::some(libc::ERANGE) {
-                buf.reserve(1);
+                // Double the allocation and try again
+                buf.reserve(buf.capacity() + 1);
                 continue;
             }
 
             return Result::err(error);
         }
 
-        let len = CString::from_raw(ret).len();
-        // We don't know the exact size of the allocated buffer, so we assume
-        // that it is at least as big as the length of the string plus the null
-        // terminator.
-        let slice = mem::slice::from_raw(ret as &mut u8, len + 1);
-        return Result::ok(fs::PathBuf { inner: collections::Vector::from_raw(slice, len) })
+        assert_eq!(ret, &spare_capacity[0] as &mut libc::c_char);
+
+        buf.truncate(CString::from_raw(ret).len());
+        return Result::ok(fs::PathBuf { inner: buf.move() });
     }
 }
 

--- a/sysroot/std/range.alu
+++ b/sysroot/std/range.alu
@@ -29,7 +29,7 @@ impl RangeFull<T: Integer> {
     /// Create a new unbounded range
     ///
     /// You usually don't need to call this method directly, use the `..` expression instead.
-    #[force_inline]
+    #[inline(always)]
     #[lang(range_full_new)]
     fn new() -> RangeFull<T> {
         RangeFull {}
@@ -57,7 +57,7 @@ impl RangeFrom<T: Integer> {
     /// Create a new range with an lower bound.
     ///
     /// You usually don't need to call this method directly, use the `a..` expression instead.
-    #[force_inline]
+    #[inline(always)]
     #[lang(range_from_new)]
     fn new(lower: T) -> RangeFrom<T> {
         RangeFrom {
@@ -66,13 +66,13 @@ impl RangeFrom<T: Integer> {
     }
 
     /// @ iter::Iterable::iter
-    #[force_inline]
+    #[inline(always)]
     fn iter(self: &RangeFrom<T>) -> RangeFrom<T> {
         *self
     }
 
     /// @ iter::Iterator::next
-    #[force_inline]
+    #[inline(always)]
     fn next(self: &mut RangeFrom<T>) -> Option<T> {
         let lower = self.lower;
         self.lower += 1;
@@ -105,7 +105,7 @@ impl RangeTo<T: Integer> {
     /// Create a new range with an upper bound.
     ///
     /// You usually don't need to call this method directly, use the `..b` expression instead.
-    #[force_inline]
+    #[inline(always)]
     #[lang(range_to_new)]
     fn new(upper: T) -> RangeTo<T> {
         RangeTo {
@@ -136,7 +136,7 @@ impl RangeToInclusive<T: Integer> {
     /// Create a new range with an inclusive upper bound.
     ///
     /// You usually don't need to call this method directly, use the `..=b` expression instead.
-    #[force_inline]
+    #[inline(always)]
     #[lang(range_to_inclusive_new)]
     fn new(upper: T) -> RangeToInclusive<T> {
         RangeToInclusive {
@@ -168,7 +168,7 @@ impl Range<T: Integer> {
     /// Create a new range from the given lower and upper bounds.
     ///
     /// You usually don't need to call this method directly, use the `a..b` expression instead.
-    #[force_inline]
+    #[inline(always)]
     #[lang(range_new)]
     fn new(lower: T, upper: T) -> Range<T> {
         Range {
@@ -178,13 +178,13 @@ impl Range<T: Integer> {
     }
 
     /// @ iter::Iterable::iter
-    #[force_inline]
+    #[inline(always)]
     fn iter(self: &Range<T>) -> Range<T> {
         *self
     }
 
     /// @ iter::Iterator::next
-    #[force_inline]
+    #[inline(always)]
     fn next(self: &mut Range<T>) -> Option<T> {
         if self.lower < self.upper {
             let lower = self.lower;
@@ -196,7 +196,7 @@ impl Range<T: Integer> {
     }
 
     /// @ iter::DoubleEndedIterator::next_back
-    #[force_inline]
+    #[inline(always)]
     fn next_back(self: &mut Range<T>) -> Option<T> {
         if self.lower < self.upper {
             self.upper -= 1;
@@ -245,7 +245,7 @@ impl RangeInclusive<T: Integer> {
     /// Create a new inclusive range from the given lower and upper bounds.
     ///
     /// You usually don't need to call this method directly, use the `a..=b` expression instead.
-    #[force_inline]
+    #[inline(always)]
     #[lang(range_inclusive_new)]
     fn new(lower: T, upper: T) -> RangeInclusive<T> {
         RangeInclusive {
@@ -256,13 +256,13 @@ impl RangeInclusive<T: Integer> {
     }
 
     /// @ iter::Iterable::iter
-    #[force_inline]
+    #[inline(always)]
     fn iter(self: &RangeInclusive<T>) -> RangeInclusive<T> {
         *self
     }
 
     /// @ iter::Iterator::next
-    #[force_inline]
+    #[inline(always)]
     fn next(self: &mut RangeInclusive<T>) -> Option<T> {
         if self.lower <= self.upper && !self._exhausted {
             let lower = self.lower;
@@ -279,7 +279,7 @@ impl RangeInclusive<T: Integer> {
     }
 
     /// @ iter::DoubleEndedIterator::next_back
-    #[force_inline]
+    #[inline(always)]
     fn next_back(self: &mut RangeInclusive<T>) -> Option<T> {
         if self.lower <= self.upper && !self._exhausted {
             let upper = self.upper;

--- a/sysroot/std/result.alu
+++ b/sysroot/std/result.alu
@@ -101,7 +101,7 @@ impl Result<T, E> {
     /// assert!(r.is_ok());
     /// assert_eq!(r.unwrap(), 10);
     /// ```
-    #[force_inline]
+    #[inline(always)]
     fn ok(ok: T) -> Result<T, E> {
         Result::<T, E> {
             _is_ok: true,
@@ -120,7 +120,7 @@ impl Result<T, E> {
     /// assert!(r.is_err());
     /// assert_eq!(r.unwrap_err(), 42);
     /// ```
-    #[force_inline]
+    #[inline(always)]
     fn err(err: E) -> Result<T, E> {
         Result::<T, E> {
             _is_ok: false,
@@ -131,14 +131,14 @@ impl Result<T, E> {
     }
 
     /// Returns `true` if the result conains an OK variant, `false` otherwise
-    #[force_inline]
+    #[inline(always)]
     fn is_ok(self: &Result<T, E>) -> bool {
         self._is_ok
     }
 
 
     /// Returns `true` if the result conains an error variant, `false` otherwise
-    #[force_inline]
+    #[inline(always)]
     fn is_err(self: &Result<T, E>) -> bool {
         !self._is_ok
     }
@@ -419,7 +419,7 @@ mod internal {
     use fmt::{write, Formatter, Formattable};
 
     #[cold]
-    #[no_inline]
+    #[inline(never)]
     fn unwrap_panic_err<E>(err: E) -> ! {
         when E: Formattable<E, panicking::internal::PanicFormatter> {
             panic!("unwrap on an err value: {}", err)
@@ -429,7 +429,7 @@ mod internal {
     }
 
     #[cold]
-    #[no_inline]
+    #[inline(never)]
     fn unwrap_panic_ok<T>(ok: T) -> ! {
         when T: Formattable<T, panicking::internal::PanicFormatter> {
             panic!("unwrap on an ok value: {}", ok)

--- a/sysroot/std/runtime.alu
+++ b/sysroot/std/runtime.alu
@@ -82,14 +82,16 @@ mod internal {
     {
         /// Program entrypoint glue.
         ///
-        /// This is the entrypoint for the program. It is called by the C runtime after static
-        /// initialization. It converts the `argc` and `argv` arguments to a slice of strings
-        /// and calls the user-defined `main` function.
+        /// This is equivalent to C's `main`, not `_start` as we still want to use the C runtime for
+        /// invoking the static constructors.
+        ///
+        /// It converts the `argc` and `argv` arguments to a slice of strings, initializes the main thread
+        /// associated data (if threading is enabled) and then invokes the user-defined `main` function.
         #[export]
         #[cfg_attr(target_os="macos", link_name("_main"))]
         #[cfg_attr(not(target_os="macos"), link_name("main"))]
         #[lang(entrypoint_glue)]
-        fn c_main<UserMain: NamedFunction>(argc: libc::c_int, argv: &&libc::c_char) -> libc::c_int {
+        fn entrypoint<UserMain: NamedFunction>(argc: libc::c_int, argv: &&libc::c_char) -> libc::c_int {
             let func = std::util::unit::<UserMain>();
 
             #[cfg(threading)]

--- a/sysroot/std/runtime.alu
+++ b/sysroot/std/runtime.alu
@@ -86,9 +86,9 @@ mod internal {
         /// initialization. It converts the `argc` and `argv` arguments to a slice of strings
         /// and calls the user-defined `main` function.
         #[export]
-        #[codegen(c_main)]
+        #[link_name("main")]
         #[lang(entrypoint_glue)]
-        fn main<UserMain: NamedFunction>(argc: libc::c_int, argv: &&libc::c_char) -> libc::c_int {
+        fn c_main<UserMain: NamedFunction>(argc: libc::c_int, argv: &&libc::c_char) -> libc::c_int {
             let func = std::util::unit::<UserMain>();
 
             #[cfg(threading)]

--- a/sysroot/std/runtime.alu
+++ b/sysroot/std/runtime.alu
@@ -86,7 +86,8 @@ mod internal {
         /// initialization. It converts the `argc` and `argv` arguments to a slice of strings
         /// and calls the user-defined `main` function.
         #[export]
-        #[link_name("main")]
+        #[cfg_attr(target_os="macos", link_name("_main"))]
+        #[cfg_attr(not(target_os="macos"), link_name("main"))]
         #[lang(entrypoint_glue)]
         fn c_main<UserMain: NamedFunction>(argc: libc::c_int, argv: &&libc::c_char) -> libc::c_int {
             let func = std::util::unit::<UserMain>();

--- a/sysroot/std/sync.alu
+++ b/sysroot/std/sync.alu
@@ -80,19 +80,19 @@ impl Atomic<T: Primitive + !ZeroSized> {
     }
 
     /// Loads a value from the atomic variable.
-    #[force_inline]
+    #[inline(always)]
     fn load(self: &Atomic<T>, ordering: Ordering) -> T {
         intrinsics::codegen_func::<T>("__atomic_load_n", &self._inner, ordering as libc::c_int)
     }
 
     /// Stores a value into the atomic variable.
-    #[force_inline]
+    #[inline(always)]
     fn store(self: &mut Atomic<T>, value: T, ordering: Ordering) {
         intrinsics::codegen_func::<void>("__atomic_store_n", &self._inner, value, ordering as libc::c_int)
     }
 
     /// Stores a value into the atomic variable, atomically returning the old value.
-    #[force_inline]
+    #[inline(always)]
     fn exchange(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
         intrinsics::codegen_func::<T>("__atomic_exchange_n", &self._inner, value, ordering as libc::c_int)
     }
@@ -129,7 +129,7 @@ impl Atomic<T: Primitive + !ZeroSized> {
     /// assert_eq!(val.fetch_sqrt(Ordering::Relaxed), 144u64);
     /// assert_eq!(val.load(Ordering::Relaxed), 12u64);
     /// ```
-    #[force_inline]
+    #[inline(always)]
     fn compare_exchange(
         self: &mut Atomic<T>,
         expected: T,
@@ -159,7 +159,7 @@ impl Atomic<T: Primitive + !ZeroSized> {
     ///
     /// Returns previous value as an `Result::ok(...)` variant if the value was updated and as
     /// an `Result::err(...)` if it was not.
-    #[force_inline]
+    #[inline(always)]
     fn compare_exchange_weak(
         self: &mut Atomic<T>,
         expected: T,
@@ -246,44 +246,44 @@ impl Atomic<T: Primitive + !ZeroSized> {
 
 impl Atomic<T: Integer> {
     /// Atomically adds `value` to the atomic variable and returns the old value.
-    #[force_inline]
+    #[inline(always)]
     fn fetch_add(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
         intrinsics::codegen_func::<T>("__atomic_fetch_add", &self._inner, value, ordering as libc::c_int)
     }
 
     /// Atomically subtracts `value` from the atomic variable and returns the old value.
-    #[force_inline]
+    #[inline(always)]
     fn fetch_sub(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
         intrinsics::codegen_func::<T>("__atomic_fetch_sub", &self._inner, value, ordering as libc::c_int)
     }
 
     /// Atomically performs `*self &= value` and returns the old value.
-    #[force_inline]
+    #[inline(always)]
     fn fetch_and(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
         intrinsics::codegen_func::<T>("__atomic_fetch_and", &self._inner, value, ordering as libc::c_int)
     }
 
     /// Atomically performs `*self |= value` and returns the old value.
-    #[force_inline]
+    #[inline(always)]
     fn fetch_or(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
         intrinsics::codegen_func::<T>("__atomic_fetch_or", &self._inner, value, ordering as libc::c_int)
     }
 
     /// Atomically performs `*self ^= value` and returns the old value.
-    #[force_inline]
+    #[inline(always)]
     fn fetch_xor(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
         intrinsics::codegen_func::<T>("__atomic_fetch_xor", &self._inner, value, ordering as libc::c_int)
     }
 
     /// Atomically performs `*self = ~(*self & value)` and returns the old value.
-    #[force_inline]
+    #[inline(always)]
     fn fetch_nand(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
         intrinsics::codegen_func::<T>("__atomic_fetch_nand", &self._inner, value, ordering as libc::c_int)
     }
 }
 
 /// Memory barrier
-#[force_inline]
+#[inline(always)]
 fn fence(ordering: Ordering) {
     intrinsics::codegen_func::<void>("__atomic_thread_fence", ordering as libc::c_int)
 }
@@ -292,7 +292,7 @@ fn fence(ordering: Ordering) {
 ///
 /// This prevents the compiler from reordering memory accesses according to the
 /// memory access ordering, but does not prevent hardware reordering.
-#[force_inline]
+#[inline(always)]
 fn compiler_fence(ordering: Ordering) {
     intrinsics::codegen_func::<void>("__atomic_signal_fence", ordering as libc::c_int)
 }
@@ -311,7 +311,7 @@ fn compiler_fence(ordering: Ordering) {
 ///     spin_loop();
 /// }
 /// ```
-#[force_inline]
+#[inline(always)]
 fn spin_loop() {
     #[cfg(target_arch = "x86")]
     std::intrinsics::asm("pause");

--- a/sysroot/std/typing.alu
+++ b/sysroot/std/typing.alu
@@ -166,13 +166,13 @@ mod internal {
     type void_ptr_of<Ptr> = builtins::pointer_with_mut_of<void, Ptr>;
 
     #[lang(enum_variant_new)]
-    #[force_inline]
+    #[inline(always)]
     fn make_enum_variant<E>(name: &[u8], value: E) -> (&[u8], E) {
         (name, value)
     }
 
     #[lang(dyn_new)]
-    #[force_inline]
+    #[inline(always)]
     fn dyn_new<Protos, Ptr>(ptr: Ptr) -> dyn<Protos, void_ptr_of<Ptr>> {
         dyn {
             _ptr: ptr as void_ptr_of<Ptr>,
@@ -181,25 +181,25 @@ mod internal {
     }
 
     #[lang(dyn_const_coerce)]
-    #[force_inline]
+    #[inline(always)]
     fn dyn_const_coerce<Protos>(self: dyn<Protos, &mut void>) -> dyn<Protos, &void> {
         dyn { _ptr: self._ptr, _vtable: self._vtable }
     }
 
     #[lang(dyn_const_cast)]
-    #[force_inline]
+    #[inline(always)]
     fn dyn_const_cast<Protos>(self: dyn<Protos, &void>) -> dyn<Protos, &mut void> {
         dyn { _ptr: self._ptr as &mut void, _vtable: self._vtable }
     }
 
     #[lang(dyn_data)]
-    #[force_inline]
+    #[inline(always)]
     fn dyn_data<Protos, Ptr>(self: dyn<Protos, Ptr>) -> Ptr {
         self._ptr
     }
 
     #[lang(dyn_vtable_index)]
-    #[force_inline]
+    #[inline(always)]
     fn dyn_vtable_index<Protos, Ptr>(self: dyn<Protos, Ptr>, idx: usize) -> fn() {
         *(self._vtable + idx)
     }

--- a/tools/alumina-doc/markdown.alu
+++ b/tools/alumina-doc/markdown.alu
@@ -429,7 +429,7 @@ fn write_docstring<T: std::io::Writable<T>>(
             if cb_type == CodeBlockType::Bare {
                 writeln!(&doctest_source, "{}", docline);
             } else {
-                writeln!(&doctest_source, "   {}", docline);
+                writeln!(&doctest_source, "    {}", docline);
             }
             writeln!(writer, "{}", HtmlEscaped::str(docline));
         }


### PR DESCRIPTION
Title + a bunch of other fixes & features

- Rename `force_inline` and `no_inline` attributes to `inline(always)` and `inline(never)` respectively
- Add `packed` attribute and enforce power-of-2 alignment for `align` attribute
- Get rid of special attribute for program entrypoint
- `cfg_attr` attribute for conditional adornment of items with additional attributes
- fix Clang warning (`-Wunknown-warning-option`)
- replace quicksort partitioning with Hoare partitioning
- fix `get_current_directory` memory leak on error
- more documentation
- some other cosmetic changes