### PR TITLE
feat(stdlib): Use libbacktrace by default for panic backtraces

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,15 @@ jobs:
       - name: Install Tree-sitter
         run: npm install -g tree-sitter-cli
 
+      - name: Install libbacktrace
+        if: matrix.os == 'macos-11'
+        run: |
+          git clone https://github.com/ianlancetaylor/libbacktrace
+          cd libbacktrace
+          ./configure
+          make -j8
+          sudo make install
+
       - name: Run all tests
         timeout-minutes: 10
         run: make test -j8

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN cargo install tree-sitter-cli
 WORKDIR /alumina/deps
 RUN curl -fsSL https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.20.7.tar.gz | tar -xz
 RUN cd tree-sitter-* && make -j8 && make install && ldconfig
+RUN curl -fsSL https://github.com/ianlancetaylor/libbacktrace/archive/master.tar.gz | tar -xz
+RUN cd libbacktrace-* && ./configure && make -j8 && make install
 
 FROM environment as builder
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,11 @@ else
 	ALUMINA_FLAGS += --sysroot $(SYSROOT) --debug
 endif
 
-LDFLAGS = -lm
+LDFLAGS ?= -lm
+ifndef STD_BACKTRACE
+	ALUMINA_FLAGS += --cfg use_libbacktrace
+	LDFLAGS += -lbacktrace
+endif
 ifndef NO_THREADS
 	ALUMINA_FLAGS += --cfg threading
 	LDFLAGS += -lpthread

--- a/README.md
+++ b/README.md
@@ -168,14 +168,21 @@ Additionally, to compile `aluminac`, these prerequisites are needed:
 
   - LLVM 13 shared libraries and headers (`llvm-13-dev`)
   - Tree-sitter runtime library (`libtree-sitter.a`/`libtree-sitter.so`):
-
-```bash
-git clone https://github.com/tree-sitter/tree-sitter
-cd tree-sitter
-make
-sudo make install
-# sudo ldconfig
-```
+   ```bash
+   git clone https://github.com/tree-sitter/tree-sitter
+   cd tree-sitter
+   make
+   sudo make install
+   # sudo ldconfig
+   ```
+  - [`libbacktrace`](https://github.com/ianlancetaylor/libbacktrace/) is an optional dependency for nice stack backtraces on panics. If disabled, pass `STD_BACKTRACE=1` when builting `aluminac` to use the libc's backtrace function instead.
+   ```bash
+   git clone https://github.com/ianlancetaylor/libbacktrace
+   cd libbacktrace
+   ./configure
+   make
+   sudo make install
+   ```
 
 ## Building
 

--- a/examples/backtrace.alu
+++ b/examples/backtrace.alu
@@ -1,0 +1,21 @@
+use std::cmp::{Ordering, sort_by};
+use std::random::thread_rng;
+
+fn chaos_comparer(a: &i32, b: &i32) -> Ordering {
+    let r: f64 = thread_rng().next_float();
+    if r < 0.0001 {
+        panic!("oops, I'm a bad comparer");
+    } else {
+        a.compare(b)
+    }
+}
+
+fn main() {
+    let vec =
+        (0..10000)
+            .map(|_: i32| -> i32 { thread_rng().next(..) })
+            .to_vector();
+    defer vec.free();
+
+    vec[..].sort_by(chaos_comparer);
+}

--- a/src/alumina-boot/src/ir/mono.rs
+++ b/src/alumina-boot/src/ir/mono.rs
@@ -3967,6 +3967,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                             .iter()
                             .zip(args.into_iter())
                             .map(|(a, b)| (a.id, b)),
+                        span,
                     )?;
 
                     self.local_defs.append(&mut additional_defs);

--- a/sysroot/std/panicking.alu
+++ b/sysroot/std/panicking.alu
@@ -163,7 +163,7 @@ mod internal {
                 fmt::writeln!(&formatter, "stack backtrace:")?;
                 let ret = backtrace_full(
                     state,
-                    2, // skip this function and print_panic_message
+                    2, // skip this function and panic_impl
                     backtrace_callback,
                     backtrace_error_callback,
                     &formatter as &mut void

--- a/sysroot/std/panicking.alu
+++ b/sysroot/std/panicking.alu
@@ -80,6 +80,7 @@ mod internal {
         PANIC_HOOK = Option::some((arg, f));
     }
 
+    #[inline(never)]
     fn print_panic_message(info: &PanicInfo) -> Result<(), fmt::Error> {
         let formatter = PanicFormatter {};
         fmt::write!(
@@ -90,8 +91,92 @@ mod internal {
         let _ = fmt::internal::write_fmt(info.args, &formatter);
         formatter.write_byte('\n')?;
 
-        #[cfg(all(debug, not(no_backtrace), not(target_os = "android")))]
+        #[cfg(all(debug, use_libbacktrace, not(no_backtrace)))]
         {
+            // Preferably use libbacktrace to print a backtrace.
+            use ffi::CString;
+            use runtime::backtrace::{backtrace_create_state, backtrace_full};
+
+            fn backtrace_error_callback(
+                state: &mut void,
+                message: &libc::c_char,
+                _errno: libc::c_int
+            ) {
+                let formatter = state as &mut PanicFormatter;
+                let msg = CString::from_raw(message);
+                let _ = fmt::write!(formatter, "error while printing backtrace: {}\n", msg);
+            }
+
+            fn demangle_alumina(name: &[u8]) -> Option<&[u8]> {
+                use string::{starts_with, is_digit};
+                use option::try;
+
+                if !name.starts_with("_AL")
+                    || name.len() < 5
+                    || name[3] == '0'
+                    || !name[3].is_digit() {
+                    return Option::none();
+                }
+
+                let end_index = 3usize;
+                while name[end_index].is_digit() {
+                    end_index += 1;
+                    if end_index == name.len() {
+                        return Option::none();
+                    }
+                }
+
+                let len = usize::parse(name[3..end_index])?;
+                Option::some(name[end_index..end_index + len])
+            }
+
+            fn backtrace_callback(
+                state: &mut void,
+                _pc: usize,
+                filename: &libc::c_char,
+                lineno: libc::c_int,
+                function: &libc::c_char
+            ) -> libc::c_int {
+                let formatter = state as &mut PanicFormatter;
+                let res = if filename != null && function != null {
+                    let function = ffi::CString::from_raw(function)[..];
+                    let filename = ffi::CString::from_raw(filename)[..];
+
+                    let demangled = demangle_alumina(function)
+                        .unwrap_or(function);
+
+                    fmt::writeln!(formatter, "--> {} at {}:{}", demangled, filename, lineno)
+                } else {
+                    fmt::writeln!(formatter, "--> <unknown>")
+                };
+
+                res.is_err() as libc::c_int
+            }
+
+
+            #[cfg(threading)]
+            let state = backtrace_create_state(null, 1, backtrace_error_callback, null);
+            #[cfg(not(threading))]
+            let state = backtrace_create_state(null, 0, backtrace_error_callback, null);
+
+            if state != null {
+                fmt::writeln!(&formatter, "stack backtrace:")?;
+                let ret = backtrace_full(
+                    state,
+                    2, // skip this function and print_panic_message
+                    backtrace_callback,
+                    backtrace_error_callback,
+                    &formatter as &mut void
+                );
+                if ret != 0 {
+                    return Result::err(fmt::Error::new());
+                }
+            }
+        }
+
+        #[cfg(all(debug, not(use_libbacktrace), not(no_backtrace), not(target_os = "android")))]
+        {
+            // Fallback use glibc's backtrace
             let buf: [&mut void; 128];
             let size = backtrace(&buf[0], 128);
             backtrace_symbols_fd(&buf[0] as &mut &void, size, libc::STDERR_FILENO);

--- a/sysroot/std/runtime/backtrace.alu
+++ b/sysroot/std/runtime/backtrace.alu
@@ -1,0 +1,123 @@
+//! Bindings to `libbacktrace`
+
+// Translated from C to Alumina. Original source available at
+// https://github.com/ianlancetaylor/libbacktrace. The original license
+// is reproduced below.
+//
+// Copyright (C) 2012-2016 Free Software Foundation, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     (1) Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//
+//     (2) Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in
+//     the documentation and/or other materials provided with the
+//     distribution.
+//
+//     (3) The name of the author may not be used to
+//     endorse or promote products derived from this software without
+//     specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, `data`, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/// The backtrace state.
+
+/// This struct is intentionally not defined in the public interface.
+struct BacktraceState {}
+
+/// The type of the error callback argument to backtrace functions.
+///
+/// This function, if not `null`, will be called for certain error cases.
+/// The `data` argument is passed to the function that calls this one.
+/// The MSG argument is an error message.  The `errnum` argument, if
+/// greater than 0, holds an errno value.  The MSG buffer may become
+/// invalid after this function returns.
+///
+/// As a special case, the `errnum` argument will be passed as -1 if no
+/// debug info can be found for the executable, or if the debug info
+/// exists but has an unsupported version, but the function requires
+/// debug info (e.g., [backtrace_full], `backtrace_pcinfo`).  The MSG in
+/// this case will be something along the lines of "no debug info".
+/// Similarly, `errnum` will be passed as -1 if there is no symbol table,
+/// but the function requires a symbol table (e.g., `backtrace_syminfo`).
+/// This may be used as a signal that some other approach should be
+/// tried.
+type BacktraceErrorCallback = fn(
+    &mut void,      // state
+    &libc::c_char,  // msg
+    libc::c_int);   // errnum
+
+/// Create state information for the backtrace routines.
+///
+/// This must be called before any of the other routines, and its return value must
+/// be passed to all of the other routines.  `filename` is the path name
+/// of the executable file; if it is `null` the library will try
+/// system-specific path names.  If not `null`, `filename` must point to a
+/// permanent buffer.  If `threaded` is non-zero the state may be
+/// accessed by multiple threads simultaneously, and the library will
+/// use appropriate atomic operations.  If `threaded` is zero the state
+/// may only be accessed by one thread at a time.  This returns a state
+/// pointer on success, `null` on error.  If an error occurs, this will
+/// call the `error_callback` routine.
+///
+/// Calling this function allocates resources that cannot be freed.
+/// There is no `backtrace_free_state` function.  The state is used to
+/// cache information that is expensive to recompute.  Programs are
+/// expected to call this function at most once and to save the return
+/// value for all later calls to backtrace functions.
+extern "C" fn backtrace_create_state(
+    filename: &libc::c_char,
+    threaded: libc::c_int,
+    error: BacktraceErrorCallback,
+    data: &mut void
+) -> &mut BacktraceState;
+
+
+/// The type of the callback argument to the backtrace_full function.
+///
+/// `data` is the argument passed to backtrace_full.  `pc` is the program
+/// counter.  `filename` is the name of the file containing `pc`, or `null`
+/// if not available.  `lineno` is the line number in `filename` containing
+/// `pc`, or 0 if not available.  `function` is the name of the function
+/// containing `pc`, or `null` if not available.  This should return 0 to
+/// continuing tracing.  The `filename` and `function` buffers may become
+/// invalid after this function returns.
+type BacktraceFullCallback = fn(
+    &mut void,       // data
+    usize,           // pc
+    &libc::c_char,   // filename
+    libc::c_int,     // lineno
+    &libc::c_char    // function
+) -> libc::c_int;
+
+/// Get a full stack backtrace.
+///
+/// `skip` is the number of frames to skip; passing 0 will start the trace with the
+/// function calling backtrace_full.  `data` is passed to the callback routine.
+/// If any call to `callback` returns a non-zero value, the stack backtrace
+/// stops, and backtrace returns that value; this may be used to limit
+/// the number of stack frames desired.  If all calls to `callback`
+/// return 0, backtrace returns 0.  The [backtrace_full] function will
+/// make at least one call to either `callback` or `error_callback`.  This
+/// function requires debug info for the executable.
+extern "C" fn backtrace_full(
+    state: &mut BacktraceState,
+    skip: libc::c_int,
+    callback: BacktraceFullCallback,
+    error: BacktraceErrorCallback,
+    data: &mut void
+) -> libc::c_int;

--- a/sysroot/std/string.alu
+++ b/sysroot/std/string.alu
@@ -23,6 +23,11 @@ fn is_whitespace(c: u8) -> bool {
     c == 0x20 || c == 0x85 || c == 0xa0 || (c >= 0x09 && c <= 0x0D)
 }
 
+/// Returns `true` if character is a decimal digit, `false` otherwise.
+fn is_digit(c: u8) -> bool {
+    c >= '0' && c <= '9'
+}
+
 /// Convert character to lower case.
 ///
 /// If character is not an ASCII uppercase letter, returns the same character.


### PR DESCRIPTION
Use `--cfg use_libbacktrace` for nicer backtraces now that alumina-boot emits full debug information.