### PR TITLE
feat(compiler): Full const evaluation

### DIFF
--- a/MISSING.md
+++ b/MISSING.md
@@ -18,7 +18,8 @@
 - Some limited pattern matching in macros (optional arguments)
 - Local items (functions, structs defined in linear scopes) that bind ambient generic parameters
   - Right now there is not even a good error message to say that this is not supported, just a cryptic "unbound placeholder" during mono
-- Lambdas in macros are broken.
+- Recursive local functions lead to stack overflow as mono monomorphizes them over and over again. The local item handling for functions was designed for lambdas that cannot be recursive (without indirection)
+- Macros cannot define local items or use anonymous function. This is quite bad and should be fixed.
 - Promoting all variables to function scope is a bit of a unique feature of Alumina and I like it (comes in quite handy for autoref - can take an address of any rvalue and defer), but it may inhibit some optimizations downstream.
 - `if opt.is_some { opt.inner }` and  `if res.is_ok() { res.unwrap() }` do not spark joy. Full pattern matching is overkill, but this is very common and
   deserves a better idiom.
@@ -83,6 +84,7 @@ macro write!($fmt, $s, $args...) {
   - Allocating collections and not freeing them - this would be pretty great to have if I can figure out a way to do it without false positives and in a generic enough fashion
     - OTOH, this is a bit of a slippery slope. Do I need to invent whole ownership system for this? If so, it's not happening, Alumina is not C++ or Rust even though it doesn't try very hard to not look like them.
 - Add more specific spans to compile errors. It's pretty good right now, but could be better.
+- Spans in IR expressions. Needed to generate debug info eventually, but also for pin-pointing const-eval errors.
 - proper backtraces for compiler warnings (currently just the span itself is shown, not it's mono stack). Might be a good to have an explicit stack in `mono` anyway and get rid of this nasty `with_no_span` hack that populates the error backtrace when unwinding.
 - do not panic on cyclic/recursive protocol bounds (figure out which ones are appropriate), but rather give a meaningful error message
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Non-exhaustive list of distinguishing features:
   - first-class 0-sized types (unit/void, 0-sized arrays, structs with no fields, ...),
   - never type
 - Hygienic expression macros
+- [Compile-time constant evaluation](./examples/constants.alu) (including loops, function calls, etc.)
 - [Unified call syntax](https://en.wikipedia.org/wiki/Uniform_Function_Call_Syntax) for functions and macros in scope
 - [Defer expressions](./examples/defer_and_move.alu)
 

--- a/examples/constants.alu
+++ b/examples/constants.alu
@@ -1,23 +1,25 @@
 // Simple constant values
 const INT: u32 = 1;
 const STR = "Hello";
+const ARR = [1, 2, 3];
 
 // Constants with compile-time evaluation
-const EVAL1: u32 = 1 + 1;
-const EVAL2: u32 = {
-    1 + 2; // Only pure statements allowed in constant expressions
-    2 + 3;
-    EVAL1
-};
+const EVAL: u32 = 1 + 1;
 
-const AACS_ENCRYPTION_KEY: u128 = {
-    // This warning will only be shown if the constant is used in the program
-    std::compile_warn!("MPAA will sue you if you use this key");
-    0x09f911029d74e35bd84156c5635688c0
-};
+// Complex expressions with loops and function calls
+const RANDOM_NUMBERS: [i32; 20] = {
+    let rng = std::random::Pcg32 {
+        state: 0xa285d44c06ab9542,
+        increment: 0x71bc6da31db36d8d,
+    };
 
-// if expressions and casts are supported
-const EVAL3 = if EVAL1 > 2 { EVAL1 as usize } else { 7usize };
+    let ret: [i32; 20];
+    (0..20)
+        .map(|&rng, _: i32| -> i32 { rng.next(-10..=10) })
+        .fill_slice(&ret);
+
+    ret
+};
 
 // Enum variants can have constant values
 enum Color {
@@ -31,41 +33,34 @@ struct Foo {
 }
 
 // arrays, tuples and structs are supported
+const OPT: Option<i32> = Option::none();
+
 const COMPLEX_CONST: [(Foo, Foo); 2] = [
     (Foo { range: 1..2 }, Foo { range: 3..4 }),
     (Foo { range: 5..6 }, Foo { range: 7..8 }),
 ];
 
-macro times($x, $y) {
-    $x * $y
-}
-
 fn main() {
     use std::fmt::{hex, zero_pad};
-    use std::mem::size_of;
+
+    print!("RANDOM NUMBERS = [");
+    for (idx, num) in RANDOM_NUMBERS.iter().enumerate() {
+        if idx == 0 {
+            print!("{}", num);
+        } else {
+            print!(", {}", num);
+        }
+    }
+    println!("]");
 
     // Constants can be used e.g. in array sizes
-    let arr: [i32; EVAL3];
+    let arr: [i32; RANDOM_NUMBERS[5] as usize];
     println!("arr.len() = {}", arr.len());
-
-    let arr_of_ints: [u8; size_of::<i32>() * 10];
-    println!("arr_of_ints.len() = {}", arr_of_ints.len());
-
-    println!("{}", AACS_ENCRYPTION_KEY);
-
-    // Macros work too. Who doesn't love arrays that change length depending on
-    // the source code line they are declared on?
-    let wacky: [i32; std::line!().times!(10)];
-    let odd: [i32; std::line!().times!(100)];
-    let quirky: [i32; std::line!().times!(1000)];
-    let weird: [i32; std::line!().times!(10000)];
-
-    println!("wacky.len() = {}", wacky.len());
-    println!("odd.len() = {}", odd.len());
-    println!("quirky.len() = {}", quirky.len());
-    println!("weird.len() = {}", weird.len());
 
     for color in [Color::Red, Color::Green, Color::Blue] {
         println!("{}", (color as i32).hex().zero_pad(6));
     }
+
+    println!("OPT = {}", OPT);
+    println!("COMPLEX_CONST[0].1.range.lower = {}", COMPLEX_CONST[0].1.range.lower);
 }

--- a/src/alumina-boot/build.rs
+++ b/src/alumina-boot/build.rs
@@ -355,6 +355,6 @@ fn compile_grammar(src_dir: &Path, parser_path: &Path) {
         .flag_if_supported("-Wno-unused-const-variable")
         .flag_if_supported("-Wno-unused-but-set-variable")
         .flag_if_supported("-Wno-trigraphs")
-        .file(&parser_path)
+        .file(parser_path)
         .compile("parser");
 }

--- a/src/alumina-boot/src/ast/maker.rs
+++ b/src/alumina-boot/src/ast/maker.rs
@@ -595,6 +595,8 @@ impl<'ast> AstItemMaker<'ast> {
             r#extern: is_extern,
         });
 
+        scope.check_unused_items(&self.global_ctx.diag());
+
         symbol.assign(result);
 
         self.symbols.push(symbol);
@@ -670,7 +672,7 @@ impl<'ast> AstItemMaker<'ast> {
                 }
                 self.make_type(
                     name,
-                    *symbol,
+                    symbol,
                     *node,
                     scope.clone(),
                     &impl_scopes[..],
@@ -681,33 +683,33 @@ impl<'ast> AstItemMaker<'ast> {
                 kind: TypeDef(symbol, node, scope),
                 attributes,
             }] => {
-                self.make_typedef(name, *symbol, *node, scope.clone(), attributes)?;
+                self.make_typedef(name, symbol, *node, scope.clone(), attributes)?;
             }
             [NI {
                 kind: Protocol(symbol, node, scope),
                 attributes,
             }] => {
                 self.make(scope.clone())?;
-                self.make_protocol(name, *symbol, *node, scope.clone(), attributes)?;
+                self.make_protocol(name, symbol, *node, scope.clone(), attributes)?;
             }
             [NI {
                 kind: Static(symbol, node, scope),
                 attributes,
             }] => {
-                self.make_static_or_const(false, name, *symbol, *node, scope.clone(), attributes)?;
+                self.make_static_or_const(false, name, symbol, *node, scope.clone(), attributes)?;
             }
             [NI {
                 kind: Const(symbol, node, scope),
                 attributes,
             }] => {
-                self.make_static_or_const(true, name, *symbol, *node, scope.clone(), attributes)?;
+                self.make_static_or_const(true, name, symbol, *node, scope.clone(), attributes)?;
             }
             [NI {
                 kind: Macro(symbol, node, scope),
                 attributes,
             }] => {
                 let mut macro_maker = MacroMaker::new(self.ast, self.global_ctx.clone());
-                macro_maker.make(name, *symbol, *node, scope.clone(), attributes)?;
+                macro_maker.make(name, symbol, *node, scope.clone(), attributes)?;
                 self.symbols.push(symbol);
             }
             [NI {

--- a/src/alumina-boot/src/ast/mod.rs
+++ b/src/alumina-boot/src/ast/mod.rs
@@ -84,7 +84,7 @@ impl<'ast> AstCtx<'ast> {
 
     pub fn intern_type(&'ast self, ty: Ty<'ast>) -> TyP<'ast> {
         if let Some(key) = self.types.borrow().get(&ty) {
-            return *key;
+            return key;
         }
 
         let inner = self.arena.alloc(ty);

--- a/src/alumina-boot/src/ast/rebind.rs
+++ b/src/alumina-boot/src/ast/rebind.rs
@@ -58,7 +58,7 @@ impl<'ast> Rebinder<'ast> {
             },
             Pointer(inner, is_const) => Pointer(self.visit_typ(inner)?, *is_const),
             Slice(inner, is_const) => Slice(self.visit_typ(inner)?, *is_const),
-            Array(inner, len) => Array(self.visit_typ(inner)?, *len),
+            Array(inner, len) => Array(self.visit_typ(inner)?, len),
             Tuple(elems) => Tuple(
                 elems
                     .iter()

--- a/src/alumina-boot/src/codegen/types.rs
+++ b/src/alumina-boot/src/codegen/types.rs
@@ -220,8 +220,8 @@ impl<'ir, 'gen> TypeWriterInner<'ir, 'gen> {
 
                 self.write_type_body(inner)?;
 
+                #[allow(unused_mut)]
                 let mut attributes = " ".to_string();
-                w!(attributes, "__attribute__((transparent_union)) ");
 
                 w!(self.type_bodies, "union {}{} {{\n", attributes, name);
                 w!(self.type_bodies, "  {} __data[{}];\n", inner_name, len);
@@ -276,8 +276,6 @@ impl<'ir, 'gen> TypeWriterInner<'ir, 'gen> {
 
                     if is_transparent {
                         assert!(s.fields.len() == 1);
-
-                        w!(attributes, "__attribute__((transparent_union)) ");
                         w!(
                             self.type_bodies,
                             "  {} {};\n",

--- a/src/alumina-boot/src/common.rs
+++ b/src/alumina-boot/src/common.rs
@@ -305,6 +305,10 @@ pub enum CodeErrorKind {
     IrInlineFlowControl,
     #[error("cannot IR-inline functions that can return early")]
     IrInlineEarlyReturn,
+    #[error("cannot define new items in a macro body (yet)")]
+    MacrosCannotDefineItems,
+    #[error("anonymous functions are not supported in a macro body (yet)")]
+    MacrosCannotDefineLambdas,
 
     // Warnings
     #[error("defer inside a loop: this defered statement will only be executed once")]

--- a/src/alumina-boot/src/diagnostics.rs
+++ b/src/alumina-boot/src/diagnostics.rs
@@ -189,7 +189,7 @@ impl DiagnosticContext {
             } = error
             {
                 // This usually means that something before the error failed, so it's just noise.
-                continue;
+                //continue;
             }
 
             let tagline = format!("{}: {}", level_string, error.kind).bold();

--- a/src/alumina-boot/src/ir/builder.rs
+++ b/src/alumina-boot/src/ir/builder.rs
@@ -25,6 +25,7 @@ impl<'ir> ExpressionBuilder<'ir> {
         Expr::const_lvalue(ExprKind::Const(item), typ).alloc_on(self.ir)
     }
 
+    #[allow(clippy::only_used_in_recursion)]
     fn fill_block(
         &self,
         target: &mut Vec<Statement<'ir>>,
@@ -157,8 +158,8 @@ impl<'ir> ExpressionBuilder<'ir> {
         result.alloc_on(self.ir)
     }
 
-    pub fn codegen_intrinsic(&self, kind: CodegenIntrinsicKind<'ir>, ty: TyP<'ir>) -> ExprP<'ir> {
-        Expr::rvalue(ExprKind::CodegenIntrinsic(kind), ty).alloc_on(self.ir)
+    pub fn codegen_intrinsic(&self, kind: IntrinsicValueKind<'ir>, ty: TyP<'ir>) -> ExprP<'ir> {
+        Expr::rvalue(ExprKind::Intrinsic(kind), ty).alloc_on(self.ir)
     }
 
     pub fn diverges(&self, exprs: impl IntoIterator<Item = ExprP<'ir>>) -> ExprP<'ir> {
@@ -230,7 +231,7 @@ impl<'ir> ExpressionBuilder<'ir> {
 
     pub fn dangling(&self, typ: TyP<'ir>) -> ExprP<'ir> {
         if let Ty::Pointer(ty, _) = typ {
-            self.codegen_intrinsic(CodegenIntrinsicKind::Dangling(ty), typ)
+            self.codegen_intrinsic(IntrinsicValueKind::Dangling(ty), typ)
         } else {
             unreachable!()
         }

--- a/src/alumina-boot/src/ir/const_eval.rs
+++ b/src/alumina-boot/src/ir/const_eval.rs
@@ -1,16 +1,23 @@
-/// Const evaluation at the moment is very rudimentary and is there only to support things like
-/// the fixed-size array lengths and enum values.
+/// An interpreter for constant expressions. It's quite slow.
 use crate::ast::BinOp;
-use crate::common::HashMap;
-use crate::ir::{BuiltinType, ExprKind, ExprP, IrCtx, IrId, Statement, Ty, TyP, UnOp};
+use crate::common::{ArenaAllocatable, HashMap, Marker};
+use crate::intrinsics::IntrinsicValueKind;
+use crate::ir::{BuiltinType, ExprKind, ExprP, IRItem, IrCtx, IrId, Statement, Ty, TyP, UnOp};
+use std::cell::RefCell;
 use std::cmp::Ordering;
+use std::num::TryFromIntError;
 use std::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Not, Rem, Shl, Shr, Sub};
+use std::rc::Rc;
 
 use thiserror::Error;
+
+const MAX_RECURSION_DEPTH: usize = 100;
+const MAX_ITERATIONS: usize = 10000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Value<'ir> {
     Void,
+    Uninitialized,
     Bool(bool),
     U8(u8),
     U16(u16),
@@ -26,27 +33,72 @@ pub enum Value<'ir> {
     ISize(isize),
     F32(&'ir str),
     F64(&'ir str),
-    Str(&'ir [u8]),
+    Str(&'ir [u8], usize),
     Tuple(&'ir [Value<'ir>]),
     Array(&'ir [Value<'ir>]),
     Struct(&'ir [(IrId, Value<'ir>)]),
     FunctionPointer(super::IRItemP<'ir>),
+    Pointer(LValue<'ir>),
+    LValue(LValue<'ir>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LValue<'ir> {
+    Variable(IrId),
+    Field(&'ir LValue<'ir>, IrId),
+    Index(&'ir LValue<'ir>, usize),
+    TupleIndex(&'ir LValue<'ir>, usize),
 }
 
 #[derive(Debug, Error, Clone, Hash, PartialEq, Eq)]
-pub enum ConstEvalError {
+pub enum ConstEvalErrorKind {
     #[error("not constant or unsupported expression")]
     Unsupported,
-    #[error("ice: encountered a branch in constant evaluation that should have been rejected during type checking")]
+    #[error("function `{}` is not supported in constant context", .0)]
+    UnsupportedFunction(String),
+    #[error("ice: encountered a branch that should have been rejected during type checking")]
     CompilerBug,
-    #[error("trying to access uninitialized field during constant evaluation")]
-    UninitializedField,
+    #[error("cyclic reference")]
+    CyclicReference,
+    #[error("trying to access uninitialized value")]
+    Uninitialized,
     #[error("index out of bounds")]
     IndexOutOfBounds,
     #[error("arithmetic overflow")]
     ArithmeticOverflow,
+    #[error("reached unreachable code")]
+    ToReachTheUnreachableStar,
     #[error("division by zero")]
     DivisionByZero,
+    #[error("max recursion depth exceeded")]
+    TooDeep,
+    #[error("max iterations exceeded")]
+    TooManyIterations,
+    #[error("contains pointer to a local variable")]
+    LValueLeak,
+
+    // These are not errors, but they are used to signal that the evaluation should stop.
+    // They are bugs if they leak to the caller
+    #[error("ice: non-local jump")]
+    Jump(IrId),
+    #[error("ice: return from a constant expression")]
+    Return,
+}
+
+#[derive(Debug, Error, Clone, Hash, PartialEq, Eq)]
+#[error("{}", .kind)]
+pub struct ConstEvalError {
+    pub kind: ConstEvalErrorKind,
+    pub backtrace: Vec<Marker>,
+}
+
+impl From<ConstEvalErrorKind> for ConstEvalError {
+    fn from(kind: ConstEvalErrorKind) -> Self {
+        Self {
+            kind,
+            backtrace: Vec::new(),
+        }
+    }
 }
 
 type Result<T> = std::result::Result<T, ConstEvalError>;
@@ -89,7 +141,7 @@ impl<'ir> Value<'ir> {
             (Value::I128(a), Value::I128(b)) => Ok(Value::Bool(a == b)),
             (Value::USize(a), Value::USize(b)) => Ok(Value::Bool(a == b)),
             (Value::ISize(a), Value::ISize(b)) => Ok(Value::Bool(a == b)),
-            _ => Err(ConstEvalError::Unsupported),
+            _ => Err(ConstEvalErrorKind::Unsupported.into()),
         }
     }
 
@@ -108,7 +160,7 @@ impl<'ir> Value<'ir> {
             (Value::USize(a), Value::USize(b)) => Ok(a.cmp(&b)),
             (Value::ISize(a), Value::ISize(b)) => Ok(a.cmp(&b)),
             (Value::Bool(a), Value::Bool(b)) => Ok(a.cmp(&b)),
-            _ => Err(ConstEvalError::Unsupported),
+            _ => Err(ConstEvalErrorKind::Unsupported.into()),
         }
     }
 }
@@ -130,28 +182,28 @@ impl<'ir> Add for Value<'ir> {
             (I8(a), I8(b)) => a
                 .checked_add(b)
                 .map(I8)
-                .ok_or(ConstEvalError::ArithmeticOverflow),
+                .ok_or_else(|| ConstEvalErrorKind::ArithmeticOverflow.into()),
             (I16(a), I16(b)) => a
                 .checked_add(b)
                 .map(I16)
-                .ok_or(ConstEvalError::ArithmeticOverflow),
+                .ok_or_else(|| ConstEvalErrorKind::ArithmeticOverflow.into()),
             (I32(a), I32(b)) => a
                 .checked_add(b)
                 .map(I32)
-                .ok_or(ConstEvalError::ArithmeticOverflow),
+                .ok_or_else(|| ConstEvalErrorKind::ArithmeticOverflow.into()),
             (I64(a), I64(b)) => a
                 .checked_add(b)
                 .map(I64)
-                .ok_or(ConstEvalError::ArithmeticOverflow),
+                .ok_or_else(|| ConstEvalErrorKind::ArithmeticOverflow.into()),
             (I128(a), I128(b)) => a
                 .checked_add(b)
                 .map(I128)
-                .ok_or(ConstEvalError::ArithmeticOverflow),
+                .ok_or_else(|| ConstEvalErrorKind::ArithmeticOverflow.into()),
             (ISize(a), ISize(b)) => a
                 .checked_add(b)
                 .map(ISize)
-                .ok_or(ConstEvalError::ArithmeticOverflow),
-            _ => Err(ConstEvalError::Unsupported),
+                .ok_or_else(|| ConstEvalErrorKind::ArithmeticOverflow.into()),
+            _ => Err(ConstEvalErrorKind::Unsupported.into()),
         }
     }
 }
@@ -173,28 +225,28 @@ impl<'ir> Sub for Value<'ir> {
             (I8(a), I8(b)) => a
                 .checked_sub(b)
                 .map(I8)
-                .ok_or(ConstEvalError::ArithmeticOverflow),
+                .ok_or_else(|| ConstEvalErrorKind::ArithmeticOverflow.into()),
             (I16(a), I16(b)) => a
                 .checked_sub(b)
                 .map(I16)
-                .ok_or(ConstEvalError::ArithmeticOverflow),
+                .ok_or_else(|| ConstEvalErrorKind::ArithmeticOverflow.into()),
             (I32(a), I32(b)) => a
                 .checked_sub(b)
                 .map(I32)
-                .ok_or(ConstEvalError::ArithmeticOverflow),
+                .ok_or_else(|| ConstEvalErrorKind::ArithmeticOverflow.into()),
             (I64(a), I64(b)) => a
                 .checked_sub(b)
                 .map(I64)
-                .ok_or(ConstEvalError::ArithmeticOverflow),
+                .ok_or_else(|| ConstEvalErrorKind::ArithmeticOverflow.into()),
             (I128(a), I128(b)) => a
                 .checked_sub(b)
                 .map(I128)
-                .ok_or(ConstEvalError::ArithmeticOverflow),
+                .ok_or_else(|| ConstEvalErrorKind::ArithmeticOverflow.into()),
             (ISize(a), ISize(b)) => a
                 .checked_sub(b)
                 .map(ISize)
-                .ok_or(ConstEvalError::ArithmeticOverflow),
-            _ => Err(ConstEvalError::Unsupported),
+                .ok_or_else(|| ConstEvalErrorKind::ArithmeticOverflow.into()),
+            _ => Err(ConstEvalErrorKind::Unsupported.into()),
         }
     }
 }
@@ -216,28 +268,28 @@ impl<'ir> Mul for Value<'ir> {
             (I8(a), I8(b)) => a
                 .checked_mul(b)
                 .map(I8)
-                .ok_or(ConstEvalError::ArithmeticOverflow),
+                .ok_or_else(|| ConstEvalErrorKind::ArithmeticOverflow.into()),
             (I16(a), I16(b)) => a
                 .checked_mul(b)
                 .map(I16)
-                .ok_or(ConstEvalError::ArithmeticOverflow),
+                .ok_or_else(|| ConstEvalErrorKind::ArithmeticOverflow.into()),
             (I32(a), I32(b)) => a
                 .checked_mul(b)
                 .map(I32)
-                .ok_or(ConstEvalError::ArithmeticOverflow),
+                .ok_or_else(|| ConstEvalErrorKind::ArithmeticOverflow.into()),
             (I64(a), I64(b)) => a
                 .checked_mul(b)
                 .map(I64)
-                .ok_or(ConstEvalError::ArithmeticOverflow),
+                .ok_or_else(|| ConstEvalErrorKind::ArithmeticOverflow.into()),
             (I128(a), I128(b)) => a
                 .checked_mul(b)
                 .map(I128)
-                .ok_or(ConstEvalError::ArithmeticOverflow),
+                .ok_or_else(|| ConstEvalErrorKind::ArithmeticOverflow.into()),
             (ISize(a), ISize(b)) => a
                 .checked_mul(b)
                 .map(ISize)
-                .ok_or(ConstEvalError::ArithmeticOverflow),
-            _ => Err(ConstEvalError::Unsupported),
+                .ok_or_else(|| ConstEvalErrorKind::ArithmeticOverflow.into()),
+            _ => Err(ConstEvalErrorKind::Unsupported.into()),
         }
     }
 }
@@ -247,10 +299,22 @@ impl<'ir> Shl<Value<'ir>> for Value<'ir> {
     fn shl(self, other: Value) -> Result<Value<'ir>> {
         use Value::*;
 
-        let other = match other {
-            USize(a) => a,
-            _ => return Err(ConstEvalError::CompilerBug),
+        let other: std::result::Result<usize, TryFromIntError> = match other {
+            U8(other) => Ok(other as _),
+            U16(other) => Ok(other as _),
+            U32(other) => other.try_into(),
+            U64(other) => other.try_into(),
+            U128(other) => other.try_into(),
+            USize(other) => Ok(other),
+            I8(other) => other.try_into(),
+            I16(other) => other.try_into(),
+            I32(other) => other.try_into(),
+            I64(other) => other.try_into(),
+            I128(other) => other.try_into(),
+            ISize(other) => other.try_into(),
+            _ => return Err(ConstEvalErrorKind::CompilerBug.into()),
         };
+        let other = other.map_err(|_| ConstEvalErrorKind::ArithmeticOverflow)?;
 
         match self {
             U8(a) => Ok(U8(a << other)),
@@ -265,7 +329,7 @@ impl<'ir> Shl<Value<'ir>> for Value<'ir> {
             I128(a) => Ok(I128(a << other)),
             USize(a) => Ok(USize(a << other)),
             ISize(a) => Ok(ISize(a << other)),
-            _ => Err(ConstEvalError::Unsupported),
+            _ => Err(ConstEvalErrorKind::Unsupported.into()),
         }
     }
 }
@@ -282,7 +346,7 @@ impl<'ir> Neg for Value<'ir> {
             I64(a) => Ok(I64(-a)),
             I128(a) => Ok(I128(-a)),
             ISize(a) => Ok(ISize(-a)),
-            _ => Err(ConstEvalError::Unsupported),
+            _ => Err(ConstEvalErrorKind::Unsupported.into()),
         }
     }
 }
@@ -306,7 +370,7 @@ impl<'ir> Not for Value<'ir> {
             USize(a) => Ok(USize(!a)),
             ISize(a) => Ok(ISize(!a)),
             Bool(a) => Ok(Bool(!a)),
-            _ => Err(ConstEvalError::Unsupported),
+            _ => Err(ConstEvalErrorKind::Unsupported.into()),
         }
     }
 }
@@ -316,10 +380,22 @@ impl<'ir> Shr<Value<'ir>> for Value<'ir> {
     fn shr(self, other: Value) -> Result<Value<'ir>> {
         use Value::*;
 
-        let other = match other {
-            USize(a) => a,
-            _ => return Err(ConstEvalError::CompilerBug),
+        let other: std::result::Result<usize, TryFromIntError> = match other {
+            U8(other) => Ok(other as _),
+            U16(other) => Ok(other as _),
+            U32(other) => other.try_into(),
+            U64(other) => other.try_into(),
+            U128(other) => other.try_into(),
+            USize(other) => Ok(other),
+            I8(other) => other.try_into(),
+            I16(other) => other.try_into(),
+            I32(other) => other.try_into(),
+            I64(other) => other.try_into(),
+            I128(other) => other.try_into(),
+            ISize(other) => other.try_into(),
+            _ => return Err(ConstEvalErrorKind::CompilerBug.into()),
         };
+        let other = other.map_err(|_| ConstEvalErrorKind::ArithmeticOverflow)?;
 
         match self {
             U8(a) => Ok(U8(a >> other)),
@@ -334,7 +410,7 @@ impl<'ir> Shr<Value<'ir>> for Value<'ir> {
             I128(a) => Ok(I128(a >> other)),
             USize(a) => Ok(USize(a >> other)),
             ISize(a) => Ok(ISize(a >> other)),
-            _ => Err(ConstEvalError::Unsupported),
+            _ => Err(ConstEvalErrorKind::Unsupported.into()),
         }
     }
 }
@@ -357,7 +433,7 @@ impl<'ir> BitOr for Value<'ir> {
             (I128(a), I128(b)) => Ok(I128(a | b)),
             (USize(a), USize(b)) => Ok(USize(a | b)),
             (ISize(a), ISize(b)) => Ok(ISize(a | b)),
-            _ => Err(ConstEvalError::Unsupported),
+            _ => Err(ConstEvalErrorKind::Unsupported.into()),
         }
     }
 }
@@ -380,7 +456,7 @@ impl<'ir> BitXor for Value<'ir> {
             (I128(a), I128(b)) => Ok(I128(a ^ b)),
             (USize(a), USize(b)) => Ok(USize(a ^ b)),
             (ISize(a), ISize(b)) => Ok(ISize(a ^ b)),
-            _ => Err(ConstEvalError::Unsupported),
+            _ => Err(ConstEvalErrorKind::Unsupported.into()),
         }
     }
 }
@@ -403,7 +479,7 @@ impl<'ir> BitAnd for Value<'ir> {
             (I128(a), I128(b)) => Ok(I128(a & b)),
             (USize(a), USize(b)) => Ok(USize(a & b)),
             (ISize(a), ISize(b)) => Ok(ISize(a & b)),
-            _ => Err(ConstEvalError::Unsupported),
+            _ => Err(ConstEvalErrorKind::Unsupported.into()),
         }
     }
 }
@@ -429,7 +505,7 @@ impl<'ir> Div for Value<'ir> {
             _ => None,
         };
 
-        result.ok_or(ConstEvalError::DivisionByZero)
+        result.ok_or_else(|| ConstEvalErrorKind::DivisionByZero.into())
     }
 }
 
@@ -454,21 +530,108 @@ impl<'ir> Rem for Value<'ir> {
             _ => None,
         };
 
-        result.ok_or(ConstEvalError::DivisionByZero)
+        result.ok_or_else(|| ConstEvalErrorKind::DivisionByZero.into())
+    }
+}
+
+struct ConstEvalCtxInner<'ir> {
+    variables: HashMap<IrId, Value<'ir>>,
+    steps_remaining: usize,
+}
+
+#[derive(Clone)]
+pub struct ConstEvalCtx<'ir> {
+    ir: &'ir IrCtx<'ir>,
+    inner: Rc<RefCell<ConstEvalCtxInner<'ir>>>,
+}
+
+impl<'ir> ConstEvalCtx<'ir> {
+    pub fn new(ir: &'ir IrCtx<'ir>) -> Self {
+        Self {
+            ir,
+            inner: Rc::new(RefCell::new(ConstEvalCtxInner {
+                variables: HashMap::default(),
+                steps_remaining: MAX_ITERATIONS,
+            })),
+        }
+    }
+
+    pub fn step(&self) -> Result<()> {
+        let mut inner = self.inner.borrow_mut();
+        if inner.steps_remaining == 0 {
+            return Err(ConstEvalErrorKind::TooManyIterations.into());
+        }
+        inner.steps_remaining -= 1;
+        Ok(())
+    }
+
+    pub fn define(&self, id: IrId, value: Value<'ir>) {
+        self.inner.borrow_mut().variables.insert(id, value);
+    }
+
+    pub fn declare(&self, id: IrId, typ: TyP<'ir>) {
+        self.inner
+            .borrow_mut()
+            .variables
+            .insert(id, make_uninitialized(self.ir, typ));
+    }
+
+    pub fn assign(&self, id: IrId, value: Value<'ir>) {
+        self.inner.borrow_mut().variables.insert(id, value);
+    }
+
+    pub fn load_var(&self, id: IrId) -> Value<'ir> {
+        *self
+            .inner
+            .borrow_mut()
+            .variables
+            .entry(id)
+            .or_insert(Value::Uninitialized)
     }
 }
 
 pub struct ConstEvaluator<'ir> {
     ir: &'ir IrCtx<'ir>,
+    ctx: ConstEvalCtx<'ir>,
+    return_slot: Option<Value<'ir>>,
+    remaining_depth: usize,
+    remapped_variables: HashMap<IrId, IrId>,
 }
 
 impl<'ir> ConstEvaluator<'ir> {
-    pub fn new(ir: &'ir IrCtx<'ir>) -> Self {
-        Self { ir }
+    pub fn new<I>(ir: &'ir IrCtx<'ir>, local_types: I) -> Self
+    where
+        I: IntoIterator<Item = (IrId, TyP<'ir>)>,
+    {
+        let ctx = ConstEvalCtx::new(ir);
+        for (id, typ) in local_types {
+            ctx.declare(id, typ);
+        }
+
+        Self {
+            ir,
+            return_slot: None,
+            remaining_depth: MAX_RECURSION_DEPTH,
+            remapped_variables: Default::default(),
+            ctx,
+        }
     }
 
-    fn cast(&self, inner: ExprP<'ir>, mut target: TyP<'ir>) -> Result<Value<'ir>> {
-        let val = self.const_eval(inner)?;
+    fn make_child(&self, remapped_variables: HashMap<IrId, IrId>) -> Result<Self> {
+        Ok(Self {
+            ir: self.ir,
+            ctx: self.ctx.clone(),
+            return_slot: None,
+            remaining_depth: self
+                .remaining_depth
+                .checked_sub(1)
+                .ok_or(ConstEvalErrorKind::TooDeep)?,
+            remapped_variables,
+        })
+    }
+
+    fn cast(&mut self, inner: ExprP<'ir>, mut target: TyP<'ir>) -> Result<Value<'ir>> {
+        let val = self.const_eval_rvalue(inner)?;
         if inner.ty == target {
             return Ok(val);
         }
@@ -492,7 +655,7 @@ impl<'ir> ConstEvaluator<'ir> {
             Value::I64(a) => Value::I128(a as i128),
             Value::I128(a) => Value::I128(a),
             Value::ISize(a) => Value::I128(a as i128),
-            Value::Bool(a) => Value::U128(if a { 1 } else { 0 }),
+            Value::Bool(a) => Value::U128(a as u128),
             _ => val,
         };
 
@@ -524,86 +687,293 @@ impl<'ir> ConstEvaluator<'ir> {
             (Value::F64(a), Ty::Builtin(BuiltinType::F32)) => Ok(Value::F32(a)),
             (Value::F32(a), Ty::Builtin(BuiltinType::F64)) => Ok(Value::F64(a)),
             (Value::FunctionPointer(id), Ty::FunctionPointer(..)) => Ok(Value::FunctionPointer(id)),
-            _ => Err(ConstEvalError::Unsupported),
+            _ => Err(ConstEvalErrorKind::Unsupported.into()),
         }
     }
 
-    pub fn const_eval(&self, expr: ExprP<'ir>) -> Result<Value<'ir>> {
+    fn field(&mut self, r#struct: Value<'ir>, field: IrId) -> Result<Value<'ir>> {
+        match r#struct {
+            Value::LValue(lv) => Ok(Value::LValue(LValue::Field(lv.alloc_on(self.ir), field))),
+            Value::Struct(fields) => Ok(fields
+                .iter()
+                .find(|(f, _)| *f == field)
+                .map(|(_, v)| *v)
+                .unwrap_or(Value::Uninitialized)),
+            _ => Err(ConstEvalErrorKind::Unsupported.into()),
+        }
+    }
+
+    fn index(&mut self, array: Value<'ir>, idx: usize) -> Result<Value<'ir>> {
+        match array {
+            Value::LValue(lv) => Ok(Value::LValue(LValue::Index(lv.alloc_on(self.ir), idx))),
+            Value::Array(values) => values
+                .get(idx)
+                .copied()
+                .ok_or_else(|| ConstEvalErrorKind::IndexOutOfBounds.into()),
+            _ => Err(ConstEvalErrorKind::Unsupported.into()),
+        }
+    }
+
+    fn tuple_index(&mut self, tup: Value<'ir>, idx: usize) -> Result<Value<'ir>> {
+        match tup {
+            Value::LValue(lv) => Ok(Value::LValue(LValue::TupleIndex(lv.alloc_on(self.ir), idx))),
+            Value::Tuple(values) => Ok(values.get(idx).cloned().unwrap_or(Value::Uninitialized)),
+            _ => Err(ConstEvalErrorKind::CompilerBug.into()),
+        }
+    }
+
+    pub fn const_eval(&mut self, expr: ExprP<'ir>) -> Result<Value<'ir>> {
+        // public facing interface. we clean up things that should not appear in the IR
+        let ret = self.const_eval_rvalue(expr)?;
+        check_lvalue_leak(&ret)?;
+        Ok(ret)
+    }
+
+    fn materialize(&mut self, value: Value<'ir>) -> Result<Value<'ir>> {
+        match value {
+            Value::LValue(v) => self.materialize_lvalue(v),
+            _ => Ok(value),
+        }
+    }
+
+    fn const_eval_rvalue(&mut self, expr: ExprP<'ir>) -> Result<Value<'ir>> {
+        self.const_eval_defered(expr)
+            .and_then(|v| self.materialize(v))
+    }
+
+    fn eval_statements(&mut self, statements: &[Statement<'ir>]) -> Result<()> {
+        let label_indexes: HashMap<IrId, usize> = statements
+            .iter()
+            .enumerate()
+            .filter_map(|(i, s)| match s {
+                Statement::Label(id) => Some((*id, i)),
+                _ => None,
+            })
+            .collect();
+
+        let mut ip = 0usize;
+        while ip < statements.len() {
+            match statements[ip] {
+                Statement::Expression(expr) => {
+                    match self.const_eval_rvalue(expr) {
+                        Ok(_) => {}
+                        Err(ConstEvalError {
+                            kind: ConstEvalErrorKind::Jump(label),
+                            ..
+                        }) => {
+                            if let Some(new_ip) = label_indexes.get(&label) {
+                                ip = *new_ip;
+                                continue;
+                            } else {
+                                // Go up one level
+                                return Err(ConstEvalErrorKind::Jump(label).into());
+                            }
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+                Statement::Label(_) => {}
+            }
+            ip += 1;
+        }
+
+        Ok(())
+    }
+
+    fn materialize_lvalue(&mut self, value: LValue<'ir>) -> Result<Value<'ir>> {
+        match value {
+            LValue::Variable(id) => Ok(self.ctx.load_var(id)),
+            LValue::Field(lvalue, field) => {
+                let base = self.materialize_lvalue(*lvalue)?;
+                self.field(base, field)
+            }
+            LValue::Index(lvalue, idx) => {
+                let base = self.materialize_lvalue(*lvalue)?;
+                self.index(base, idx)
+            }
+            LValue::TupleIndex(lvalue, idx) => {
+                let base = self.materialize_lvalue(*lvalue)?;
+                self.tuple_index(base, idx)
+            }
+        }
+    }
+
+    fn assign(&mut self, lhs: LValue<'ir>, value: Value<'ir>) -> Result<()> {
+        match lhs {
+            LValue::Variable(id) => {
+                self.ctx.assign(id, value);
+                Ok(())
+            }
+            LValue::Field(lvalue, field) => {
+                let base = self.materialize_lvalue(*lvalue)?;
+
+                match base {
+                    Value::Struct(fields) => {
+                        let new_fields: Vec<_> = fields
+                            .iter()
+                            .filter(|(f, _)| *f != field)
+                            .copied()
+                            .chain(std::iter::once((field, value)))
+                            .collect();
+
+                        self.assign(
+                            *lvalue,
+                            Value::Struct(self.ir.arena.alloc_slice_copy(&new_fields[..])),
+                        )
+                    }
+                    _ => Err(ConstEvalErrorKind::CompilerBug.into()),
+                }
+            }
+            LValue::Index(lvalue, idx) => {
+                let base = self.materialize_lvalue(*lvalue)?;
+
+                match base {
+                    Value::Array(values) => {
+                        let new_values: Vec<_> = values
+                            .iter()
+                            .enumerate()
+                            .map(|(i, v)| if i == idx { value } else { *v })
+                            .collect();
+
+                        self.assign(
+                            *lvalue,
+                            Value::Array(self.ir.arena.alloc_slice_copy(&new_values[..])),
+                        )
+                    }
+                    _ => Err(ConstEvalErrorKind::CompilerBug.into()),
+                }
+            }
+            LValue::TupleIndex(lvalue, idx) => {
+                let base = self.materialize_lvalue(*lvalue)?;
+
+                match base {
+                    Value::Tuple(values) => {
+                        let new_values: Vec<_> = values
+                            .iter()
+                            .enumerate()
+                            .map(|(i, v)| if i == idx { value } else { *v })
+                            .collect();
+
+                        self.assign(
+                            *lvalue,
+                            Value::Tuple(self.ir.arena.alloc_slice_copy(&new_values[..])),
+                        )
+                    }
+                    _ => Err(ConstEvalErrorKind::CompilerBug.into()),
+                }
+            }
+        }
+    }
+
+    #[allow(unreachable_code)]
+    fn const_eval_defered(&mut self, expr: ExprP<'ir>) -> Result<Value<'ir>> {
+        // Comment this line to debug expressions not being evaluated
+        // successfully
+        return self.const_eval_defered_inner(expr);
+
+        match self.const_eval_defered_inner(expr) {
+            Ok(v) => Ok(v),
+            Err(ref err @ ConstEvalError { ref kind, .. })
+                if !matches!(
+                    kind,
+                    ConstEvalErrorKind::Jump(..) | ConstEvalErrorKind::Return
+                ) =>
+            {
+                panic!(
+                    "Could not const-evaluate: {}\nEXPRESSION:\n{:#?}",
+                    err, expr
+                )
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Variant of const-eval that leaves LValues in place
+    fn const_eval_defered_inner(&mut self, expr: ExprP<'ir>) -> Result<Value<'ir>> {
+        self.ctx.step()?;
+
         match &expr.kind {
             ExprKind::Void => Ok(Value::Void),
             ExprKind::Binary(op, lhs, rhs) => {
-                let lhs = self.const_eval(lhs)?;
+                let lhs = self.const_eval_rvalue(lhs)?;
 
                 // Special case for short-circuiting operators
                 match (op, lhs) {
                     (BinOp::Or, Value::Bool(a)) => {
-                        return if a { Ok(lhs) } else { self.const_eval(rhs) }
+                        return if a {
+                            Ok(lhs)
+                        } else {
+                            self.const_eval_rvalue(rhs)
+                        }
                     }
                     (BinOp::And, Value::Bool(a)) => {
-                        return if a { self.const_eval(rhs) } else { Ok(lhs) }
+                        return if a {
+                            self.const_eval_rvalue(rhs)
+                        } else {
+                            Ok(lhs)
+                        }
                     }
-                    (BinOp::Or | BinOp::And, _) => return Err(ConstEvalError::CompilerBug),
+                    (BinOp::Or | BinOp::And, _) => {
+                        return Err(ConstEvalErrorKind::CompilerBug.into())
+                    }
                     _ => {}
                 };
 
-                let rhs = self.const_eval(rhs)?;
-                match op {
-                    BinOp::BitAnd => lhs & rhs,
-                    BinOp::BitOr => lhs | rhs,
-                    BinOp::BitXor => lhs ^ rhs,
-                    BinOp::Eq => lhs.equal(rhs),
-                    BinOp::Neq => lhs.equal(rhs).and_then(|v| !v),
-                    BinOp::Lt => Ok(Value::Bool(matches!(lhs.cmp(rhs)?, Ordering::Less))),
-                    BinOp::LEq => Ok(Value::Bool(matches!(
-                        lhs.cmp(rhs)?,
-                        Ordering::Less | Ordering::Equal
-                    ))),
-                    BinOp::Gt => Ok(Value::Bool(matches!(lhs.cmp(rhs)?, Ordering::Greater))),
-                    BinOp::GEq => Ok(Value::Bool(matches!(
-                        lhs.cmp(rhs)?,
-                        Ordering::Greater | Ordering::Equal
-                    ))),
-                    BinOp::LShift => lhs << rhs,
-                    BinOp::RShift => lhs >> rhs,
-                    BinOp::Plus => lhs + rhs,
-                    BinOp::Minus => lhs - rhs,
-                    BinOp::Mul => lhs * rhs,
-                    BinOp::Div => lhs / rhs,
-                    BinOp::Mod => lhs % rhs,
-                    _ => Err(ConstEvalError::Unsupported),
-                }
+                let rhs = self.const_eval_rvalue(rhs)?;
+                self.bin_op(lhs, *op, rhs)
             }
+            ExprKind::Local(id) => Ok(Value::LValue(LValue::Variable(
+                *self.remapped_variables.get(id).unwrap_or(id),
+            ))),
             ExprKind::Unary(op, inner) => {
-                let inner = self.const_eval(inner)?;
+                let inner = self.const_eval_rvalue(inner)?;
 
                 match op {
                     UnOp::Not if matches!(inner, Value::Bool(_)) => !inner,
                     UnOp::Neg => -inner,
                     UnOp::BitNot if !matches!(inner, Value::Bool(_)) => !inner,
-                    _ => Err(ConstEvalError::CompilerBug),
+                    _ => Err(ConstEvalErrorKind::CompilerBug.into()),
+                }
+            }
+            ExprKind::Ref(value) => {
+                let value = self.const_eval_defered(value)?;
+                match value {
+                    Value::LValue(lvalue) => Ok(Value::Pointer(lvalue)),
+                    _ => Err(ConstEvalErrorKind::Unsupported.into()),
+                }
+            }
+            ExprKind::Deref(value) => {
+                let value = self.const_eval_rvalue(value)?;
+                match value {
+                    Value::Pointer(lvalue) => Ok(Value::LValue(lvalue)),
+                    _ => Err(ConstEvalErrorKind::Unsupported.into()),
                 }
             }
             ExprKind::Literal(value) => Ok(*value),
+            ExprKind::Const(item) => item
+                .get_const()
+                .map(|c| c.value)
+                .map_err(|_| ConstEvalErrorKind::CompilerBug.into()),
             ExprKind::Cast(inner) => self.cast(inner, expr.ty),
             ExprKind::If(cond, then, els) => {
-                let cond = self.const_eval(cond)?;
+                let condv = self.const_eval_rvalue(cond)?;
 
-                let cond_value = match cond {
+                let cond_value = match condv {
                     Value::Bool(b) => b,
-                    _ => return Err(ConstEvalError::CompilerBug),
+                    _ => return Err(ConstEvalErrorKind::CompilerBug.into()),
                 };
 
                 if cond_value {
-                    self.const_eval(then)
+                    self.const_eval_rvalue(then)
                 } else {
-                    self.const_eval(els)
+                    self.const_eval_rvalue(els)
                 }
             }
             ExprKind::Tuple(exprs) => {
                 let mut values = Vec::new();
                 for (idx, init) in exprs.iter().enumerate() {
                     assert_eq!(idx, init.index);
-                    values.push(self.const_eval(init.value)?);
+                    values.push(self.const_eval_rvalue(init.value)?);
                 }
                 Ok(Value::Tuple(
                     self.ir.arena.alloc_slice_fill_iter(values.into_iter()),
@@ -612,67 +982,270 @@ impl<'ir> ConstEvaluator<'ir> {
             ExprKind::Array(elems) => {
                 let mut values = Vec::new();
                 for elem in *elems {
-                    values.push(self.const_eval(elem)?);
+                    values.push(self.const_eval_rvalue(elem)?);
                 }
                 Ok(Value::Array(
                     self.ir.arena.alloc_slice_fill_iter(values.into_iter()),
                 ))
             }
+            ExprKind::Goto(id) => Err(ConstEvalErrorKind::Jump(*id).into()),
             ExprKind::Struct(fields) => {
                 // Last assignment wins
                 let mut values = HashMap::default();
                 for field in *fields {
-                    values.insert(field.field, self.const_eval(field.value)?);
+                    values.insert(field.field, self.const_eval_rvalue(field.value)?);
                 }
                 Ok(Value::Struct(
                     self.ir.arena.alloc_slice_fill_iter(values.into_iter()),
                 ))
             }
             ExprKind::TupleIndex(tup, idx) => {
-                let tup = self.const_eval(tup)?;
-                match tup {
-                    Value::Tuple(values) => Ok(values[*idx]),
-                    _ => Err(ConstEvalError::CompilerBug),
-                }
+                let tup = self.const_eval_defered(tup)?;
+                self.tuple_index(tup, *idx)
             }
             ExprKind::Index(array, idx) => {
-                let array = self.const_eval(array)?;
-                let idx = self.const_eval(idx)?;
-                match (array, idx) {
-                    (Value::Array(values), Value::USize(idx)) => values
-                        .get(idx)
-                        .copied()
-                        .ok_or(ConstEvalError::IndexOutOfBounds),
-                    _ => Err(ConstEvalError::Unsupported),
-                }
+                let array = self.const_eval_defered(array)?;
+                let idx = match self.const_eval_rvalue(idx)? {
+                    Value::USize(idx) => idx,
+                    _ => return Err(ConstEvalErrorKind::CompilerBug.into()),
+                };
+                self.index(array, idx)
             }
             ExprKind::Field(r#struct, field) => {
-                let r#struct = self.const_eval(r#struct)?;
-                match r#struct {
-                    Value::Struct(fields) => fields
-                        .iter()
-                        .find(|(f, _)| *f == *field)
-                        .map(|(_, v)| *v)
-                        .ok_or(ConstEvalError::UninitializedField),
-                    _ => Err(ConstEvalError::Unsupported),
+                let r#struct = self.const_eval_defered(r#struct)?;
+                self.field(r#struct, *field)
+            }
+            ExprKind::Assign(lhs, rhs) => {
+                let lhs = self.const_eval_defered(lhs)?;
+                let rhs = self.const_eval_rvalue(rhs)?;
+                match lhs {
+                    Value::LValue(lvalue) => {
+                        self.assign(lvalue, rhs)?;
+                        Ok(Value::Void)
+                    }
+                    _ => Err(ConstEvalErrorKind::CompilerBug.into()),
+                }
+            }
+            ExprKind::AssignOp(op, lhs, rhs) => {
+                let lhs = self.const_eval_defered(lhs)?;
+                let rhs = self.const_eval_rvalue(rhs)?;
+                match lhs {
+                    Value::LValue(lvalue) => {
+                        let normalized = self.materialize(lhs)?;
+                        let res = self.bin_op(normalized, *op, rhs)?;
+                        self.assign(lvalue, res)?;
+                        Ok(Value::Void)
+                    }
+                    _ => Err(ConstEvalErrorKind::CompilerBug.into()),
                 }
             }
             ExprKind::Block(statements, ret) => {
-                for stmt in *statements {
-                    // You can have statements in constant expressions as long as they're constant expressions themselves (and therefore pure)
-                    match stmt {
-                        Statement::Expression(expr) => {
-                            self.const_eval(expr)?;
-                            assert!(expr.pure());
-                        }
-                        _ => return Err(ConstEvalError::Unsupported),
+                self.eval_statements(statements)?;
+                self.const_eval_rvalue(ret)
+            }
+            ExprKind::Intrinsic(kind) => match kind {
+                IntrinsicValueKind::Uninitialized => Ok(Value::Uninitialized),
+                IntrinsicValueKind::Dangling(..) => Ok(Value::Uninitialized),
+                IntrinsicValueKind::SizeOfLike(_, _) => Err(ConstEvalErrorKind::Unsupported.into()),
+                IntrinsicValueKind::Asm(_) => Err(ConstEvalErrorKind::Unsupported.into()),
+                IntrinsicValueKind::FunctionLike(_) => Err(ConstEvalErrorKind::Unsupported.into()),
+                IntrinsicValueKind::ConstLike(_) => Err(ConstEvalErrorKind::Unsupported.into()),
+                IntrinsicValueKind::InConstContext => Ok(Value::Bool(true)),
+            },
+            ExprKind::Fn(item) => Ok(Value::FunctionPointer(item)),
+            ExprKind::Return(value) => {
+                self.return_slot = Some(self.const_eval_rvalue(value)?);
+                Err(ConstEvalErrorKind::Return.into())
+            }
+            ExprKind::Call(callee, args) => {
+                let callee = self.const_eval_rvalue(callee)?;
+                let (arg_spec, expr, local_defs) = match callee {
+                    Value::FunctionPointer(fun) => {
+                        let func = fun
+                            .get_function()
+                            .map_err(|_| ConstEvalErrorKind::Unsupported)?;
+
+                        let (body, local_defs) = func
+                            .body
+                            .get()
+                            .and_then(|b| b.raw_body.map(|rb| (rb, b.local_defs)))
+                            .ok_or_else(|| {
+                                ConstEvalErrorKind::UnsupportedFunction(
+                                    func.name.unwrap_or("<unnamed>").to_string(),
+                                )
+                            })?;
+
+                        (func.args, body, local_defs)
                     }
+                    _ => return Err(ConstEvalErrorKind::Unsupported.into()),
+                };
+
+                let mut remapped_variables = HashMap::default();
+                for local_def in local_defs {
+                    let new_id = self.ir.make_id();
+                    remapped_variables.insert(local_def.id, new_id);
+
+                    self.ctx.declare(new_id, local_def.typ);
                 }
 
-                self.const_eval(ret)
+                for (arg, arg_spec) in args.iter().zip(arg_spec) {
+                    let arg = self.const_eval_rvalue(arg)?;
+                    let new_id = self.ir.make_id();
+                    remapped_variables.insert(arg_spec.id, new_id);
+
+                    self.ctx.define(new_id, arg);
+                }
+
+                let mut child = self.make_child(remapped_variables)?;
+
+                let ret = match child.const_eval_rvalue(expr) {
+                    Ok(value) => Ok(value),
+                    Err(ConstEvalError {
+                        kind: ConstEvalErrorKind::Return,
+                        ..
+                    }) => {
+                        let value = child.return_slot.take().unwrap();
+                        Ok(value)
+                    }
+                    Err(e) => Err(e),
+                };
+                ret
             }
-            ExprKind::Fn(item) => Ok(Value::FunctionPointer(item)),
-            _ => Err(ConstEvalError::Unsupported),
+
+            ExprKind::Static(_) => Err(ConstEvalErrorKind::Unsupported.into()),
+            ExprKind::Unreachable => Err(ConstEvalErrorKind::ToReachTheUnreachableStar.into()),
         }
+    }
+
+    // Handle pointer arithmetic
+    fn plus_minus(&mut self, lhs: Value<'ir>, op: BinOp, rhs: Value<'ir>) -> Result<Value<'ir>> {
+        macro_rules! offset {
+            () => {
+                match rhs {
+                    // if you do offsets > isize::MAX in const-eval, you are on your own
+                    Value::USize(i) => i as isize,
+                    Value::ISize(i) => i,
+                    _ => return Err(ConstEvalErrorKind::Unsupported.into()),
+                }
+            };
+        }
+
+        match (lhs, rhs) {
+            (
+                Value::Pointer(LValue::Index(a, a_offset)),
+                Value::Pointer(LValue::Index(b, b_offset)),
+            ) if op == BinOp::Minus => {
+                if b != a {
+                    return Err(ConstEvalErrorKind::IndexOutOfBounds.into());
+                }
+
+                let diff = (a_offset as isize) - (b_offset as isize);
+                return Ok(Value::ISize(diff));
+            }
+            (Value::Str(buf, offset), _) => {
+                let new_offset = match op {
+                    BinOp::Plus => (offset as isize) + offset!(),
+                    BinOp::Minus => (offset as isize) + offset!(),
+                    _ => return Err(ConstEvalErrorKind::CompilerBug.into()),
+                };
+                if new_offset < 0 || new_offset > (buf.len() as isize) {
+                    return Err(ConstEvalErrorKind::IndexOutOfBounds.into());
+                }
+                return Ok(Value::Str(buf, new_offset as usize));
+            }
+            (Value::Pointer(LValue::Index(inner, offset)), _) => {
+                let arr = match self.materialize_lvalue(*inner)? {
+                    Value::Array(arr) => arr,
+                    _ => return Err(ConstEvalErrorKind::Unsupported.into()),
+                };
+
+                let new_offset = match op {
+                    BinOp::Plus => (offset as isize) + offset!(),
+                    BinOp::Minus => (offset as isize) + offset!(),
+                    _ => return Err(ConstEvalErrorKind::CompilerBug.into()),
+                };
+                if new_offset < 0 || new_offset > (arr.len() as isize) {
+                    return Err(ConstEvalErrorKind::IndexOutOfBounds.into());
+                }
+                return Ok(Value::Pointer(LValue::Index(inner, new_offset as usize)));
+            }
+
+            _ => {}
+        }
+
+        match op {
+            BinOp::Plus => lhs + rhs,
+            BinOp::Minus => lhs - rhs,
+            _ => unreachable!(),
+        }
+    }
+
+    fn bin_op(&mut self, lhs: Value<'ir>, op: BinOp, rhs: Value<'ir>) -> Result<Value<'ir>> {
+        match op {
+            BinOp::BitAnd => lhs & rhs,
+            BinOp::BitOr => lhs | rhs,
+            BinOp::BitXor => lhs ^ rhs,
+            BinOp::Or => lhs | rhs,
+            BinOp::And => lhs & rhs,
+            BinOp::Eq => lhs.equal(rhs),
+            BinOp::Neq => lhs.equal(rhs).and_then(|v| !v),
+            BinOp::Lt => Ok(Value::Bool(matches!(lhs.cmp(rhs)?, Ordering::Less))),
+            BinOp::LEq => Ok(Value::Bool(matches!(
+                lhs.cmp(rhs)?,
+                Ordering::Less | Ordering::Equal
+            ))),
+            BinOp::Gt => Ok(Value::Bool(matches!(lhs.cmp(rhs)?, Ordering::Greater))),
+            BinOp::GEq => Ok(Value::Bool(matches!(
+                lhs.cmp(rhs)?,
+                Ordering::Greater | Ordering::Equal
+            ))),
+            BinOp::LShift => lhs << rhs,
+            BinOp::RShift => lhs >> rhs,
+            BinOp::Mul => lhs * rhs,
+            BinOp::Div => lhs / rhs,
+            BinOp::Mod => lhs % rhs,
+            BinOp::Plus | BinOp::Minus => self.plus_minus(lhs, op, rhs),
+        }
+    }
+}
+
+fn check_lvalue_leak(value: &Value<'_>) -> Result<()> {
+    match value {
+        Value::Pointer(_) | Value::LValue(_) => Err(ConstEvalErrorKind::LValueLeak.into()),
+        Value::Tuple(values) => values.iter().try_for_each(check_lvalue_leak),
+        Value::Struct(fields) => fields
+            .iter()
+            .map(|(_, v)| v)
+            .try_for_each(check_lvalue_leak),
+        Value::Array(values) => values.iter().try_for_each(check_lvalue_leak),
+        _ => Ok(()),
+    }
+}
+
+fn make_uninitialized<'ir>(ir: &'ir IrCtx<'ir>, typ: TyP<'ir>) -> Value<'ir> {
+    match typ {
+        Ty::Array(inner, size) => {
+            let inner = make_uninitialized(ir, inner);
+            let buf = ir.arena.alloc_slice_fill_copy(*size, inner);
+
+            Value::Array(buf)
+        }
+        Ty::Tuple(tys) => {
+            let elems = tys.iter().map(|t| make_uninitialized(ir, t));
+
+            Value::Tuple(ir.arena.alloc_slice_fill_iter(elems))
+        }
+        Ty::Item(item) => match item.get().unwrap() {
+            IRItem::StructLike(s) => {
+                let fields = s.fields.iter().map(|f| {
+                    let value = make_uninitialized(ir, f.ty);
+                    (f.id, value)
+                });
+
+                Value::Struct(ir.arena.alloc_slice_fill_iter(fields))
+            }
+            _ => Value::Uninitialized,
+        },
+        _ => Value::Uninitialized,
     }
 }

--- a/src/alumina-boot/src/ir/dce.rs
+++ b/src/alumina-boot/src/ir/dce.rs
@@ -1,5 +1,5 @@
 use crate::common::{AluminaError, CodeErrorBuilder, HashSet};
-use crate::intrinsics::CodegenIntrinsicKind;
+use crate::intrinsics::IntrinsicValueKind;
 use crate::ir::const_eval::Value;
 use crate::ir::ExpressionVisitor;
 use crate::ir::{IRItem, IRItemP, Statement, Ty, TyP};
@@ -138,10 +138,10 @@ impl<'ir> ExpressionVisitor<'ir> for DeadCodeEliminator<'ir> {
 
     fn visit_codegen_intrinsic(
         &mut self,
-        kind: &CodegenIntrinsicKind<'ir>,
+        kind: &IntrinsicValueKind<'ir>,
     ) -> Result<(), AluminaError> {
         match kind {
-            CodegenIntrinsicKind::SizeOfLike(_, typ) => self.visit_typ(typ),
+            IntrinsicValueKind::SizeOfLike(_, typ) => self.visit_typ(typ),
             _ => Ok(()),
         }
     }

--- a/src/alumina-boot/src/ir/infer.rs
+++ b/src/alumina-boot/src/ir/infer.rs
@@ -128,7 +128,7 @@ impl<'a, 'ast, 'ir> TypeInferer<'a, 'ast, 'ir> {
                 }
 
                 for (holder, t) in holders.iter().zip(mono_key.1.iter()) {
-                    self.match_slot(inferred, *holder, *t)?;
+                    self.match_slot(inferred, holder, t)?;
                 }
             }
             (ast::Ty::Dyn(a_protos, a_const), _) => {
@@ -158,7 +158,7 @@ impl<'a, 'ast, 'ir> TypeInferer<'a, 'ast, 'ir> {
                         }
 
                         for (holder, t) in holders.iter().zip(mono_key.1.iter()) {
-                            self.match_slot(inferred, *holder, *t)?;
+                            self.match_slot(inferred, holder, t)?;
                         }
                     }
                 } else {

--- a/src/alumina-boot/src/ir/inline.rs
+++ b/src/alumina-boot/src/ir/inline.rs
@@ -101,7 +101,7 @@ impl<'ir> IrInliner<'ir> {
             ExprKind::Call(callee, args) => builder.call(
                 self.visit_expr(callee)?,
                 args.iter()
-                    .map(|a| self.visit_expr(*a))
+                    .map(|a| self.visit_expr(a))
                     .collect::<Result<Vec<_>, _>>()?,
                 expr.ty,
             ),
@@ -111,7 +111,7 @@ impl<'ir> IrInliner<'ir> {
             ExprKind::Literal(_) => expr,
             ExprKind::Unreachable => expr,
             ExprKind::Void => expr,
-            ExprKind::CodegenIntrinsic(_) => expr,
+            ExprKind::Intrinsic(_) => expr,
             ExprKind::Local(id) => self.replacements.get(&id).copied().unwrap_or(expr),
             ExprKind::Ref(e) => builder.r#ref(self.visit_expr(e)?),
             ExprKind::Deref(e) => builder.deref(self.visit_expr(e)?),
@@ -131,7 +131,7 @@ impl<'ir> IrInliner<'ir> {
             ExprKind::Array(elems) => builder.array(
                 elems
                     .iter()
-                    .map(|e| self.visit_expr(*e))
+                    .map(|e| self.visit_expr(e))
                     .collect::<Result<Vec<_>, _>>()?,
                 expr.ty,
             ),

--- a/src/tests/lang.alu
+++ b/src/tests/lang.alu
@@ -321,3 +321,141 @@ fn test_static_initialization_order() {
     assert_eq!(A7, 41);
     assert_eq!(A8, 67);
 }
+
+
+
+#[test]
+fn test_const_eval_basic() {
+    const A = 1;
+    assert_eq!(A, 1);
+
+    const A = 1 + 1;
+    assert_eq!(A, 2);
+
+    const A = {
+        let a = 1;
+        a + 2
+    };
+
+    assert_eq!(A, 3);
+
+    const A = "hello world";
+    assert_eq!(A, "hello world");
+
+    const A = [1, 2, 3];
+    assert_eq!(A, [1, 2, 3]);
+
+    const A = [1, 2, 3][1];
+    assert_eq!(A, 2);
+
+    const A = [1, 2, 3][1] + 1;
+    assert_eq!(A, 3);
+
+    const A = "hello world"[2..5];
+    assert_eq!(A, "llo");
+
+    const A = "hello world"[2..5].len();
+    assert_eq!(A, 3);
+}
+
+
+fn fib(n: i32) -> i32 {
+    if n < 2 {
+        n
+    } else {
+        fib(n - 1) + fib(n - 2)
+    }
+}
+
+#[test]
+fn test_const_eval_fancy() {
+    const FIB_50 = {
+        let a = 0u64;
+        let b = 1u64;
+
+        for _ in 0..50 {
+            let c = a + b;
+            a = b;
+            b = c;
+        }
+
+        a
+    };
+    assert_eq!(FIB_50, 12586269025u64);
+
+    const FIB_10 = fib(10);
+    assert_eq!(FIB_10, 55);
+}
+
+
+#[test]
+fn test_const_eval_uninitialized() {
+    const MATRIX = {
+        let a: [[i32; 3]; 3];
+
+        for i in 0usize..3 {
+            for j in 0usize..3 {
+                a[i][j] = (i + j) as i32;
+            }
+        }
+
+        a
+    };
+
+    assert_eq!(MATRIX, [
+        [0, 1, 2],
+        [1, 2, 3],
+        [2, 3, 4],
+    ]);
+}
+
+#[test]
+fn test_const_eval_pointer_arithmetic() {
+    const VALUES: ([i32; 5], isize) = {
+        let a = [1, 2, 3, 4, 5];
+        let ptr = &a[0];
+
+        *ptr = -1;
+        *(ptr + 1) = -2;
+        *(ptr + 4) = -10;
+
+        (a, &a[0] - &a[5])
+    };
+
+
+    assert_eq!(VALUES.0, [-1, -2, 3, 4, -10]);
+    assert_eq!(VALUES.1, -5);
+}
+
+#[test]
+
+
+#[test]
+fn test_const_eval_library_functions() {
+    fn calc() -> ([i32; 10], bool) {
+        let rng = std::random::Pcg32 {
+            state: 0xa285d44c06ab9542,
+            increment: 0x71bc6da31db36d8d,
+        };
+
+        let ret: [i32; 10];
+        (0..10)
+            .map(|&rng, _: i32| -> i32 { rng.next(0..10) })
+            .fill_slice(&ret);
+
+        (ret, std::runtime::in_const_context())
+    }
+
+    const RANDOM_VALUES = calc();
+    let random_values = calc();
+
+    assert_eq!(RANDOM_VALUES.0, random_values.0);
+
+    assert!(RANDOM_VALUES.1);
+    assert!(!random_values.1);
+}
+
+#[test]
+fn test_const_eval_intrinsics() {
+    std::compile_note!("this is a warning"[3..7]);
+}

--- a/sysroot/std.alu
+++ b/sysroot/std.alu
@@ -115,12 +115,15 @@ macro assert_ne($lhs, $rhs) {
 }
 
 /// Panics if `cond` evaluates to false when compiled in debug mode. Otherwise, does nothing.
+#[allow(unused_parameter)]
 macro debug_assert($cond) { #[cfg(debug)] assert!($cond); }
 
 /// Panics if `lhs` and `rhs` are not equal when compiled in debug mode. Otherwise, does nothing.
+#[allow(unused_parameter)]
 macro debug_assert_eq($lhs, $rhs) { #[cfg(debug)] assert_eq!($lhs, $rhs); }
 
 /// Panics if `lhs` and `rhs` are equal when compiled in debug mode. Otherwise, does nothing.
+#[allow(unused_parameter)]
 macro debug_assert_ne($lhs, $rhs) { #[cfg(debug)] assert_ne!($lhs, $rhs); }
 
 /// Treats the location as unreachable during program flow.

--- a/sysroot/std/builtins.alu
+++ b/sysroot/std/builtins.alu
@@ -1143,6 +1143,12 @@ impl array<Arr: builtins::Array> {
     fn iter(self: &Arr) -> mem::SliceIterator<&element_of<Arr>> {
         self.as_slice().iter()
     }
+
+    fn equals(lhs: &Arr, rhs: &Arr) -> bool {
+        lhs[..] == rhs[..]
+    }
+
+    mixin cmp::Equatable<Arr>;
 }
 
 // The following are "type-operators", pseudo-types, implemented inside the compiler

--- a/sysroot/std/ffi.alu
+++ b/sysroot/std/ffi.alu
@@ -84,6 +84,11 @@ impl CString {
         self.ptr = null;
         ret
     }
+
+    /// @ fmt::Formattable::fmt
+    fn fmt<F: fmt::Formatter<F>>(self: &CString, f: &mut F) -> fmt::Result {
+        f.write_str(self.as_slice())
+    }
 }
 
 
@@ -95,6 +100,10 @@ mod tests {
         let s = CString::from_raw(c_str!("Hello, World"));
 
         assert_eq!(s[..], "Hello, World");
+        let f = fmt::format!("{}", s).unwrap();
+        defer f.free();
+
+        assert_eq!(f[..] as &[u8], "Hello, World");
     }
 
     #[test]

--- a/sysroot/std/intrinsics.alu
+++ b/sysroot/std/intrinsics.alu
@@ -10,7 +10,7 @@
 /// Fail the compilation process with a human-readable message.
 ///
 /// Use [std::compile_fail] instead.
-extern "intrinsic" fn compile_fail(reason: &[u8]) -> !;
+extern "intrinsic" fn compile_fail(reason: &[u8]) -> !; // that's like a super !, since the code following it will not even be compiled, let alone executed
 
 /// Emit a warning message during compilation.
 extern "intrinsic" fn compile_warn(reason: &[u8]);
@@ -84,6 +84,11 @@ extern "intrinsic" fn uninitialized<T>() -> T;
 ///
 /// Use [mem::dangling] instead.
 extern "intrinsic" fn dangling<Ptr: builtins::Pointer>() -> Ptr;
+
+/// Whether we are in constant evaluation context
+///
+/// Use [runtime::in_const_context] instead.
+extern "intrinsic" fn in_const_context() -> bool;
 
 #[cfg(boot)]
 {

--- a/sysroot/std/mem.alu
+++ b/sysroot/std/mem.alu
@@ -460,6 +460,7 @@ impl SliceRefIterator<Ptr: builtins::Pointer> {
 mod internal {
     use builtins::{Primitive, Pointer, RangeOf};
 
+    #[allow(unused_parameter)]
     macro bounds_check($cond, $msg, $args...) {
         #[cfg(any(debug, bounds_checks))]
         {

--- a/sysroot/std/runtime.alu
+++ b/sysroot/std/runtime.alu
@@ -1,5 +1,21 @@
 //! Run time glue code (program entrypoint, tests, ...)
 
+/// Returns `true` when evaluated in a const context and `false` otherwise.
+///
+/// ## Example
+/// ```
+/// use std::runtime::in_const_context;
+///
+/// const IN_CONST_CONTEXT: bool = in_const_context();
+///
+/// assert!(IN_CONST_CONTEXT);
+/// assert!(!in_const_context());
+/// ```
+#[inline(ir)]
+fn in_const_context() -> bool {
+    intrinsics::in_const_context()
+}
+
 #[cfg(not(output_type = "library"))]
 mod internal {
     use builtins::{return_type_of, arguments_of, NamedFunction};


### PR DESCRIPTION
This PR implements "full" const eval, including loops, function calls etc. There are still a bunch of limitations (documented in the lang guide) and parts of the interpreter are hacky and inefficient, but anyway, good enough for now.

The requirement for functions to be IR-inlinable to be able to be used in const context is now dropped.