### PR TITLE
fix: Const-eval fixes

### DIFF
--- a/src/alumina-boot/src/diagnostics.rs
+++ b/src/alumina-boot/src/diagnostics.rs
@@ -189,7 +189,7 @@ impl DiagnosticContext {
             } = error
             {
                 // This usually means that something before the error failed, so it's just noise.
-                //continue;
+                continue;
             }
 
             let tagline = format!("{}: {}", level_string, error.kind).bold();

--- a/src/alumina-boot/src/ir/dce.rs
+++ b/src/alumina-boot/src/ir/dce.rs
@@ -99,10 +99,7 @@ impl<'ir> DeadCodeEliminator<'ir> {
 
             IRItem::Const(c) => {
                 self.visit_typ(c.typ)?;
-                self.visit_expr(
-                    c.init
-                        .expect("inlined consts should never appear in the IR"),
-                )?;
+                self.visit_expr(c.init)?;
             }
 
             // Should be inlined

--- a/src/alumina-boot/src/ir/mod.rs
+++ b/src/alumina-boot/src/ir/mod.rs
@@ -350,8 +350,7 @@ pub struct Const<'ir> {
     pub name: Option<&'ir str>,
     pub typ: TyP<'ir>,
     pub value: Value<'ir>,
-    // If init is None, the const should be inlined
-    pub init: Option<ExprP<'ir>>,
+    pub init: ExprP<'ir>,
 }
 
 #[derive(Debug)]

--- a/src/tests/lang.alu
+++ b/src/tests/lang.alu
@@ -456,6 +456,59 @@ fn test_const_eval_library_functions() {
 }
 
 #[test]
+fn test_const_eval_const() {
+    const A: [i32; 3] = [1, 2, 3];
+    const B: &i32 = &A[2];
+
+    const C: i32 = 5;
+    const D: &i32 = &C;
+
+    assert_eq!(*B, 3);
+    assert_eq!(*D, 5);
+}
+
+
+#[test]
+fn test_const_zst() {
+    struct S<T> {
+        a: T,
+        b: i32,
+    };
+
+    const A = ();
+    const B1: [i32; 0] = [];
+    const B2: [(); 3] = [(), (), ()];
+    const C = ((),(()),((())));
+    const D1 = S { a: (), b: 5 };
+    const D2 = S { a: [(), (), ()], b: 5 };
+    const E = ((), 5);
+
+    const F = &A;
+    const G1 = &B1;
+    const G2 = &B2[1];
+    const H = &C;
+    const I1 = &D1.a;
+    const I2 = &D2.a[1];
+    const J = &E.0;
+
+    assert_eq!(A, ());
+    assert_eq!(B1, []);
+    assert_eq!(B2, [(), (), ()]);
+    assert_eq!(C, ((),(()),((()))));
+    assert_eq!(D1.b, 5);
+    assert_eq!(D2.b, 5);
+    assert_eq!(E.1, 5);
+
+    assert_eq!(F, &());
+    assert_eq!(G1, &[]);
+    assert_eq!(G2, &());
+    assert_eq!(H, &((),(()),((()))));
+    assert_eq!(I1, &());
+    assert_eq!(I2, &());
+    assert_eq!(J, &());
+}
+
+#[test]
 fn test_const_eval_intrinsics() {
     std::compile_note!("this is a warning"[3..7]);
 }


### PR DESCRIPTION
Adds ability to have a pointer to another const in a const and fixes some of the bugs and inconsistencies, especially wrt. ZSTs.