### PR TITLE
feat(compiler): Source-level debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug",
+            "program": "${workspaceFolder}/quick",
+            "preLaunchTask": "quick",
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "python.formatting.provider": "black"
+    "python.formatting.provider": "black",
+    "debug.allowBreakpointsEverywhere": true
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "quick",
+            "type": "shell",
+            "command": "make quick",
+            "group": {
+                "kind": "build"
+            }
+        }
+    ]
+}

--- a/src/alumina-boot/src/ast/expressions.rs
+++ b/src/alumina-boot/src/ast/expressions.rs
@@ -1584,6 +1584,7 @@ impl<'ast, 'src> ClosureVisitor<'ast, 'src> {
                 id: *k,
                 value: v,
                 binding_type: *t,
+                span: v.span,
             })
             .collect::<Vec<_>>()
             .alloc_on(self.ast);

--- a/src/alumina-boot/src/ast/mod.rs
+++ b/src/alumina-boot/src/ast/mod.rs
@@ -742,6 +742,7 @@ pub struct ClosureBinding<'ast> {
     pub id: AstId,
     pub value: ExprP<'ast>,
     pub binding_type: BoundItemType,
+    pub span: Option<Span>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]

--- a/src/alumina-boot/src/ir/const_eval.rs
+++ b/src/alumina-boot/src/ir/const_eval.rs
@@ -401,7 +401,6 @@ impl<'ir> Shr<Value<'ir>> for Value<'ir> {
             _ => return Err(ConstEvalErrorKind::CompilerBug.into()),
         };
         let other = other.map_err(|_| ConstEvalErrorKind::ArithmeticOverflow)?;
-
         let ret = match self {
             U8(a) => a.checked_shr(other).map(U8),
             U16(a) => a.checked_shr(other).map(U16),

--- a/src/alumina-boot/src/ir/inline.rs
+++ b/src/alumina-boot/src/ir/inline.rs
@@ -61,11 +61,13 @@ impl<'ir> IrInliner<'ir> {
                 let new_id = ir.make_id();
                 let ty = expr.ty;
 
-                let expr = std::mem::replace(expr, builder.local(new_id, ty));
+                let expr = std::mem::replace(expr, builder.local(new_id, ty, expr.span));
 
-                statements.push(Statement::Expression(
-                    builder.assign(builder.local(new_id, ty), expr),
-                ));
+                statements.push(Statement::Expression(builder.assign(
+                    builder.local(new_id, ty, expr.span),
+                    expr,
+                    expr.span,
+                )));
                 local_defs.push(LocalDef {
                     id: new_id,
                     typ: ty,
@@ -76,7 +78,7 @@ impl<'ir> IrInliner<'ir> {
         let mut inliner = Self { ir, replacements };
 
         Ok((
-            builder.block(statements, inliner.visit_expr(body)?),
+            builder.block(statements, inliner.visit_expr(body)?, body.span),
             local_defs,
         ))
     }
@@ -91,12 +93,17 @@ impl<'ir> IrInliner<'ir> {
                     .map(|s| self.visit_statement(s))
                     .collect::<Result<Vec<_>, _>>()?,
                 self.visit_expr(ret)?,
+                expr.span,
             ),
-            ExprKind::Binary(op, a, b) => {
-                builder.binary(op, self.visit_expr(a)?, self.visit_expr(b)?, expr.ty)
-            }
+            ExprKind::Binary(op, a, b) => builder.binary(
+                op,
+                self.visit_expr(a)?,
+                self.visit_expr(b)?,
+                expr.ty,
+                expr.span,
+            ),
             ExprKind::AssignOp(op, a, b) => {
-                builder.assign_op(op, self.visit_expr(a)?, self.visit_expr(b)?)
+                builder.assign_op(op, self.visit_expr(a)?, self.visit_expr(b)?, expr.span)
             }
             ExprKind::Call(callee, args) => builder.call(
                 self.visit_expr(callee)?,
@@ -104,6 +111,7 @@ impl<'ir> IrInliner<'ir> {
                     .map(|a| self.visit_expr(a))
                     .collect::<Result<Vec<_>, _>>()?,
                 expr.ty,
+                expr.span,
             ),
             ExprKind::Fn(_) => expr,
             ExprKind::Static(_) => expr,
@@ -113,27 +121,35 @@ impl<'ir> IrInliner<'ir> {
             ExprKind::Void => expr,
             ExprKind::Intrinsic(_) => expr,
             ExprKind::Local(id) => self.replacements.get(&id).copied().unwrap_or(expr),
-            ExprKind::Ref(e) => builder.r#ref(self.visit_expr(e)?),
-            ExprKind::Deref(e) => builder.deref(self.visit_expr(e)?),
+            ExprKind::Ref(e) => builder.r#ref(self.visit_expr(e)?, expr.span),
+            ExprKind::Deref(e) => builder.deref(self.visit_expr(e)?, expr.span),
             ExprKind::Return(_) => return Err(CodeErrorKind::IrInlineEarlyReturn).with_no_span(),
             ExprKind::Goto(_) => return Err(CodeErrorKind::IrInlineFlowControl).with_no_span(),
-            ExprKind::Unary(op, e) => builder.unary(op, self.visit_expr(e)?, expr.ty),
-            ExprKind::Assign(a, b) => builder.assign(self.visit_expr(a)?, self.visit_expr(b)?),
-            ExprKind::Index(a, b) => builder.index(self.visit_expr(a)?, self.visit_expr(b)?),
-            ExprKind::Field(e, f) => builder.field(self.visit_expr(e)?, f, expr.ty),
-            ExprKind::TupleIndex(e, i) => builder.tuple_index(self.visit_expr(e)?, i, expr.ty),
+            ExprKind::Unary(op, e) => builder.unary(op, self.visit_expr(e)?, expr.ty, expr.span),
+            ExprKind::Assign(a, b) => {
+                builder.assign(self.visit_expr(a)?, self.visit_expr(b)?, expr.span)
+            }
+            ExprKind::Index(a, b) => {
+                builder.index(self.visit_expr(a)?, self.visit_expr(b)?, expr.span)
+            }
+            ExprKind::Field(e, f) => builder.field(self.visit_expr(e)?, f, expr.ty, expr.span),
+            ExprKind::TupleIndex(e, i) => {
+                builder.tuple_index(self.visit_expr(e)?, i, expr.ty, expr.span)
+            }
             ExprKind::If(cond, then, els) => builder.if_then(
                 self.visit_expr(cond)?,
                 self.visit_expr(then)?,
                 self.visit_expr(els)?,
+                expr.span,
             ),
-            ExprKind::Cast(inner) => builder.cast(self.visit_expr(inner)?, expr.ty),
+            ExprKind::Cast(inner) => builder.cast(self.visit_expr(inner)?, expr.ty, expr.span),
             ExprKind::Array(elems) => builder.array(
                 elems
                     .iter()
                     .map(|e| self.visit_expr(e))
                     .collect::<Result<Vec<_>, _>>()?,
                 expr.ty,
+                expr.span,
             ),
             ExprKind::Tuple(elems) => builder.tuple(
                 elems
@@ -141,6 +157,7 @@ impl<'ir> IrInliner<'ir> {
                     .map(|e| self.visit_expr(e.value).map(|v| (e.index, v)))
                     .collect::<Result<Vec<_>, _>>()?,
                 expr.ty,
+                expr.span,
             ),
             ExprKind::Struct(fields) => builder.r#struct(
                 fields
@@ -148,6 +165,7 @@ impl<'ir> IrInliner<'ir> {
                     .map(|f| self.visit_expr(f.value).map(|v| (f.field, v)))
                     .collect::<Result<Vec<_>, _>>()?,
                 expr.ty,
+                expr.span,
             ),
         };
 

--- a/src/alumina-boot/src/ir/mod.rs
+++ b/src/alumina-boot/src/ir/mod.rs
@@ -8,7 +8,7 @@ pub mod lang;
 pub mod layout;
 pub mod mono;
 
-use crate::ast::{Attribute, BinOp, BuiltinType, UnOp};
+use crate::ast::{Attribute, BinOp, BuiltinType, Span, UnOp};
 use crate::common::{
     impl_allocatable, Allocatable, AluminaError, ArenaAllocatable, CodeErrorKind, HashSet,
     Incrementable,
@@ -576,34 +576,38 @@ pub struct Expr<'ir> {
     pub value_type: ValueType,
     pub is_const: bool,
     pub kind: ExprKind<'ir>,
+    pub span: Option<Span>,
     pub ty: TyP<'ir>,
 }
 
 impl<'ir> Expr<'ir> {
-    pub fn lvalue(kind: ExprKind<'ir>, typ: TyP<'ir>) -> Self {
+    pub fn lvalue(kind: ExprKind<'ir>, typ: TyP<'ir>, span: Option<Span>) -> Self {
         Self {
             kind,
             value_type: ValueType::LValue,
             is_const: false,
             ty: typ,
+            span,
         }
     }
 
-    pub fn rvalue(kind: ExprKind<'ir>, typ: TyP<'ir>) -> Self {
+    pub fn rvalue(kind: ExprKind<'ir>, typ: TyP<'ir>, span: Option<Span>) -> Self {
         Self {
             kind,
             value_type: ValueType::RValue,
             is_const: false,
             ty: typ,
+            span,
         }
     }
 
-    pub fn const_lvalue(kind: ExprKind<'ir>, typ: TyP<'ir>) -> Self {
+    pub fn const_lvalue(kind: ExprKind<'ir>, typ: TyP<'ir>, span: Option<Span>) -> Self {
         Self {
             kind,
             value_type: ValueType::LValue,
             is_const: true,
             ty: typ,
+            span,
         }
     }
 

--- a/sysroot/libc.alu
+++ b/sysroot/libc.alu
@@ -404,6 +404,7 @@ extern "C" fn puts(s: &c_char) -> c_int;
     #[cfg(not(target_os="macos"))]
     extern "C" fn execvpe(prog: &c_char, argv: &&c_char, envp: &&c_char) -> c_int;
     extern "C" fn kill(pid: pid_t, sig: c_int) -> c_int;
+    extern "C" fn raise(sig: c_int) -> c_int;
     extern "C" fn getpid() -> pid_t;
     extern "C" fn sleep(secs: c_uint) -> c_uint;
     extern "C" fn nanosleep(rqtp: &timespec, rmtp: &mut timespec) -> c_int;


### PR DESCRIPTION
This PR extends IR expressions with source code spans and adds `#line` attributes in the generated C code. This allows for a full featured source-level debugging with gdd/lldb. 

Next step would be better stack traces when panicking. For this we also need to mangle symbol names properly rather than just with a counter.