### PR TITLE
perf(compiler): Convert node & field kinds to enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "clap",
  "colored",
  "indexmap",
+ "itertools",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -154,6 +155,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
 name = "gimli"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +195,15 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,18 @@ quick: $(BUILD_DIR)/quick
 	ln -sf $^.c $@.c
 	ln -sf $^ $@
 
+## ------------------------------ Benchmarking -------------------------
+
+.PHONY: bench-std bench-std-cc
+
+BENCH_CMD = ./tools/bench.py -n$(if $(TIMES),$(TIMES),20) $(if $(MARKDOWN),--markdown,)
+
+bench-std: $(ALUMINA_BOOT) $(SYSROOT_FILES)
+	$(BENCH_CMD) $(ALUMINA_BOOT) $(ALUMINA_FLAGS) --timings --cfg test --cfg test_std --output /dev/null
+
+bench-std-cc: $(STDLIB_TESTS).c
+	$(BENCH_CMD) $(CC) $(CFLAGS) -o/dev/null $^ $(LDFLAGS)
+
 ## ------------------------------ Dist ----------------------------------
 
 .PHONY: lint-rust dist-check

--- a/src/alumina-boot/Cargo.toml
+++ b/src/alumina-boot/Cargo.toml
@@ -12,6 +12,7 @@ quote = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 proc-macro2 = "1.0"
+itertools = "0.10.5"
 
 [dependencies]
 regex = "1"

--- a/src/alumina-boot/build.rs
+++ b/src/alumina-boot/build.rs
@@ -1,29 +1,51 @@
+use std::collections::HashMap;
+use std::env;
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
-use std::{env, iter::once};
 
 use quote::{format_ident, quote};
 use serde::Deserialize;
-use serde_json::from_reader;
+use serde_json::from_slice;
 use std::fs::File;
 use std::io::Write;
 use syn::{parse_quote, TraitItem};
 
+use itertools::Itertools;
+
 #[derive(Deserialize)]
-struct Node {
-    r#type: String,
-    named: bool,
+struct Item {
+    name: String,
+    id: i32,
 }
 
-fn sanitize_identifier(name: &str) -> String {
+#[derive(Deserialize)]
+struct LanguageInfo {
+    fields: Vec<Item>,
+    symbols: Vec<Item>,
+}
+
+fn sanitize_identifier(name: &str, pascal_case: bool) -> String {
     let mut result = String::with_capacity(name.len());
+    let mut first_char = true;
     for c in name.chars() {
         if ('a'..='z').contains(&c)
             || ('A'..='Z').contains(&c)
             || ('0'..='9').contains(&c)
             || c == '_'
         {
-            result.push(c);
+            if pascal_case {
+                if c == '_' {
+                    first_char = true;
+                } else if first_char {
+                    result.push(c.to_ascii_uppercase());
+                    first_char = false;
+                } else {
+                    result.push(c);
+                }
+            } else {
+                result.push(c);
+            }
         } else {
             let replacement = match c {
                 '~' => "TILDE",
@@ -71,40 +93,82 @@ fn sanitize_identifier(name: &str) -> String {
     result
 }
 
-fn generate_visitor(filename: PathBuf) -> String {
-    let file = File::open(filename).unwrap();
-    let parsed: Vec<Node> = from_reader(file).expect("could not parse the node types JSON");
-
-    let (trait_fns, match_arms): (Vec<_>, Vec<_>) = parsed
-        .into_iter()
-        .filter(|node| node.named)
-        .chain(once(Node {
-            r#type: "ERROR".to_string(),
-            named: true,
-        }))
-        .map(|symbol| {
-            let raw_name = &symbol.r#type;
-            let sanitized_name = sanitize_identifier(&symbol.r#type);
-            let method_name = format_ident!("visit_{}", sanitized_name);
-            let doc_name = format!("{:?}", raw_name).replace('`', "\\`");
-            let doc_string = format!("Visits a node of type `{}`", doc_name);
-
-            let trait_fn: TraitItem = parse_quote! {
-                #[doc=#doc_string]
-                #[allow(non_snake_case)]
-                #[allow(unused_variables)]
-                fn #method_name(&mut self, node: ::tree_sitter::Node<'tree>) -> Self::ReturnType {
-                    unimplemented!(#sanitized_name)
-                }
+fn generate_visitor(language_info: LanguageInfo) -> String {
+    let fields = language_info
+        .fields
+        .iter()
+        .map(|field| {
+            let name = sanitize_identifier(&field.name, true);
+            let id = field.id as u16;
+            let ident = format_ident!("{}", name);
+            let field = quote! {
+                #ident = #id,
             };
-
-            let match_arm = quote! {
-                #raw_name => self.#method_name(node)
-            };
-
-            (trait_fn, match_arm)
+            field
         })
-        .unzip();
+        .collect::<Vec<_>>();
+
+    let mut node_kinds = Vec::new();
+    let mut trait_fns = Vec::new();
+    let mut match_arms = Vec::new();
+
+    let mut id_map = HashMap::new();
+
+    for (raw_name, ids) in language_info
+        .symbols
+        .into_iter()
+        .map(|a| (a.name, a.id as u16))
+        .into_group_map()
+        .into_iter()
+        .sorted_by_key(|(_, ids)| ids[0])
+    {
+        let enum_name = sanitize_identifier(&raw_name, true);
+        let sanitized_name = sanitize_identifier(&raw_name, false);
+        let method_name = format_ident!("visit_{}", sanitized_name);
+        let enum_member_name = format_ident!("{}", enum_name);
+        let doc_name = format!("{:?}", raw_name).replace('`', "\\`");
+        let doc_string = format!("Visits a node of type `{}`", doc_name);
+
+        let trait_fn: TraitItem = parse_quote! {
+            #[doc=#doc_string]
+            #[allow(non_snake_case)]
+            #[allow(unused_variables)]
+            fn #method_name(&mut self, node: ::tree_sitter::Node<'tree>) -> Self::ReturnType {
+                unimplemented!(#sanitized_name)
+            }
+        };
+
+        let match_arm = quote! {
+            NodeKind::#enum_member_name => self.#method_name(node)
+        };
+
+        let enum_member = quote! {
+            #enum_member_name,
+        };
+
+        node_kinds.push(enum_member);
+        trait_fns.push(trait_fn);
+        match_arms.push(match_arm);
+
+        id_map.extend(ids.into_iter().map(|id| (id, enum_member_name.clone())));
+    }
+
+    let mut node_kind_map = Vec::new();
+
+    let max_id = id_map.iter().map(|(id, _)| *id).max().unwrap();
+    for i in 0..=max_id {
+        if let Some(enum_member) = id_map.get(&i) {
+            node_kind_map.push(quote! {
+                NodeKind::#enum_member,
+            });
+        } else {
+            node_kind_map.push(quote! {
+                NodeKind::Unknown,
+            });
+        }
+    }
+
+    let node_kind_map_len = node_kind_map.len();
 
     let return_item: TraitItem = parse_quote! {
         type ReturnType;
@@ -113,7 +177,7 @@ fn generate_visitor(filename: PathBuf) -> String {
     let dispatch_visit_fn: TraitItem = parse_quote! {
         #[doc=r"Visits a node of any type."]
         fn visit(&mut self, node: ::tree_sitter::Node<'tree>) -> Self::ReturnType {
-            match node.kind() {
+            match node.kind_typed() {
                 #(#match_arms,)*
                 _ => panic!("unknown node kind: {}", node.kind())
             }
@@ -127,6 +191,90 @@ fn generate_visitor(filename: PathBuf) -> String {
 
         pub fn language() -> tree_sitter::Language {
             unsafe { tree_sitter_alumina() }
+        }
+
+        #[repr(u16)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[allow(dead_code)]
+        pub enum FieldKind {
+            #(#fields)*
+        }
+
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[allow(dead_code)]
+        pub enum NodeKind {
+            Unknown,
+            #(#node_kinds)*
+        }
+
+        const NODE_KIND_MAP: [NodeKind; #node_kind_map_len] = [
+            #(#node_kind_map)*
+        ];
+
+        pub trait NodeExt<'tree, 'a> {
+            type Iterator;
+
+            fn kind_typed(&self) -> NodeKind;
+            fn child_by_field(&self, field: FieldKind) -> Option<::tree_sitter::Node<'tree>>;
+            fn children_by_field(
+                &self,
+                field: FieldKind,
+                cursor: &'a mut ::tree_sitter::TreeCursor<'tree>,
+            ) -> Self::Iterator;
+        }
+
+        pub struct ChildrenIterator<'tree, 'a> {
+            cursor: &'a mut ::tree_sitter::TreeCursor<'tree>,
+            done: bool,
+            field: FieldKind,
+        }
+
+        impl<'tree, 'a> Iterator for ChildrenIterator<'tree, 'a> {
+            type Item = ::tree_sitter::Node<'tree>;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                if !self.done {
+                    while self.cursor.field_id() != Some(self.field as u16) {
+                        if !self.cursor.goto_next_sibling() {
+                            return None;
+                        }
+                    }
+                    let result = self.cursor.node();
+                    if !self.cursor.goto_next_sibling() {
+                        self.done = true;
+                    }
+                    return Some(result);
+                }
+                None
+            }
+        }
+
+        impl<'tree, 'a> NodeExt<'tree, 'a> for ::tree_sitter::Node<'tree> where 'tree: 'a {
+            type Iterator = ChildrenIterator<'tree, 'a>;
+
+            fn kind_typed(&self) -> NodeKind {
+                unsafe {
+                    *NODE_KIND_MAP.get_unchecked(self.kind_id() as usize)
+                }
+            }
+
+            fn child_by_field(&self, field: FieldKind) -> Option<::tree_sitter::Node<'tree>> {
+                self.child_by_field_id(field as u16)
+            }
+
+            fn children_by_field(
+                &self,
+                field: FieldKind,
+                cursor: &'a mut ::tree_sitter::TreeCursor<'tree>,
+            ) -> Self::Iterator {
+                cursor.reset(*self);
+                cursor.goto_first_child();
+                ChildrenIterator {
+                    cursor,
+                    done: false,
+                    field,
+                }
+            }
         }
 
         pub trait AluminaVisitor<'tree>: Sized {
@@ -158,25 +306,60 @@ fn main() {
 
     let src_dir = out_dir.join("src");
     let parser_path = src_dir.join("parser.c");
-    let mut c_config = cc::Build::new();
 
-    c_config.include(&src_dir);
-    c_config
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wno-unused-const-variable")
-        .flag_if_supported("-Wno-unused-but-set-variable")
-        .flag_if_supported("-Wno-trigraphs");
-    c_config.file(&parser_path);
-    c_config.compile("parser");
+    compile_grammar(&src_dir, &parser_path);
 
+    let language_info = get_language_info(&manifest_dir, &out_dir, &src_dir, &parser_path);
     let parser_file = out_dir.join("parser.rs");
-    let node_types = src_dir.join("node-types.json");
 
-    let visitor = generate_visitor(node_types);
+    let visitor = generate_visitor(language_info);
     File::create(parser_file)
         .unwrap()
         .write_all(visitor.as_bytes())
         .unwrap();
 
     println!("cargo:rerun-if-changed={}", grammar_path.display());
+}
+
+fn get_language_info(
+    manifest_dir: &Path,
+    out_dir: &Path,
+    src_dir: &Path,
+    parser_path: &Path,
+) -> LanguageInfo {
+    let dump_tool_path = manifest_dir.join("dump_lang.c");
+    let dump_tool_out_path = out_dir.join("dump_lang");
+
+    // Build the tool first
+    let mut cmd = cc::Build::new()
+        .include(src_dir)
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-const-variable")
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-trigraphs")
+        .get_compiler()
+        .to_command();
+    cmd.arg(parser_path)
+        .arg(&dump_tool_path)
+        .arg("-o")
+        .arg(&dump_tool_out_path);
+    assert!(cmd.status().unwrap().success());
+
+    // Run the tool
+    let output = Command::new(&dump_tool_out_path).output().unwrap();
+
+    assert!(output.status.success());
+
+    from_slice(&output.stdout[..]).expect("could not parse the node types JSON")
+}
+
+fn compile_grammar(src_dir: &Path, parser_path: &Path) {
+    cc::Build::new()
+        .include(src_dir)
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-const-variable")
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-trigraphs")
+        .file(&parser_path)
+        .compile("parser");
 }

--- a/src/alumina-boot/dump_lang.c
+++ b/src/alumina-boot/dump_lang.c
@@ -1,0 +1,34 @@
+/*
+    Dumps the names of the symbols and fields with associated IDs to JSON.
+    This is done because node-types.json does not include numeric IDs, which requires
+    the parsing to be done by string names (error-prone and inefficient).
+*/
+
+#include <stdio.h>
+#include "tree_sitter/parser.h"
+
+extern const TSLanguage *tree_sitter_alumina(void);
+
+int main(void) {
+    TSLanguage *language = (TSLanguage *)tree_sitter_alumina();
+    printf("{\"fields\":[");
+    for (int i = 1; i <= language->field_count; ++i) {
+        if (i > 1) {
+            printf(",");
+        }
+        printf("{\"name\":\"%s\",\"id\":%d}", language->field_names[i], i);
+    }
+    printf("],\"symbols\":[");
+    int first = true;
+    for (int i = 1; i <= language->symbol_count + 1; ++i) {
+        if (language->symbol_metadata[i].visible && language->symbol_metadata[i].named) {
+            if (first) {
+                first = false;
+            } else {
+                printf(",");
+            }
+            printf("{\"name\":\"%s\",\"id\":%d}", language->symbol_names[i], i);
+        }
+    }
+    printf("]}");
+}

--- a/src/alumina-boot/src/ast/macros.rs
+++ b/src/alumina-boot/src/ast/macros.rs
@@ -16,6 +16,9 @@ use super::{
     expressions::ExpressionVisitor, AstId, Attribute, ExprP, Macro, MacroParameter, Span, Statement,
 };
 
+use crate::parser::FieldKind;
+use crate::parser::NodeExt;
+
 pub struct MacroMaker<'ast> {
     ast: &'ast AstCtx<'ast>,
     global_ctx: GlobalCtx,
@@ -151,7 +154,7 @@ impl<'ast> MacroMaker<'ast> {
             scope.clone(),
             has_et_cetera,
         )
-        .generate(node.child_by_field_name("body").unwrap())?;
+        .generate(node.child_by_field(FieldKind::Body).unwrap())?;
 
         // Two-step assignment to detect recursion
         symbol.get_macro().body.set(body).unwrap();

--- a/src/alumina-boot/src/name_resolution/pass1.rs
+++ b/src/alumina-boot/src/name_resolution/pass1.rs
@@ -14,6 +14,9 @@ use crate::visitors::{AttributeVisitor, UseClauseVisitor, VisitorExt};
 use super::path::Path;
 use super::scope::NamedItem;
 
+use crate::parser::FieldKind;
+use crate::parser::NodeExt;
+
 type ItemMap<'ast, 'src> =
     IndexMap<(Scope<'ast, 'src>, Option<&'ast str>), Vec<NamedItem<'ast, 'src>>>;
 
@@ -129,7 +132,7 @@ macro_rules! with_child_scope_container {
 
 impl<'ast, 'src> FirstPassVisitor<'ast, 'src> {
     fn parse_name(&self, node: Node<'src>) -> &'ast str {
-        let name_node = node.child_by_field_name("name").unwrap();
+        let name_node = node.child_by_field(FieldKind::Name).unwrap();
         self.code.node_text(name_node).alloc_on(self.ast)
     }
 }
@@ -200,7 +203,7 @@ impl<'ast, 'src> AluminaVisitor<'src> for FirstPassVisitor<'ast, 'src> {
         )?;
 
         with_child_scope_container!(self, child_scope, {
-            if let Some(f) = node.child_by_field_name("type_arguments") {
+            if let Some(f) = node.child_by_field(FieldKind::TypeArguments) {
                 self.visit(f)?;
             }
             self.visit_children_by_field(node, "body")?;
@@ -226,7 +229,7 @@ impl<'ast, 'src> AluminaVisitor<'src> for FirstPassVisitor<'ast, 'src> {
         )?;
 
         with_child_scope!(self, child_scope, {
-            if let Some(f) = node.child_by_field_name("type_arguments") {
+            if let Some(f) = node.child_by_field(FieldKind::TypeArguments) {
                 self.visit(f)?;
             }
             self.visit_children_by_field(node, "body")?;
@@ -248,7 +251,7 @@ impl<'ast, 'src> AluminaVisitor<'src> for FirstPassVisitor<'ast, 'src> {
         )?;
 
         with_child_scope_container!(self, child_scope, {
-            if let Some(f) = node.child_by_field_name("type_arguments") {
+            if let Some(f) = node.child_by_field(FieldKind::TypeArguments) {
                 self.visit(f)?;
             }
             self.visit_children_by_field(node, "body")?;
@@ -352,7 +355,7 @@ impl<'ast, 'src> AluminaVisitor<'src> for FirstPassVisitor<'ast, 'src> {
         )?;
 
         with_child_scope!(self, child_scope, {
-            if let Some(f) = node.child_by_field_name("type_arguments") {
+            if let Some(f) = node.child_by_field(FieldKind::TypeArguments) {
                 self.visit(f)?;
             }
             self.visit_children_by_field(node, "parameters")?;
@@ -379,7 +382,7 @@ impl<'ast, 'src> AluminaVisitor<'src> for FirstPassVisitor<'ast, 'src> {
         )?;
 
         with_child_scope!(self, child_scope, {
-            if let Some(f) = node.child_by_field_name("type_arguments") {
+            if let Some(f) = node.child_by_field(FieldKind::TypeArguments) {
                 self.visit(f)?;
             }
         });
@@ -397,7 +400,7 @@ impl<'ast, 'src> AluminaVisitor<'src> for FirstPassVisitor<'ast, 'src> {
         )?;
 
         with_child_scope!(self, child_scope, {
-            if let Some(f) = node.child_by_field_name("type_arguments") {
+            if let Some(f) = node.child_by_field(FieldKind::TypeArguments) {
                 self.visit(f)?;
             }
         });
@@ -422,7 +425,7 @@ impl<'ast, 'src> AluminaVisitor<'src> for FirstPassVisitor<'ast, 'src> {
         )?;
 
         with_child_scope!(self, child_scope, {
-            if let Some(f) = node.child_by_field_name("type_arguments") {
+            if let Some(f) = node.child_by_field(FieldKind::TypeArguments) {
                 self.visit(f)?;
             }
         });
@@ -447,7 +450,7 @@ impl<'ast, 'src> AluminaVisitor<'src> for FirstPassVisitor<'ast, 'src> {
         )?;
 
         with_child_scope!(self, child_scope, {
-            if let Some(f) = node.child_by_field_name("type_arguments") {
+            if let Some(f) = node.child_by_field(FieldKind::TypeArguments) {
                 self.visit(f)?;
             }
         });
@@ -457,10 +460,10 @@ impl<'ast, 'src> AluminaVisitor<'src> for FirstPassVisitor<'ast, 'src> {
 
     fn visit_generic_argument_list(&mut self, node: Node<'src>) -> Self::ReturnType {
         let mut cursor = node.walk();
-        for argument in node.children_by_field_name("argument", &mut cursor) {
+        for argument in node.children_by_field(FieldKind::Argument, &mut cursor) {
             let name = self
                 .code
-                .node_text(argument.child_by_field_name("placeholder").unwrap())
+                .node_text(argument.child_by_field(FieldKind::Placeholder).unwrap())
                 .alloc_on(self.ast);
             self.add_item(
                 node,
@@ -492,7 +495,7 @@ impl<'ast, 'src> AluminaVisitor<'src> for FirstPassVisitor<'ast, 'src> {
             name,
             NamedItem::new_default(NamedItemKind::MacroParameter(
                 self.ast.make_id(),
-                node.child_by_field_name("et_cetera").is_some(),
+                node.child_by_field(FieldKind::EtCetera).is_some(),
             )),
         )?;
 
@@ -511,7 +514,7 @@ impl<'ast, 'src> AluminaVisitor<'src> for FirstPassVisitor<'ast, 'src> {
         let attributes = parse_attributes!(self, node);
 
         let mut visitor = UseClauseVisitor::new(self.ast, self.scope.clone(), attributes, false);
-        visitor.visit(node.child_by_field_name("argument").unwrap())?;
+        visitor.visit(node.child_by_field(FieldKind::Argument).unwrap())?;
 
         Ok(())
     }


### PR DESCRIPTION
Runs codegen in the buildscript to generate strongly typed enums for field and node kinds in the parse tree. This is a good idea in general, but also has a slight perf benefit (string matching had to allocate because tree-sitter expected the identifiers to be null-terminated).

## Before
| Stage | Median time (ms) | Min time (ms) | Max time (ms) | Average time (ms) | Standard deviation (ms) |
| --- | --: | --: | --: | --: | --: |
| Init | 0 | 0 | 0 | 0.00 | 0.00 |
| Parse | 125 | 119 | 193 | 126.22 | 7.23 |
| Pass1 | 12 | 11 | 20 | 11.68 | 0.93 |
| Ast | 90 | 86 | 138 | 91.19 | 5.33 |
| Mono | 93 | 87 | 128 | 93.69 | 4.51 |
| Optimizations | 5 | 4 | 6 | 4.79 | 0.47 |
| Codegen | 28 | 26 | 50 | 28.32 | 2.15 |
| TOTAL | 359 | 348 | 503 | 362.62 | 15.41 |

## After
| Stage | Median time (ms) | Min time (ms) | Max time (ms) | Average time (ms) | Standard deviation (ms) |
| --- | --: | --: | --: | --: | --: |
| Init | 0 | 0 | 0 | 0.00 | 0.00 |
| Parse | 126 | 120 | 148 | 126.97 | 3.88 |
| Pass1 | 9 | 8 | 13 | 8.61 | 0.70 |
| Ast | 68 | 65 | 76 | 68.55 | 1.89 |
| Mono | 93 | 88 | 103 | 93.47 | 2.62 |
| Optimizations | 5 | 4 | 7 | 4.94 | 0.44 |
| Codegen | 28 | 26 | 34 | 28.12 | 1.21 |
| TOTAL | 336 | 321 | 366 | 337.06 | 6.90 |