### PR TITLE
perf(compiler): Cache expensive computation during mono

### DIFF
--- a/src/alumina-boot/src/common.rs
+++ b/src/alumina-boot/src/common.rs
@@ -22,6 +22,8 @@ pub(crate) use ice;
 
 pub type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;
 pub type HashSet<T> = rustc_hash::FxHashSet<T>;
+pub type IndexMap<K, V> =
+    indexmap::IndexMap<K, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
 
 #[derive(Debug, Error)]
 pub enum AluminaError {

--- a/src/alumina-boot/src/name_resolution/pass1.rs
+++ b/src/alumina-boot/src/name_resolution/pass1.rs
@@ -5,7 +5,7 @@ use crate::global_ctx::GlobalCtx;
 use crate::name_resolution::scope::{NamedItemKind, Scope, ScopeType};
 use crate::parser::{AluminaVisitor, ParseCtx};
 
-use indexmap::IndexMap;
+use crate::common::IndexMap;
 use std::result::Result;
 use tree_sitter::Node;
 
@@ -47,7 +47,7 @@ impl<'ast, 'src> FirstPassVisitor<'ast, 'src> {
             enum_item: None,
             main_module_path: None,
             main_candidate: None,
-            items: IndexMap::new(),
+            items: IndexMap::default(),
         }
     }
 
@@ -67,7 +67,7 @@ impl<'ast, 'src> FirstPassVisitor<'ast, 'src> {
             in_a_container: false,
             enum_item: None,
             main_candidate: None,
-            items: IndexMap::new(),
+            items: IndexMap::default(),
         }
     }
 

--- a/src/alumina-boot/src/name_resolution/scope.rs
+++ b/src/alumina-boot/src/name_resolution/scope.rs
@@ -4,12 +4,13 @@ use std::{
     rc::{Rc, Weak},
 };
 
+use crate::common::IndexMap;
 use crate::{
     ast::{AstId, Attribute, ItemP},
     common::CodeErrorKind,
     parser::ParseCtx,
 };
-use indexmap::{map::Entry, IndexMap};
+use indexmap::map::Entry;
 use once_cell::unsync::OnceCell;
 use tree_sitter::Node;
 
@@ -203,7 +204,7 @@ impl<'ast, 'src> Scope<'ast, 'src> {
         Scope(Rc::new(RefCell::new(ScopeInner {
             r#type: ScopeType::Root,
             path: Path::root(),
-            items: IndexMap::new(),
+            items: IndexMap::default(),
             shadowed_items: Vec::new(),
             star_imports: Vec::new(),
             parent: None,
@@ -234,7 +235,7 @@ impl<'ast, 'src> Scope<'ast, 'src> {
         Scope(Rc::new(RefCell::new(ScopeInner {
             r#type,
             path: new_path,
-            items: IndexMap::new(),
+            items: IndexMap::default(),
             star_imports: Vec::new(),
             shadowed_items: Vec::new(),
             code,
@@ -248,7 +249,7 @@ impl<'ast, 'src> Scope<'ast, 'src> {
         Scope(Rc::new(RefCell::new(ScopeInner {
             r#type,
             path: new_path,
-            items: IndexMap::new(),
+            items: IndexMap::default(),
             star_imports: Vec::new(),
             shadowed_items: Vec::new(),
             code: OnceCell::new(),
@@ -262,7 +263,7 @@ impl<'ast, 'src> Scope<'ast, 'src> {
         Scope(Rc::new(RefCell::new(ScopeInner {
             r#type,
             path: self.path(),
-            items: IndexMap::new(),
+            items: IndexMap::default(),
             star_imports: Vec::new(),
             shadowed_items: Vec::new(),
             code,

--- a/src/alumina-boot/src/parser.rs
+++ b/src/alumina-boot/src/parser.rs
@@ -54,6 +54,10 @@ impl<'src> ParseCtx<'src> {
         &'src self,
         node: tree_sitter::Node<'src>,
     ) -> Result<(), AluminaError> {
+        if !node.has_error() {
+            return Ok(());
+        }
+
         let mut cursor = QueryCursor::new();
         let query = ERROR_QUERY.get_or_init(|| Query::new(language(), "(ERROR) @node").unwrap());
 

--- a/src/tests/lang.alu
+++ b/src/tests/lang.alu
@@ -306,3 +306,29 @@ fn test_nested_zst_layout() {
     struct S { a: u8, b: [[u64; 0]; 1] }
     assert_layout::<S>(8, 8);
 }
+
+
+// Define them in random order; not that it matters.
+static A3: i32 = A2 + 1 + A1;
+static A7: i32 = A6 + 1 + A5;
+static A6: i32 = A5 + 1 + A4;
+static A5: i32 = A4 + 1 + A3;
+static A0: i32 = 1;
+static A2: i32 = A1 + 1 + A0;
+static A4: i32 = A3 + 1 + A2;
+static A8: i32 = A7 + 1 + A6;
+static A1: i32 = 1;
+
+#[test]
+fn test_static_initialization_order() {
+    // https://oeis.org/A001595
+    assert_eq!(A0, 1);
+    assert_eq!(A1, 1);
+    assert_eq!(A2, 3);
+    assert_eq!(A3, 5);
+    assert_eq!(A4, 9);
+    assert_eq!(A5, 15);
+    assert_eq!(A6, 25);
+    assert_eq!(A7, 41);
+    assert_eq!(A8, 67);
+}


### PR DESCRIPTION
That's probably it for this perf uplift, most of the low-hanging fruits have been picked.

## Before
| Stage | Median time (ms) | Min time (ms) | Max time (ms) | Average time (ms) | Standard deviation (ms) |
| --- | --: | --: | --: | --: | --: |
| Init | 0 | 0 | 0 | 0.00 | 0.00 |
| Parse | 122 | 117 | 153 | 122.16 | 3.74 |
| Pass1 | 8 | 7 | 12 | 8.11 | 0.50 |
| Ast | 64 | 62 | 76 | 64.72 | 1.78 |
| Mono | 87 | 85 | 117 | 87.43 | 2.93 |
| Optimizations | 4 | 4 | 6 | 4.28 | 0.47 |
| Codegen | 26 | 25 | 39 | 26.11 | 1.46 |
| **TOTAL** | 318 | 311 | 352 | 319.23 | 6.20 |

## After
| Stage | Median time (ms) | Min time (ms) | Max time (ms) | Average time (ms) | Standard deviation (ms) |
| --- | --: | --: | --: | --: | --: |
| Init | 0 | 0 | 0 | 0.00 | 0.00 |
| Parse | 104 | 101 | 137 | 104.87 | 4.50 |
| Pass1 | 8 | 7 | 16 | 8.18 | 0.83 |
| Ast | 61 | 60 | 114 | 62.34 | 5.39 |
| Mono | 63 | 61 | 97 | 63.77 | 3.74 |
| Optimizations | 4 | 4 | 9 | 4.18 | 0.51 |
| Codegen | 26 | 25 | 36 | 26.79 | 1.72 |
| **TOTAL** | 267 | 261 | 383 | 270.12 | 12.47 |