### PR TITLE
feat(compiler): Calculate struct size and alignment internally

### DIFF
--- a/examples/constants.alu
+++ b/examples/constants.alu
@@ -42,10 +42,14 @@ macro times($x, $y) {
 
 fn main() {
     use std::fmt::{hex, zero_pad};
+    use std::mem::size_of;
 
     // Constants can be used e.g. in array sizes
     let arr: [i32; EVAL3];
     println!("arr.len() = {}", arr.len());
+
+    let arr_of_ints: [u8; size_of::<i32>() * 10];
+    println!("arr_of_ints.len() = {}", arr_of_ints.len());
 
     println!("{}", AACS_ENCRYPTION_KEY);
 

--- a/src/alumina-boot/src/ast/mod.rs
+++ b/src/alumina-boot/src/ast/mod.rs
@@ -704,7 +704,7 @@ pub enum Attribute {
     Cold,
     TestMain,
     Inline,
-    Align(u32),
+    Align(usize),
     Packed,
     Transparent,
     NoInline,

--- a/src/alumina-boot/src/codegen/types.rs
+++ b/src/alumina-boot/src/codegen/types.rs
@@ -4,7 +4,7 @@ use crate::{
     ast::{Attribute, BuiltinType},
     codegen::w,
     common::AluminaError,
-    ir::{IRItem, Ty, TyP},
+    ir::{layout::LayoutCalculator, IRItem, Ty, TyP},
 };
 
 use super::{CName, CodegenCtx};
@@ -228,6 +228,26 @@ impl<'ir, 'gen> TypeWriterInner<'ir, 'gen> {
         Ok(())
     }
 
+    /// Special case for aggregates containing zero-sized types
+    fn get_min_alignment<I>(&self, it: I) -> Result<Option<usize>, AluminaError>
+    where
+        I: IntoIterator<Item = TyP<'ir>>,
+    {
+        let mut min_align = None;
+        let layout_calc = LayoutCalculator::new(self.ctx.global_ctx.clone());
+
+        for t in it {
+            if t.is_zero_sized() {
+                min_align = match min_align {
+                    None => Some(layout_calc.layout_of(t)?.align),
+                    Some(a) => Some(a.max(layout_calc.layout_of(t)?.align)),
+                }
+            }
+        }
+
+        Ok(min_align)
+    }
+
     fn write_type_body(&mut self, ty: TyP<'ir>) -> Result<(), AluminaError> {
         if !self.needs_body.contains(&ty) {
             return Ok(());
@@ -245,7 +265,12 @@ impl<'ir, 'gen> TypeWriterInner<'ir, 'gen> {
                         self.write_type_body(f.ty)?;
                     }
 
-                    w!(self.type_bodies, "struct {} {{\n", name);
+                    let mut attributes = " ".to_string();
+                    if let Some(align) = self.get_min_alignment(c.fields.iter().map(|f| f.ty))? {
+                        w!(attributes, "__attribute__((aligned({}))) ", align);
+                    }
+
+                    w!(self.type_bodies, "struct {}{} {{\n", attributes, name);
                     for f in c.fields.iter().filter(|f| !f.ty.is_zero_sized()) {
                         w!(
                             self.type_bodies,
@@ -266,11 +291,10 @@ impl<'ir, 'gen> TypeWriterInner<'ir, 'gen> {
 
                 self.write_type_body(inner)?;
 
-                w!(
-                    self.type_bodies,
-                    "union __attribute__((transparent_union)) {} {{\n",
-                    name
-                );
+                let mut attributes = " ".to_string();
+                w!(attributes, "__attribute__((transparent_union)) ");
+
+                w!(self.type_bodies, "union {}{} {{\n", attributes, name);
                 w!(self.type_bodies, "  {} __data[{}];\n", inner_name, len);
                 w!(self.type_bodies, "}};\n");
             }
@@ -284,18 +308,36 @@ impl<'ir, 'gen> TypeWriterInner<'ir, 'gen> {
 
                     let mut attributes = " ".to_string();
                     let mut is_transparent = false;
+                    let mut is_packed = false;
+                    let mut alignment = None;
 
                     for attr in s.attributes {
                         if let Attribute::Align(val) = attr {
-                            w!(attributes, "__attribute__((aligned({}))) ", *val);
+                            alignment = Some(*val);
                         }
                         if let Attribute::Packed = attr {
+                            is_packed = true;
                             w!(attributes, "__attribute__((packed)) ");
                         }
                         if let Attribute::Transparent = attr {
                             w!(attributes, "__attribute__((transparent_union)) ");
                             is_transparent = true;
                         }
+                    }
+
+                    if !is_packed {
+                        alignment = match (
+                            alignment,
+                            self.get_min_alignment(s.fields.iter().map(|f| f.ty))?,
+                        ) {
+                            (None, None) => None,
+                            (Some(a), None) | (None, Some(a)) => Some(a),
+                            (Some(a), Some(b)) => Some(a.max(b)),
+                        };
+                    }
+
+                    if let Some(alignment) = alignment {
+                        w!(attributes, "__attribute__((aligned({}))) ", alignment);
                     }
 
                     if s.is_union || is_transparent {
@@ -323,7 +365,12 @@ impl<'ir, 'gen> TypeWriterInner<'ir, 'gen> {
                     self.write_type_body(f)?;
                 }
 
-                w!(self.type_bodies, "struct {} {{\n", name);
+                let mut attributes = " ".to_string();
+                if let Some(align) = self.get_min_alignment(items.iter().copied())? {
+                    w!(attributes, "__attribute__((aligned({}))) ", align);
+                }
+
+                w!(self.type_bodies, "struct {}{} {{\n", attributes, name);
                 for (idx, f) in items.iter().enumerate().filter(|(_, f)| !f.is_zero_sized()) {
                     w!(self.type_bodies, "  {} _{};\n", self.ctx.get_type(f), idx);
                 }

--- a/src/alumina-boot/src/common.rs
+++ b/src/alumina-boot/src/common.rs
@@ -251,6 +251,8 @@ pub enum CodeErrorKind {
     CannotReadFile(String),
     #[error("type alias must have a target")] // unless it is a blessed builtin :)
     TypedefWithoutTarget,
+    #[error("type with infinite size (recursive type without indirection)")]
+    TypeWithInfiniteSize,
 
     // IR inlining is very restricitve at the moment, these may eventually be removed
     #[error("cannot IR-inline functions that use variables")]

--- a/src/alumina-boot/src/ir/layout.rs
+++ b/src/alumina-boot/src/ir/layout.rs
@@ -1,0 +1,180 @@
+use crate::{
+    ast::{Attribute, BuiltinType},
+    common::{AluminaError, CodeErrorBuilder, CodeErrorKind, CycleGuardian},
+    global_ctx::GlobalCtx,
+};
+
+use super::{IRItem, IRItemP, Ty, TyP};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum PointerWidth {
+    U32,
+    U64,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Layout {
+    pub size: usize,
+    pub align: usize,
+}
+
+impl Layout {
+    pub fn new(size: usize, align: usize) -> Self {
+        Self { size, align }
+    }
+
+    pub fn zst() -> Self {
+        Self::new(0, 1)
+    }
+
+    pub fn bool() -> Self {
+        Self::new(1, 1)
+    }
+
+    pub fn integer(bit_width: usize) -> Self {
+        Self::new(bit_width / 8, bit_width / 8)
+    }
+
+    pub fn pointer(pointer_size: PointerWidth) -> Self {
+        match pointer_size {
+            PointerWidth::U32 => Self::integer(32),
+            PointerWidth::U64 => Self::integer(64),
+        }
+    }
+
+    pub fn float(bit_width: usize) -> Self {
+        Self::new(bit_width / 8, bit_width / 8)
+    }
+
+    pub fn array(&self, len: usize) -> Self {
+        Self::new(self.size * len, self.align)
+    }
+}
+
+pub struct LayoutCalculator<'ir> {
+    pointer_width: PointerWidth,
+    cycle_guardian: CycleGuardian<IRItemP<'ir>>,
+}
+
+impl<'ir> LayoutCalculator<'ir> {
+    pub fn new(global_ctx: GlobalCtx) -> Self {
+        let pointer_width = match global_ctx
+            .cfg("target_pointer_width")
+            .as_ref()
+            .map(|s| s.as_deref())
+        {
+            Some(Some("64")) => PointerWidth::U64,
+            Some(Some("32")) => PointerWidth::U32,
+            _ => panic!("unsupported target_pointer_width"),
+        };
+
+        Self {
+            pointer_width,
+            cycle_guardian: CycleGuardian::new(),
+        }
+    }
+
+    fn size_of_aggregate<I>(
+        &self,
+        custom_align: Option<usize>,
+        is_union: bool,
+        is_packed: bool,
+        fields: I,
+    ) -> Result<Layout, AluminaError>
+    where
+        I: IntoIterator<Item = TyP<'ir>>,
+    {
+        let mut align = 1;
+        let mut size = 0;
+
+        for field_ty in fields {
+            let field_layout = self.layout_of(field_ty)?;
+            let field_align = if is_packed { 1 } else { field_layout.align };
+
+            align = align.max(field_align);
+            if is_union {
+                size = size.max(field_layout.size);
+            } else {
+                size = (size + field_align - 1) / field_align * field_align; // add padding between fields
+                size += field_layout.size;
+            }
+        }
+
+        align = align.max(custom_align.unwrap_or(1));
+        size = (size + align - 1) / align * align; // add padding at the end
+
+        Ok(Layout::new(size, align))
+    }
+
+    pub fn layout_of_item(&self, item: IRItemP<'ir>) -> Result<Layout, AluminaError> {
+        let _guard = self
+            .cycle_guardian
+            .guard(item)
+            .map_err(|_| CodeErrorKind::TypeWithInfiniteSize)
+            .with_no_span()?;
+
+        let ret = match item.get().with_no_span()? {
+            IRItem::StructLike(s) => {
+                let mut custom_align = None;
+                let mut is_packed = false;
+
+                for attr in s.attributes {
+                    match attr {
+                        Attribute::Align(a) => custom_align = Some(*a),
+                        Attribute::Packed => is_packed = true,
+                        Attribute::Transparent => {}
+                        _ => {}
+                    }
+                }
+                self.size_of_aggregate(
+                    custom_align,
+                    s.is_union,
+                    is_packed,
+                    s.fields.iter().map(|f| f.ty),
+                )?
+            }
+            IRItem::Alias(i) => self.layout_of(i)?,
+            IRItem::Protocol(_) => Layout::zst(),
+            IRItem::Function(_) => Layout::zst(),
+            IRItem::Enum(e) => self.layout_of(e.underlying_type)?,
+            IRItem::Static(_) => unreachable!(),
+            IRItem::Const(_) => unreachable!(),
+            IRItem::Closure(c) => {
+                self.size_of_aggregate(None, false, false, c.fields.iter().map(|f| f.ty))?
+            }
+        };
+
+        Ok(ret)
+    }
+
+    pub fn layout_of(&self, ty: TyP<'ir>) -> Result<Layout, AluminaError> {
+        match ty {
+            Ty::Array(inner, len) => {
+                let inner_layout = self.layout_of(inner)?;
+                Ok(inner_layout.array(*len))
+            }
+            Ty::Builtin(kind) => match kind {
+                BuiltinType::Void => Ok(Layout::zst()),
+                BuiltinType::Never => Ok(Layout::zst()),
+                BuiltinType::Bool => Ok(Layout::bool()),
+                BuiltinType::U8 | BuiltinType::I8 => Ok(Layout::integer(8)),
+                BuiltinType::U16 | BuiltinType::I16 => Ok(Layout::integer(16)),
+                BuiltinType::U32 | BuiltinType::I32 => Ok(Layout::integer(32)),
+                BuiltinType::U64 | BuiltinType::I64 => Ok(Layout::integer(64)),
+                BuiltinType::U128 | BuiltinType::I128 => Ok(Layout::integer(128)),
+                BuiltinType::USize | BuiltinType::ISize => Ok(Layout::pointer(self.pointer_width)),
+                BuiltinType::F32 => Ok(Layout::float(32)),
+                BuiltinType::F64 => Ok(Layout::float(64)),
+            },
+
+            Ty::Pointer(_, _) => Ok(Layout::pointer(self.pointer_width)),
+            Ty::NamedFunction(_) => Ok(Layout::zst()),
+            Ty::FunctionPointer(_, _) => Ok(Layout::pointer(self.pointer_width)),
+            Ty::Tuple(elems) => self.size_of_aggregate(None, false, false, elems.iter().copied()),
+            Ty::Closure(item) | Ty::NamedType(item) => self.layout_of_item(item),
+
+            Ty::Protocol(_) => Ok(Layout::zst()),
+            Ty::Unqualified(_) => todo!(),
+        }
+    }
+}

--- a/src/alumina-boot/src/ir/mod.rs
+++ b/src/alumina-boot/src/ir/mod.rs
@@ -5,6 +5,7 @@ pub mod elide_zst;
 pub mod infer;
 pub mod ir_inline;
 pub mod lang;
+pub mod layout;
 pub mod mono;
 
 use crate::{
@@ -250,7 +251,7 @@ impl<'ir> Ty<'ir> {
     pub fn is_zero_sized(&self) -> bool {
         match self {
             Ty::Builtin(BuiltinType::Void) => true,
-            Ty::Builtin(BuiltinType::Never) => true, // or false? dunno, never type is weird
+            Ty::Builtin(BuiltinType::Never) => true,
             Ty::Builtin(_) => false,
             Ty::Protocol(_) => unreachable!("used protocol as a concrete type"),
             Ty::NamedType(inner) => match inner.get().unwrap() {

--- a/src/alumina-boot/src/visitors.rs
+++ b/src/alumina-boot/src/visitors.rs
@@ -348,7 +348,7 @@ impl<'ast, 'src> AluminaVisitor<'src> for AttributeVisitor<'ast, 'src> {
 
         match name {
             "align" => {
-                let align: u32 = node
+                let align: usize = node
                     .child_by_field_name("arguments")
                     .and_then(|n| n.child_by_field_name("argument"))
                     .map(|n| self.code.node_text(n))

--- a/src/aluminac/lib/node_kinds.alu
+++ b/src/aluminac/lib/node_kinds.alu
@@ -171,7 +171,7 @@ enum FieldKind {
     Value = 53u16,
 }
 
-static NODE_KINDS: [NodeKind; 253] = [
+const NODE_KINDS: [NodeKind; 253] = [
     NodeKind::Invalid,
     NodeKind::Identifier,
     NodeKind::DocComment,

--- a/src/tests/lang.alu
+++ b/src/tests/lang.alu
@@ -58,44 +58,251 @@ fn test_linear_scope_shadowing_mixed() {
     assert_eq!(foo(), 4);
 }
 
-#[test]
-fn test_align_attribute() {
-    use std::mem::align_of;
-
-    #[align(1)] struct A1 { val: u8 }
-    #[align(2)] struct A2 { val: u8 }
-    #[align(4)] struct A4 { val: u8 }
-    #[align(8)] struct A8 { val: u8 }
-    #[align(16)] struct A16 { val: u8 }
-    #[align(32)] struct A32 { val: u8 }
-    #[align(64)] struct A64 { val: u8 }
-
-    assert_eq!(align_of::<A1>(), 1);
-    assert_eq!(align_of::<A2>(), 2);
-    assert_eq!(align_of::<A4>(), 4);
-    assert_eq!(align_of::<A8>(), 8);
-    assert_eq!(align_of::<A16>(), 16);
-    assert_eq!(align_of::<A32>(), 32);
-    assert_eq!(align_of::<A64>(), 64);
-}
-
-#[test]
-fn test_packed_attribute() {
-    use std::mem::align_of;
-
-    struct S1 { val: u8, ptr: &void }
-    #[packed] struct S2 { val: u8, ptr: &void }
-
-    let s1: S1;
-    let s2: S2;
-
-    assert!((&s1.ptr as usize) - (&s1 as usize) > 1usize);
-    assert_eq!((&s2.ptr as usize) - (&s2 as usize), 1usize);
-}
-
 
 #[test]
 fn test_no_int_promotion() {
     let a = 63u8;
     assert!(a < ~a);
+}
+
+fn assert_layout<T>(size: usize, align: usize) {
+    use std::mem::{align_of, size_of};
+
+    assert_eq!(size_of::<T>(), size);
+    assert_eq!(align_of::<T>(), align);
+
+    // Check that our own layout computation agrees with C's.
+    when T: !std::builtins::ZeroSized {
+        assert_eq!(std::intrinsics::codegen_type_func::<T, usize>("sizeof"), size);
+        assert_eq!(std::intrinsics::codegen_type_func::<T, usize>("_Alignof"), align);
+    }
+}
+
+#[test]
+fn test_builtin_layout() {
+    use std::mem::{align_of, size_of};
+
+    assert_layout::<bool>(1, 1);
+    assert_layout::<u8>(1, 1);
+    assert_layout::<u16>(2, 2);
+    assert_layout::<u32>(4, 4);
+    assert_layout::<u64>(8, 8);
+
+    #[cfg(target_pointer_width = "64")]
+    assert_layout::<usize>(8, 8);
+    #[cfg(target_pointer_width = "32")]
+    assert_layout::<usize>(4, 4);
+
+    assert_layout::<u128>(16, 16);
+
+    assert_layout::<i8>(1, 1);
+    assert_layout::<i16>(2, 2);
+    assert_layout::<i32>(4, 4);
+    assert_layout::<i64>(8, 8);
+
+    #[cfg(target_pointer_width = "64")]
+    assert_layout::<isize>(8, 8);
+    #[cfg(target_pointer_width = "32")]
+    assert_layout::<isize>(4, 4);
+
+    assert_layout::<i128>(16, 16);
+
+    assert_layout::<f32>(4, 4);
+    assert_layout::<f64>(8, 8);
+
+    assert_layout::<()>(0, 1);
+    assert_layout::<!>(0, 1);
+
+    #[cfg(target_pointer_width = "64")]
+    {
+        assert_layout::<&u8>(8, 8);
+        assert_layout::<&mut u8>(8, 8);
+        assert_layout::<fn()>(8, 8);
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    {
+        assert_layout::<&u8>(4, 4);
+        assert_layout::<&mut u8>(4, 4);
+        assert_layout::<fn()>(4, 4);
+    }
+
+    // named functions are ZSTs
+    assert_layout::<test_builtin_layout>(0, 1);
+}
+
+#[test]
+fn test_struct_layout() {
+    use std::mem::{align_of, size_of};
+
+    struct S {}
+    assert_layout::<S>(0, 1);
+
+    struct S { a: u8 }
+    assert_layout::<S>(1, 1);
+
+    struct S { a: u8, b: u8 }
+    assert_layout::<S>(2, 1);
+
+    struct S { a: u8, b: u32, c: u8 }
+    assert_layout::<S>(12, 4);
+
+    struct S { a: u32, b: u8, c: u8 }
+    assert_layout::<S>(8, 4);
+
+    struct S { a: (), b: u32, c: () }
+    assert_layout::<S>(4, 4);
+
+    struct S { a: (), b: u128, c: () }
+    assert_layout::<S>(16, 16);
+
+    #[packed] struct S { a: u32, b: u8, c: u8 }
+    assert_layout::<S>(6, 1);
+
+    // tuple is still padded internally, but struct is not
+    #[packed] struct S { a: u32, b: (u8, u128), c: u8 }
+    assert_layout::<S>(37, 1);
+
+    #[packed] struct Inner { a: u8, b: u128 }
+    #[packed] struct S { a: u32, b: Inner, c: u8 }
+    assert_layout::<S>(22, 1);
+
+    #[align(1)] struct S { val: u8 }
+    assert_layout::<S>(1, 1);
+
+    #[align(2)] struct S { val: u8 }
+    assert_layout::<S>(2, 2);
+
+    #[align(4)] struct S { val: u8 }
+    assert_layout::<S>(4, 4);
+
+    #[align(8)] struct S { val: u8 }
+    assert_layout::<S>(8, 8);
+
+    #[align(16)] struct S { val: u8 }
+    assert_layout::<S>(16, 16);
+
+    #[align(32)] struct S { val: u8 }
+    assert_layout::<S>(32, 32);
+
+    #[align(64)] struct S { val: u8 }
+    assert_layout::<S>(64, 64);
+
+    // align attribute is minimum, not exact alignment
+    #[align(1)] struct S { a: u8, b: u32 }
+    assert_layout::<S>(8, 4);
+}
+
+#[test]
+fn test_union_layout() {
+    use std::mem::{align_of, size_of};
+
+    union U { }
+    assert_layout::<U>(0, 1);
+
+    union U { a: () }
+    assert_layout::<U>(0, 1);
+
+    union U { a: u8, b: u8 }
+    assert_layout::<U>(1, 1);
+
+    union U { a: u8, b: u32 }
+    assert_layout::<U>(4, 4);
+
+    union U { a: u32, b: u8 }
+    assert_layout::<U>(4, 4);
+
+    union U { a: u32, b: u8, c: u8 }
+    assert_layout::<U>(4, 4);
+
+    union U { a: (), b: u32, c: () }
+    assert_layout::<U>(4, 4);
+
+    union U { a: (), b: u128, c: () }
+    assert_layout::<U>(16, 16);
+
+    #[packed] union U { a: u32, b: u8, c: u8 }
+    assert_layout::<U>(4, 1);
+
+    union Inner { a: u8, b: u128 }
+    #[packed] union U { a: u32, b: Inner, c: u8 }
+    assert_layout::<U>(16, 1);
+
+    #[packed] union Inner { a: u8, b: u128 }
+    #[packed] union U { a: u32, b: Inner, c: u8 }
+    assert_layout::<U>(16, 1);
+}
+
+#[test]
+fn test_tuple_layout() {
+    use std::mem::{align_of, size_of};
+
+    assert_layout::<()>(0, 1);
+    assert_layout::<(u8,)>(1, 1);
+
+    assert_layout::<((), u64)>(8, 8);
+    assert_layout::<(u8, u64)>(16, 8);
+    assert_layout::<(u8, u64)>(16, 8);
+}
+
+#[test]
+fn test_closure_layout() {
+    use std::mem::{align_of, size_of};
+
+    let f = || {};
+    assert_layout::<typeof(f)>(0, 1);
+
+    let f = |a: u8| {};
+    assert_layout::<typeof(f)>(0, 1);
+
+    let a: ();
+    let b: u8;
+    let c: u64;
+
+    let f = |=a| {};
+    assert_layout::<typeof(f)>(0, 1);
+    let f = |=a, =b| {};
+    assert_layout::<typeof(f)>(1, 1);
+    let f = |=a, =b, =c| {};
+    assert_layout::<typeof(f)>(16, 8);
+}
+
+#[test]
+fn test_array_layout() {
+    use std::mem::{align_of, size_of};
+
+    assert_layout::<[u8; 0]>(0, 1);
+    assert_layout::<[u8; 1]>(1, 1);
+    assert_layout::<[u8; 2]>(2, 1);
+    assert_layout::<[u8; 3]>(3, 1);
+
+    assert_layout::<[u64; 0]>(0, 8);
+    assert_layout::<[u64; 1]>(8, 8);
+    assert_layout::<[u64; 2]>(16, 8);
+    assert_layout::<[u64; 3]>(24, 8);
+}
+
+#[test]
+fn test_nested_zst_layout() {
+    use std::mem::{align_of, size_of};
+
+    #[packed] struct S { a: u8, b: [u64; 0] }
+    assert_layout::<S>(1, 1);
+
+    // ZST structs do not affect the size of the aggregate they are nested in,
+    // but they do affect the alignment.
+
+    #[align(64)] struct BigZst {}
+
+    struct S { a: u8, b: [u64; 0] }
+    assert_layout::<S>(8, 8);
+
+    struct S { b: BigZst }
+    assert_layout::<S>(0, 64);
+
+    struct S { a: u8, b: BigZst }
+    assert_layout::<S>(64, 64);
+
+    struct S { a: u8, b: [[u64; 0]; 1] }
+    assert_layout::<S>(8, 8);
 }

--- a/sysroot/std/builtins.alu
+++ b/sysroot/std/builtins.alu
@@ -1444,9 +1444,9 @@ mod internal {
     /// equality and comparison operators.
     protocol BuiltinComparable<Self: builtins::Numeric> {
         /// @ cmp::Equatable::equals
-        #[inline(always)] fn equals(lhs: &Self, rhs: &Self) -> bool { *lhs == *rhs }
+        #[inline(ir)] fn equals(lhs: &Self, rhs: &Self) -> bool { *lhs == *rhs }
         /// @ cmp::Equatable::not_equals
-        #[inline(always)] fn not_equals(lhs: &Self, rhs: &Self) -> bool { *lhs != *rhs }
+        #[inline(ir)] fn not_equals(lhs: &Self, rhs: &Self) -> bool { *lhs != *rhs }
         /// @ cmp::Comparable::compare
         #[inline(always)]
         fn compare(lhs: &Self, rhs: &Self) -> Ordering {
@@ -1460,13 +1460,13 @@ mod internal {
         }
 
         /// @ cmp::Comparable::less_than
-        #[inline(always)] fn less_than(lhs: &Self, rhs: &Self) -> bool { *lhs < *rhs }
+        #[inline(ir)] fn less_than(lhs: &Self, rhs: &Self) -> bool { *lhs < *rhs }
         /// @ cmp::Comparable::less_than_or_equal
-        #[inline(always)] fn less_than_or_equal(lhs: &Self, rhs: &Self) -> bool { *lhs <= *rhs }
+        #[inline(ir)] fn less_than_or_equal(lhs: &Self, rhs: &Self) -> bool { *lhs <= *rhs }
         /// @ cmp::Comparable::greater_than
-        #[inline(always)] fn greater_than(lhs: &Self, rhs: &Self) -> bool { *lhs > *rhs }
+        #[inline(ir)] fn greater_than(lhs: &Self, rhs: &Self) -> bool { *lhs > *rhs }
         /// @ cmp::Comparable::greater_than_or_equal
-        #[inline(always)] fn greater_than_or_equal(lhs: &Self, rhs: &Self) -> bool { *lhs >= *rhs }
+        #[inline(ir)] fn greater_than_or_equal(lhs: &Self, rhs: &Self) -> bool { *lhs >= *rhs }
     }
 
     /// Mixin for parsing integers from strings.
@@ -1950,19 +1950,19 @@ mod internal {
     /// Mixin for common floating point functions
     protocol FloatOps<Self> {
         /// Returns `NaN`.
-        #[inline]
+        #[inline(ir)]
         fn nan() -> Self {
             (0.0 as Self) / (0.0 as Self)
         }
 
         /// Returns a positive infinity.
-        #[inline]
+        #[inline(ir)]
         fn infinity() -> Self {
             (1.0 as Self) / (0.0 as Self)
         }
 
         /// Returns a negative infinity.
-        #[inline]
+        #[inline(ir)]
         fn neg_infinity() -> Self {
             (-1.0 as Self) / (0.0 as Self)
         }
@@ -2076,12 +2076,12 @@ mod tests {
         // Totally not an excuse to work in some Shakespeare...
         #[cfg(target_endian = "little")]
         assert_eq!(0x100u16
-            .to_be() | ~ to_be
+            .to_be() | ~ to_be //, that is the question
         (0x1u16), 0xfeffu16);
 
         #[cfg(target_endian = "big")]
         assert_eq!(0x100u16
-            .to_be() | ~ to_be
+            .to_be() | ~ to_be //, that is the question
         (0x1u16), 0xfffeu16);
     }
 

--- a/sysroot/std/collections/vector.alu
+++ b/sysroot/std/collections/vector.alu
@@ -336,8 +336,8 @@ impl Vector {
         Result::ok(())
     }
 
-    /// @ std::fmt::Formatter::write_char
-    fn write_char(self: &mut Vector<u8>, c: u8) -> Result<(), fmt::Error> {
+    /// @ std::fmt::Formatter::write_byte
+    fn write_byte(self: &mut Vector<u8>, c: u8) -> Result<(), fmt::Error> {
         self.push(c);
         Result::ok(())
     }

--- a/sysroot/std/fmt.alu
+++ b/sysroot/std/fmt.alu
@@ -32,7 +32,7 @@ protocol Formatter<Self> {
     /// Write a string
     fn write_str(self: &mut Self, buf: &[u8]) -> Result;
     /// Write a single character
-    fn write_char(self: &mut Self, byte: u8) -> Result {
+    fn write_byte(self: &mut Self, byte: u8) -> Result {
         self.write_str(mem::slice::from_raw(&byte, 1))
     }
 }
@@ -199,9 +199,9 @@ impl SliceFormatter {
         Result::ok(())
     }
 
-    /// @ Formatter::write_char
+    /// @ Formatter::write_byte
     #[inline]
-    fn write_char(self: &mut SliceFormatter, byte: u8) -> Result {
+    fn write_byte(self: &mut SliceFormatter, byte: u8) -> Result {
         if self.buf_pos >= self.buf.len() {
             return Result::err(Error::new());
         }
@@ -226,8 +226,8 @@ impl NullFormatter {
     fn write_str(self: &mut NullFormatter, buf: &[u8]) -> Result {
         Result::ok(())
     }
-    /// @ Formatter::write_char
-    fn write_char(self: &mut NullFormatter, byte: u8) -> Result {
+    /// @ Formatter::write_byte
+    fn write_byte(self: &mut NullFormatter, byte: u8) -> Result {
         Result::ok(())
     }
 }
@@ -257,11 +257,11 @@ impl StreamFormatter<W: io::Writable<W>> {
         }
     }
 
-    /// @ Formatter::write_char
+    /// @ Formatter::write_byte
     #[inline]
-    fn write_char(self: &mut StreamFormatter<W>, byte: u8) -> Result {
+    fn write_byte(self: &mut StreamFormatter<W>, byte: u8) -> Result {
         when W: Formattable<W> {
-            self.inner.write_char(byte)
+            self.inner.write_byte(byte)
         } else {
             self.write_str(mem::slice::from_raw(&byte, 1))
         }
@@ -286,7 +286,7 @@ mod internal {
 
         when T: builtins::Signed {
             if val < 0 {
-                fmt.write_char('-')?;
+                fmt.write_byte('-')?;
             }
         }
 
@@ -298,7 +298,7 @@ mod internal {
 
             if val_u == 0 {
                 while i + 1 < pad {
-                    fmt.write_char('0')?;
+                    fmt.write_byte('0')?;
                     pad -= 1;
                 }
                 fmt.write_str(buf[(buf.len() - i - 1)..])?;
@@ -420,7 +420,7 @@ mod internal {
 
             if s.len() < self.len {
                 for _ in (0usize..self.len - s.len()) {
-                    fmt.write_char(self.pad)?;
+                    fmt.write_byte(self.pad)?;
                 }
             }
             fmt.write_str(s)

--- a/sysroot/std/intrinsics.alu
+++ b/sysroot/std/intrinsics.alu
@@ -89,4 +89,6 @@ extern "intrinsic" fn uninitialized<T>() -> T;
     extern "intrinsic" fn codegen_const<T>(name: &[u8]) -> T;
     /// Call a builtin C function
     extern "intrinsic" fn codegen_func<T>(name: &[u8], ...) -> T;
+    /// Call a builtin C "type function" (e.g. sizeof)
+    extern "intrinsic" fn codegen_type_func<T, Ret>(name: &[u8]) -> T;
 }

--- a/sysroot/std/option.alu
+++ b/sysroot/std/option.alu
@@ -88,7 +88,7 @@ impl Option<T> {
     /// assert!(opt.is_some());
     /// assert_eq!(opt.unwrap(), 42);
     /// ```
-    #[inline(always)]
+    #[inline(ir)]
     fn some(inner: T) -> Option<T> {
         Option::<T> {
             _is_some: true,
@@ -104,7 +104,7 @@ impl Option<T> {
     ///
     /// assert!(opt.is_none());
     /// ```
-    #[inline(always)]
+    #[inline(ir)]
     fn none() -> Option<T> {
         Option::<T> {
             _is_some: false,
@@ -113,13 +113,13 @@ impl Option<T> {
     }
 
     /// Returns `true` if the option is populated, `false` otherwise.
-    #[inline(always)]
+    #[inline(ir)]
     fn is_some(self: &Option<T>) -> bool {
         self._is_some
     }
 
     /// Returns `true` if the option is empty, `false` otherwise.
-    #[inline(always)]
+    #[inline(ir)]
     fn is_none(self: &Option<T>) -> bool {
         !self._is_some
     }

--- a/sysroot/std/panicking.alu
+++ b/sysroot/std/panicking.alu
@@ -88,7 +88,7 @@ mod internal {
             info.file, info.line, info.column
         )?;
         fmt::internal::write_fmt(info.args, &formatter);
-        formatter.write_char('\n')?;
+        formatter.write_byte('\n')?;
 
         #[cfg(all(debug, not(no_backtrace), not(target_os = "android")))]
         {

--- a/sysroot/std/result.alu
+++ b/sysroot/std/result.alu
@@ -101,7 +101,7 @@ impl Result<T, E> {
     /// assert!(r.is_ok());
     /// assert_eq!(r.unwrap(), 10);
     /// ```
-    #[inline(always)]
+    #[inline(ir)]
     fn ok(ok: T) -> Result<T, E> {
         Result::<T, E> {
             _is_ok: true,
@@ -120,7 +120,7 @@ impl Result<T, E> {
     /// assert!(r.is_err());
     /// assert_eq!(r.unwrap_err(), 42);
     /// ```
-    #[inline(always)]
+    #[inline(ir)]
     fn err(err: E) -> Result<T, E> {
         Result::<T, E> {
             _is_ok: false,
@@ -131,14 +131,14 @@ impl Result<T, E> {
     }
 
     /// Returns `true` if the result conains an OK variant, `false` otherwise
-    #[inline(always)]
+    #[inline(ir)]
     fn is_ok(self: &Result<T, E>) -> bool {
         self._is_ok
     }
 
 
     /// Returns `true` if the result conains an error variant, `false` otherwise
-    #[inline(always)]
+    #[inline(ir)]
     fn is_err(self: &Result<T, E>) -> bool {
         !self._is_ok
     }

--- a/sysroot/std/time.alu
+++ b/sysroot/std/time.alu
@@ -336,7 +336,7 @@ impl Duration {
         use fmt::{write, zero_pad};
 
         let abs = if self.is_negative() {
-            f.write_char('-')?;
+            f.write_byte('-')?;
             Duration::zero().sub(self)
         } else {
             *self

--- a/tools/alumina-doc/markdown.alu
+++ b/tools/alumina-doc/markdown.alu
@@ -209,7 +209,7 @@ impl HtmlEscaped {
                 '&' => f.write_str("&amp;")?,
                 '<' => f.write_str("&lt;")?,
                 '>' => f.write_str("&gt;")?,
-                _ => f.write_char(ch)?
+                _ => f.write_byte(ch)?
             }
         }
 

--- a/tools/tree-sitter-codegen/main.alu
+++ b/tools/tree-sitter-codegen/main.alu
@@ -45,10 +45,10 @@ impl SanitizedIdentifier {
                             first_char = true;
                         }
                         if ch != '_' {
-                            f.write_char(ch)?;
+                            f.write_byte(ch)?;
                         }
                     } else {
-                        f.write_char(ch)?;
+                        f.write_byte(ch)?;
                     }
                     continue;
             }
@@ -131,7 +131,7 @@ fn main(args: &[&[u8]]) {
     }
     println!("}}");
     println!("")
-    println!("static NODE_KINDS: [NodeKind; {}] = [", language.symbols().size_hint().unwrap() + 1)
+    println!("const NODE_KINDS: [NodeKind; {}] = [", language.symbols().size_hint().unwrap() + 1)
     for symbol in (0 as TSSymbol)..(max_symbol_id + 1) {
         if symbol == 0 || language.symbol_type(symbol) != TSSymbolType::Regular {
             println!("    NodeKind::Invalid,");


### PR DESCRIPTION
Implementations of `size_of` and `align_of` intrinsics previously just defered to the C's `sizeof` and `_Alignof`, which meant that they could not be used in const expressions.

This change brings struct layout calculation to Alumina proper. Also clarifies and fixes with the layout of ZSTs with alignment > 1. 